### PR TITLE
Add MLModelConfig schema

### DIFF
--- a/ml_model_config.py
+++ b/ml_model_config.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, ClassVar, Dict, List, Optional, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, root_validator
+
+
+# ---------------------------------------------------------------------------
+# Compatibility helper mirroring pydantic v2 model_validator
+
+def model_validator(*, mode: str = "after"):
+    def decorator(func):
+        if mode == "after":
+            def wrapper(cls, values):
+                inst = cls.construct(**values)
+                result = func(cls, inst)
+                return result.__dict__ if isinstance(result, cls) else values
+            return root_validator(pre=False, skip_on_failure=True, allow_reuse=True)(wrapper)
+        else:
+            def wrapper(cls, values):
+                out = func(values)
+                return out if out is not None else values
+            return root_validator(pre=True, skip_on_failure=True, allow_reuse=True)(wrapper)
+    return decorator
+
+
+if not hasattr(BaseModel, "model_validate"):
+    BaseModel.model_validate = classmethod(lambda cls, d, **_: cls.parse_obj(d))
+if not hasattr(BaseModel, "model_dump"):
+    BaseModel.model_dump = BaseModel.dict
+if not hasattr(BaseModel, "model_dump_json"):
+    BaseModel.model_dump_json = BaseModel.json
+if not hasattr(BaseModel, "model_copy"):
+    BaseModel.model_copy = BaseModel.copy
+
+# Local imports ---------------------------------------------------------------
+from core_schema import ConfigSectionBase, to_camel_case
+from metadata import Metadata  # noqa: F401 - used for integration hints
+from postprocessing_settings import PostprocessingSettings  # noqa: F401
+from validation_suite import ValidationSuite  # noqa: F401
+
+
+class MLModelConfig(ConfigSectionBase):
+    """Validated configuration for machine learning models."""
+
+    config_section_id: ClassVar[Literal["ml_model"]] = "ml_model"
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        extra="forbid",
+        alias_generator=to_camel_case,
+        populate_by_name=True,
+        validate_default=True,
+    )
+
+    # ------------------------------------------------------------------
+    # Model specification
+    model_type: Literal["regression", "classification"] = "regression"
+    surrogate_model_enabled: bool = False
+    model_name: str
+    model_engine: Literal[
+        "sklearn", "tensorflow", "pytorch", "xgboost", "lightgbm", "gpytorch"
+    ] = "sklearn"
+    model_architecture_template: Optional[
+        Literal["MLP", "CNN1D", "LSTM", "Transformer", "Custom"]
+    ] = "MLP"
+    model_architecture: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Training configuration
+    training_dataset_path: Path
+    input_features: List[str]
+    output_targets: List[str]
+    normalization_method: Literal["zscore", "minmax", "custom"] = "zscore"
+    training_epochs: Optional[int] = 100
+    batch_size: Optional[int] = 32
+    optimizer_type: Optional[Literal["adam", "sgd", "lbfgs", "custom"]] = "adam"
+    loss_function: Optional[
+        Literal["mse", "mae", "crossentropy", "logloss", "custom"]
+    ] = "mse"
+    validation_split: Optional[float] = Field(0.2, ge=0.0, le=0.5)
+    early_stopping_enabled: bool = True
+    early_stopping_patience: Optional[int] = 10
+    split_mode: Optional[Literal["train_val", "train_val_test"]] = "train_val"
+    cv_folds: Optional[int] = Field(None, ge=2, le=10)
+    save_best_model_enabled: bool = True
+    best_model_output_path: Optional[Path] = None
+
+    # ------------------------------------------------------------------
+    # Inference configuration
+    inference_enabled: bool = False
+    load_existing_model: bool = False
+    existing_model_path: Optional[Path] = None
+    inference_input_path: Optional[Path] = None
+    inference_output_path: Optional[Path] = None
+    confidence_threshold: Optional[float] = None
+    normalize_input_features: bool = True
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    evaluation_metrics: List[
+        Literal[
+            "rmse",
+            "mae",
+            "r2",
+            "accuracy",
+            "precision",
+            "recall",
+            "f1",
+            "logloss",
+        ]
+    ] = ["rmse", "r2"]
+    track_feature_importance: bool = True
+    model_config_hash: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def with_defaults(cls) -> "MLModelConfig":
+        return cls(
+            model_name="default_model",
+            training_dataset_path=Path("datasets/train.csv"),
+            input_features=["V0"],
+            output_targets=["neutron_yield"],
+        )
+
+    def resolve_defaults(self) -> "MLModelConfig":
+        data = self.model_dump()
+        return self.model_validate(data)
+
+    @classmethod
+    def required_fields(cls) -> List[str]:
+        return [n for n, f in cls.model_fields.items() if f.is_required()]
+
+    @classmethod
+    def get_field_metadata(cls) -> Dict[str, Dict[str, Any]]:
+        return {n: (f.json_schema_extra or f.metadata or {}) for n, f in cls.model_fields.items()}
+
+    def normalize_units(self) -> "MLModelConfig":
+        return self
+
+    def summarize(self) -> str:
+        arch = self.model_architecture_template or "None"
+        parts = [
+            f"ML Model: {self.model_name} [{self.model_engine}], Template: {arch}",
+            f"Task: {self.model_type}, Loss = {self.loss_function}, Opt = {self.optimizer_type}, ",
+            f"CV = {self.cv_folds or 'none'} folds",
+            f"Features: [{', '.join(self.input_features)}] → [{', '.join(self.output_targets)}]",
+        ]
+        if self.inference_output_path:
+            inf = str(self.inference_output_path)
+            conf = (
+                f" < {self.confidence_threshold}" if self.confidence_threshold is not None else ""
+            )
+            parts.append(f"Inference: {inf} | Confidence{conf}")
+        return "\n".join(parts)
+
+    def hash_ml_model_config(self) -> str:
+        data = self.model_dump(by_alias=True, exclude={"model_config_hash"}, exclude_none=True)
+        serialized = json.dumps(data, sort_keys=True, default=str)
+        return hashlib.sha256(serialized.encode()).hexdigest()
+
+    # ------------------------------------------------------------------
+    @model_validator(mode="after")
+    def check_rules(cls, values: "MLModelConfig") -> "MLModelConfig":
+        if not values.input_features:
+            raise ValueError("input_features must not be empty")
+        if not values.output_targets:
+            raise ValueError("output_targets must not be empty")
+        if values.model_type == "classification" and values.loss_function not in {"crossentropy", "logloss"}:
+            raise ValueError("classification models require crossentropy or logloss loss_function")
+        if values.inference_enabled:
+            if values.inference_input_path is None or values.inference_output_path is None:
+                raise ValueError("inference_input_path and inference_output_path required when inference_enabled")
+        if values.cv_folds is not None and values.validation_split is not None:
+            raise ValueError("validation_split must be None when cv_folds is set")
+        if values.load_existing_model and values.existing_model_path is None:
+            raise ValueError("existing_model_path required when load_existing_model is True")
+        values = values.model_copy(update={"model_config_hash": values.hash_ml_model_config()})
+        return values
+
+
+__all__ = ["MLModelConfig"]

