### PR TITLE
Add semi-analytic pinch model

### DIFF
--- a/dpf2/__init__.py
+++ b/dpf2/__init__.py
@@ -1,12 +1,13 @@
 """Minimal Dense Plasma Focus simulator package."""
 
 from .circuit_solver import RLCCircuit, CircuitSolver
-from .plasma_model import AnalyticPinchModel
+from .pinch_models import AnalyticPinchModel, SemiAnalyticPinchModel
 from .simulation_engine import SimulationEngine
 
 __all__ = [
     "RLCCircuit",
     "CircuitSolver",
     "AnalyticPinchModel",
+    "SemiAnalyticPinchModel",
     "SimulationEngine",
 ]

--- a/dpf2/cli.py
+++ b/dpf2/cli.py
@@ -18,6 +18,12 @@ def build_parser() -> argparse.ArgumentParser:
     sim.add_argument("config", type=Path, help="Path to JSON/YAML configuration")
     sim.add_argument("-o", "--output", type=Path, default=Path("results.json"), help="Output file")
     sim.add_argument("--method", choices=["analytical", "ode"], default="analytical", help="Circuit solver method")
+    sim.add_argument(
+        "--pinch-model",
+        choices=["analytic", "semi-analytic"],
+        default="analytic",
+        help="Pinch dynamics model",
+    )
     return parser
 
 
@@ -28,7 +34,7 @@ def main(argv: list[str] | None = None) -> None:
     if args.command == "simulate":
         cfg = DPFConfig.from_file(args.config)
         engine = SimulationEngine(cfg)
-        results = engine.run(method=args.method)
+        results = engine.run(method=args.method, pinch_model=args.pinch_model)
         args.output.write_text(json.dumps(results.to_dict(), indent=2))
     else:
         parser.print_help()

--- a/dpf2/pinch_models.py
+++ b/dpf2/pinch_models.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+from scipy.integrate import solve_ivp
+
+__all__ = ["PinchModelBase", "PinchResult", "AnalyticPinchModel", "SemiAnalyticPinchModel"]
+
+
+@dataclass
+class PinchResult:
+    time: np.ndarray
+    radius: np.ndarray
+    temperature: np.ndarray
+    pressure: np.ndarray
+    neutron_yield: float
+    axial_position: np.ndarray | None = None
+
+
+class PinchModelBase:
+    """Base interface for pinch dynamics models."""
+
+    def run(self, time: Iterable[float], current: Iterable[float]) -> PinchResult:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class AnalyticPinchModel(PinchModelBase):
+    """Very simple analytic model of the DPF pinch."""
+
+    def __init__(self, initial_radius: float = 1e-2, tau: float = 50e-9) -> None:
+        self.initial_radius = initial_radius
+        self.tau = tau
+
+    def run(self, time: Iterable[float], current: Iterable[float]) -> PinchResult:
+        t = np.asarray(time)
+        I = np.asarray(current)
+        radius = self.initial_radius * np.exp(-t / self.tau)
+        pressure = 0.5 * (I ** 2) * 1e-6  # arbitrary scaling
+        temperature = 1e3 * (I / 1e4) ** 2
+        yield_integrand = (temperature / 1e3) ** 3 * I ** 2
+        neutron_yield = float(np.trapz(yield_integrand, t) * 1e-20)
+        return PinchResult(t, radius, temperature, pressure, neutron_yield)
+
+
+class SemiAnalyticPinchModel(PinchModelBase):
+    """Cylindrical collapse model with simple pressure balance."""
+
+    def __init__(
+        self,
+        initial_radius: float = 1e-2,
+        initial_axial: float = 0.1,
+        mass: float = 1e-6,
+        ext_pressure: float = 1e5,
+        damping: float = 0.0,
+    ) -> None:
+        self.initial_radius = initial_radius
+        self.initial_axial = initial_axial
+        self.mass = mass
+        self.ext_pressure = ext_pressure
+        self.damping = damping
+
+    def _dynamics(self, t: float, y: np.ndarray, current: np.ndarray, time: np.ndarray) -> np.ndarray:
+        r, vr, z, vz = y
+        I = np.interp(t, time, current)
+        # magnetic pressure term; avoid divide by zero
+        force_r = (1e-7 * I ** 2) / max(r, 1e-6)  # approx mu0/(2*pi)=2e-7, simplified
+        acc_r = (force_r - self.ext_pressure * r) / self.mass - self.damping * vr
+        acc_z = -self.ext_pressure / self.mass - self.damping * vz
+        return np.array([vr, acc_r, vz, acc_z])
+
+    def run(self, time: Iterable[float], current: Iterable[float]) -> PinchResult:
+        t = np.asarray(time)
+        I = np.asarray(current)
+        y0 = [self.initial_radius, 0.0, self.initial_axial, 0.0]
+        sol = solve_ivp(self._dynamics, (t[0], t[-1]), y0, t_eval=t, args=(I, t), method="RK45")
+        r = sol.y[0]
+        z = sol.y[2]
+        temperature = 1e3 * (I / 1e4) ** 2 + 0.1 * r ** -1
+        pressure = self.ext_pressure + 0.5 * (I ** 2) * 1e-6
+        yield_integrand = (temperature / 1e3) ** 3 * I ** 2
+        neutron_yield = float(np.trapz(yield_integrand, t) * 1e-20)
+        return PinchResult(t, r, temperature, pressure, neutron_yield, axial_position=z)
+

--- a/dpf2/plasma_model.py
+++ b/dpf2/plasma_model.py
@@ -1,37 +1,11 @@
-"""Simple 0D analytic pinch model for DPF simulations."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from types import SimpleNamespace
-from typing import Iterable
+# Backward compatibility wrapper
+from .pinch_models import (
+    AnalyticPinchModel,
+    PinchResult,
+    SemiAnalyticPinchModel,
+    PinchModelBase,
+)
 
-import numpy as np
-
-__all__ = ["AnalyticPinchModel", "PinchResult"]
-
-
-@dataclass
-class PinchResult:
-    time: np.ndarray
-    radius: np.ndarray
-    temperature: np.ndarray
-    pressure: np.ndarray
-    neutron_yield: float
-
-
-class AnalyticPinchModel:
-    """Very simple analytic model of the DPF pinch."""
-
-    def __init__(self, initial_radius: float = 1e-2, tau: float = 50e-9) -> None:
-        self.initial_radius = initial_radius
-        self.tau = tau
-
-    def run(self, time: Iterable[float], current: Iterable[float]) -> PinchResult:
-        t = np.asarray(time)
-        I = np.asarray(current)
-        radius = self.initial_radius * np.exp(-t / self.tau)
-        pressure = 0.5 * (I ** 2) * 1e-6  # arbitrary scaling
-        temperature = 1e3 * (I / 1e4) ** 2
-        yield_integrand = (temperature / 1e3) ** 3 * I ** 2
-        neutron_yield = float(np.trapz(yield_integrand, t) * 1e-20)
-        return PinchResult(t, radius, temperature, pressure, neutron_yield)
+__all__ = ["AnalyticPinchModel", "PinchResult", "SemiAnalyticPinchModel", "PinchModelBase"]

--- a/tests/test_pinch_models.py
+++ b/tests/test_pinch_models.py
@@ -1,0 +1,20 @@
+import numpy as np
+from dpf2.pinch_models import AnalyticPinchModel, SemiAnalyticPinchModel
+
+
+def test_analytic_model():
+    model = AnalyticPinchModel()
+    t = np.linspace(0, 1e-6, 10)
+    I = np.ones_like(t) * 1e4
+    res = model.run(t, I)
+    assert res.radius.size == t.size
+    assert res.neutron_yield >= 0.0
+
+
+def test_semi_analytic_model():
+    model = SemiAnalyticPinchModel()
+    t = np.linspace(0, 1e-6, 10)
+    I = np.ones_like(t) * 1e4
+    res = model.run(t, I)
+    assert res.radius.size == t.size
+    assert res.axial_position is not None


### PR DESCRIPTION
## Summary
- add new `pinch_models` module with base class and semi-analytic implementation
- update `SimulationEngine` to select pinch model
- expose pinch model choice in CLI
- keep compatibility wrapper in `plasma_model`
- export new model in package `__init__`
- add tests for pinch models

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*