--- a/tests/test_ml_model_config.py
+++ b/tests/test_ml_model_config.py
@@ -1,0 +1,111 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from ml_model_config import MLModelConfig
+
+try:
+    import yaml  # type: ignore
+    YAML_AVAILABLE = True
+except Exception:
+    YAML_AVAILABLE = False
+
+
+def base_data(tmp_path: Path) -> dict:
+    p = tmp_path / "train.csv"
+    p.write_text("data")
+    data = MLModelConfig.with_defaults().model_dump(by_alias=True)
+    data["trainingDatasetPath"] = p
+    data["inferenceOutputPath"] = tmp_path / "out.csv"
+    data["inferenceInputPath"] = tmp_path / "X.csv"
+    return data
+
+
+def test_feature_and_target_lists_not_empty(tmp_path: Path):
+    data = base_data(tmp_path)
+    data["inputFeatures"] = []
+    with pytest.raises(ValueError):
+        MLModelConfig.model_validate(data)
+    data = base_data(tmp_path)
+    data["outputTargets"] = []
+    with pytest.raises(ValueError):
+        MLModelConfig.model_validate(data)
+
+
+def test_model_type_matches_loss_function(tmp_path: Path):
+    data = base_data(tmp_path)
+    data["modelType"] = "classification"
+    data["lossFunction"] = "mse"
+    with pytest.raises(ValueError):
+        MLModelConfig.model_validate(data)
+    data["lossFunction"] = "crossentropy"
+    cfg = MLModelConfig.model_validate(data)
+    assert cfg.model_type == "classification"
+
+
+def test_inference_paths_required_if_enabled(tmp_path: Path):
+    data = base_data(tmp_path)
+    data["inferenceEnabled"] = True
+    data.pop("inferenceInputPath")
+    with pytest.raises(ValueError):
+        MLModelConfig.model_validate(data)
+    data = base_data(tmp_path)
+    data["inferenceEnabled"] = True
+    cfg = MLModelConfig.model_validate(data)
+    assert cfg.inference_output_path
+
+
+def test_yaml_round_trip_and_summary_output(tmp_path: Path):
+    yaml_text = """
+mlModel:
+  modelType: regression
+  surrogateModelEnabled: true
+  modelName: gpr_v4
+  modelEngine: gpytorch
+  modelArchitectureTemplate: MLP
+  modelArchitecture: 3x64-relu
+  trainingDatasetPath: datasets/train.csv
+  inputFeatures: [V0, C_ext, L_ext]
+  outputTargets: [neutron_yield, pinch_radius]
+  normalizationMethod: zscore
+  trainingEpochs: 200
+  batchSize: 32
+  optimizerType: adam
+  lossFunction: mse
+  validationSplit: 0.2
+  earlyStoppingEnabled: true
+  earlyStoppingPatience: 10
+  splitMode: train_val
+  cvFolds: 5
+  saveBestModelEnabled: true
+  bestModelOutputPath: models/gpr_best.pt
+  inferenceEnabled: true
+  loadExistingModel: true
+  existingModelPath: models/gpr_best.pt
+  inferenceInputPath: datasets/infer_X.csv
+  inferenceOutputPath: results/predict_Y.csv
+  confidenceThreshold: 0.05
+  normalizeInputFeatures: true
+  evaluationMetrics: [rmse, r2, f1]
+  trackFeatureImportance: true
+"""
+    if not YAML_AVAILABLE:
+        with pytest.raises(Exception):
+            __import__("yaml")
+        return
+    p = tmp_path / "ml.yml"
+    p.write_text(yaml_text)
+    data = yaml.safe_load(p.read_text())
+    cfg = MLModelConfig.model_validate(data["mlModel"])
+    dumped = json.loads(cfg.model_dump_json(by_alias=True))
+    cfg2 = MLModelConfig.model_validate(dumped)
+    assert cfg == cfg2
+    summary = cfg.summarize()
+    assert "ML Model" in summary and "Inference" in summary
+
+
+def test_hash_changes_with_model_name(tmp_path: Path):
+    cfg1 = MLModelConfig.with_defaults()
+    cfg2 = MLModelConfig.with_defaults().model_copy(update={"model_name": "other"})
+    assert cfg1.hash_ml_model_config() != cfg2.hash_ml_model_config()


### PR DESCRIPTION
## Summary
- add MLModelConfig section for surrogate/ML model settings
- support regression and classification modes with validation rules
- include YAML round‑trip and hashing tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*