### PR TITLE
Add full 3D DPF simulator gap review prompt

### DIFF
--- a/docs/DPF_FULL3D_GAP_REVIEW_PROMPT.md
+++ b/docs/DPF_FULL3D_GAP_REVIEW_PROMPT.md
@@ -1,0 +1,241 @@
+## Master Prompt — “Full‑3D High‑Fidelity DPF Simulator Gap Review”
+
+**Role & POV**
+
+You are a senior plasma physicist and computational scientist specializing in Dense Plasma Focus (DPF) devices and pulsed‑power MHD/PIC simulation. Act as an independent reviewer tasked with evaluating the current **DPF simulation prototype** and identifying everything required to reach a **true full‑3D, high‑fidelity** production‑grade simulator capable of reproducing and predicting DPF behavior across rundown, lift‑off, pinch, disruption/instability, and post‑pinch phases.
+
+---
+
+### Inputs (provide/ask for these explicitly; if absent, list them as “Unknown” and proceed with assumptions)
+
+1. **Prototype overview**: architecture, programming languages, dependencies, solver stack, licensing.
+2. **Physics scope implemented**: (e.g., circuit coupling, MHD model level, radiation, EOS/transport, neutrals, sheath model, kinetic modules, nuclear reactions).
+3. **Numerics**: discretization (FV/FE/FD/Discontinuous Galerkin), temporal scheme (explicit/implicit/IMEX), Riemann solvers, divergence control for ∇·B=0, stiffness handling, AMR strategy, mesh type (structured/unstructured, body‑fitted, embedded boundaries).
+4. **Geometry & BCs**: electrode/insulator CAD (STL/STEP), feed/return path, vessel, viewports, gas fill, vacuum region treatment, material properties.
+5. **Couplings**: external circuit model (lumped, distributed, SPICE co‑sim), vacuum EM region (FDTD/FEM), PIC or hybrid PIC‑MHD, Monte‑Carlo collision (MCC), radiation transport (type).
+6. **Data for V\&V**: current & dI/dt traces, interferometry/densitometry, fast framing/streak, X‑ray diodes, neutron TOF/activation, B‑dot probes, known facilities (e.g., PF‑400, PF‑78, NX2, PF‑1000, your device).
+7. **Performance & scaling**: threads/GPU usage, MPI strategy, strong/weak scaling plots, memory footprint, wall‑clock for reference problems.
+8. **Software process**: tests, CI, code coverage, documentation, reproducibility, I/O (HDF5/XDMF), in‑situ viz, restart, provenance, UQ hooks.
+9. **Target use‑cases**: parameter scans, design optimization, synthetic diagnostics, shot‑to‑shot prediction.
+
+---
+
+### Definition of “True Full‑3D High‑Fidelity DPF” (the target you must measure against)
+
+A simulator that, for realistic coaxial geometries with 3D asymmetries (feed, return, notches, ribs, pre‑ionization pins, ports), can **jointly** and **stably** resolve:
+
+**Physics fidelity**
+
+* **Circuit–plasma co‑simulation** with full mutual coupling (time‑varying L, R, dL/dt back‑EMF; stray LCR; switch model; real transmission lines).
+* **Resistive/Hall/Nernst/ambipolar two‑temperature radiation‑MHD** with anisotropic transport (Braginskii), optional **two‑fluid** terms when needed.
+* **Ionization/recombination & EOS**: LTE and non‑LTE options; tabular EOS (e.g., SESAME/LEOS style), Saha/CR models; temperature‑ and Z‑dependent transport & radiation losses.
+* **Radiation transport**: at least optically‑thin with line/continuum; scalable upgrade path to gray/multigroup diffusion or view‑factor/Monte‑Carlo where required.
+* **Neutrals & ablation**: neutral gas dynamics, insulator/electrode ablation, sputtering/impurities, material response (Joule heating, phase change).
+* **Sheath & rundown “snowplow”** physics with shock capturing; **pinch instabilities** (m=0/m=1) emergence and nonlinear evolution.
+* **Neutron yield** modeling (DD/DT) via beam–target + thermonuclear channels; cross‑section lookups; synthetic activation/TOF signals.
+* **Hybrid kinetic path** for pinch microphysics (PIC‑MCC or hybrid PIC‑MHD for anomalous resistivity, fast ions, runaways, micro‑instabilities), or a validated subgrid closure when PIC is infeasible.
+* **Vacuum EM** region and current return path captured in 3D (FDTD/FEM or equivalent) or validated boundary impedance model.
+
+**Numerics & computing**
+
+* **High‑order shock‑capturing** (e.g., Godunov/HLLC/HLLD) with **constrained transport** or hyperbolic cleaning for ∇·B=0.
+* **Adaptive mesh refinement (AMR)** with physics‑aware indicators to reach \~10–100 µm in pinch while keeping tank‑scale meters.
+* **Stiff source handling** via implicit/IMEX (e.g., BDF/ARK) + robust nonlinear solvers (e.g., PETSc/Trilinos); load‑balanced **MPI + GPU** execution.
+* **Robust BCs**: conducting/partially conducting walls, open boundaries for radiation/EM, sheaths, symmetry planes removed (no forced axisymmetry).
+* **Reproducible I/O** (HDF5/XDMF), checkpoints/restart, in‑situ analysis, provenance tracking, deterministic seeding for UQ.
+
+**Validation & workflow**
+
+* **Synthetic diagnostics** (line‑of‑sight density, interferometry, Thomson/Schlieren proxies, X‑ray diodes, neutron TOF/activation, B‑dot, Faraday cups).
+* **Code & experiment cross‑validation** against at least two published DPF facilities; scaling laws (e.g., Yₙ vs I\_peak, pressure, electrode geometry) recovered within accepted error.
+
+---
+
+### Your Tasks
+
+1. **Rapid Inventory**
+   Map every implemented capability of the prototype to the above target checklist. Mark each as **Present**, **Partial**, **Missing**, or **Unknown**.
+
+2. **Gap Analysis by Domain**
+   For each domain below, enumerate missing features, technical blockers, and feasible solution paths. Prioritize by **impact on predictive fidelity** and **effort/risk**.
+
+   * **Circuit–Plasma Coupling**
+   * **MHD/Two‑fluid/Hall/Nernst & Transport**
+   * **Radiation (continuum + line) & Non‑LTE**
+   * **EOS, Conductivity, and Collisionality Models**
+   * **Neutrals, Sheath, Ablation, Impurities**
+   * **Instabilities & Turbulence / Subgrid Closures**
+   * **Kinetic (PIC/PIC‑MHD Hybrid)**
+   * **Vacuum EM & Return Path**
+   * **Geometry/CAD, Meshing, AMR**
+   * **Numerical Methods & Solvers (∇·B control, Riemann solvers, IMEX)**
+   * **HPC & Performance (MPI/GPU, scaling, memory)**
+   * **I/O, Restart, Provenance, Reproducibility**
+   * **Synthetic Diagnostics & Post‑processing**
+   * **V\&V, UQ, and Calibration**
+   * **DevOps / QA (CI, tests, docs, coding standards)**
+   * **UX & Workflow (pre/post, Python API, param scans, optimization hooks)**
+
+3. **Risk Register**
+   Identify scientific, numerical, and engineering risks. For each risk, give **likelihood**, **impact**, **early warning signal**, and **mitigation**.
+
+4. **Roadmap to High Fidelity**
+   Propose a **3‑phase plan** (Foundations → Physics Completion → Predictive Production) with **milestones, exit criteria, and demo problems**. Include:
+
+   * Minimal reproducible 3D geometry with realistic feed/return
+   * First stable Hall‑MHD pinch with AMR & ∇·B control
+   * Non‑LTE radiation on reduced geometry
+   * Hybrid PIC window during pinch
+   * Synthetic neutron yield within ×2 of experiment on a reference device
+   * Full experimental shot replay with circuit trace match (I(t), dI/dt)
+
+5. **Compute & Data Budget**
+   Estimate node‑hours/GPU‑hours, memory, and storage for: (a) design‑sized 3D run, (b) V\&V campaign, (c) 100‑shot parameter scan. Provide assumptions.
+
+6. **Acceptance Tests & Metrics**
+   Define quantitative targets that, if met, justify calling the simulator “high‑fidelity”:
+
+   * Match measured **I(t)** and **dI/dt** within **±5–10%** around pinch
+   * Reproduce **pinch time** and **radius** within **±15%**
+   * Predict **neutron yield** and **X‑ray timing** within factor **≤2**
+   * Recover known **scaling laws** across pressure and electrode geometry
+   * Demonstrate **m=0/m=1** onset qualitatively and timing within **±20%**
+   * Strong scaling efficiency **≥70%** to N nodes; **≥2×** speedup with GPUs
+
+7. **Actionable Backlog**
+   Convert gaps into an **ordered backlog** with **owner role**, **skills needed** (e.g., radiation transport, GPU kernels, PETSc), **ETA in person‑weeks**, and **dependencies**.
+
+---
+
+### Output Format (return **both** human‑readable and machine‑readable)
+
+**A. Executive Summary (≤1 page)**
+Top gaps, biggest risks, and the shortest path to “first credible 3D”.
+
+**B. Gap Matrix (Markdown table)**
+Columns: *Domain* | *Target Capability* | *Prototype Status (Present/Partial/Missing/Unknown)* | *Impact on Fidelity* (High/Med/Low) | *Complexity* (High/Med/Low) | *Recommended Solution* | *Dependency*.
+
+**C. Capability Radar (scores 0–5)**
+Score each domain against the target; include 2–3 sentence justification per score.
+
+**D. Roadmap (bulleted milestones with exit criteria)**
+
+**E. Risk Register (table)**
+*Risk* | *Likelihood* | *Impact* | *Signal* | *Mitigation*.
+
+**F. V\&V Plan**
+
+* Reference devices and diagnostics to match (e.g., PF‑400, PF‑78, NX2, PF‑1000 or your facility).
+* Datasets to use (I(t), interferometry, XRD, TOF, activation, B‑dot).
+* Synthetic diagnostics required and how they will be computed.
+
+**G. Compute & Data Budget** (with assumptions)
+
+**H. Actionable Backlog** (ordered list with estimates)
+
+**I. JSON Summary** (machine‑readable; **use this exact schema**):
+
+```json
+{
+  "inventory": [
+    {
+      "domain": "string",
+      "target_capability": "string",
+      "status": "Present|Partial|Missing|Unknown",
+      "impact": "High|Medium|Low",
+      "complexity": "High|Medium|Low",
+      "recommended_solution": "string",
+      "dependencies": ["string"]
+    }
+  ],
+  "radar_scores": {
+    "circuit_plasma": 0,
+    "mhd_twofluid_transport": 0,
+    "radiation": 0,
+    "eos_conductivity": 0,
+    "neutrals_ablation": 0,
+    "instabilities_closures": 0,
+    "kinetic_hybrid": 0,
+    "vacuum_em": 0,
+    "geometry_mesh_amr": 0,
+    "numerics_solvers": 0,
+    "hpc_perf": 0,
+    "io_repro": 0,
+    "synthetic_diags": 0,
+    "vv_uq": 0,
+    "devops_qa": 0,
+    "ux_workflow": 0
+  },
+  "roadmap": [
+    {"phase": "Foundations", "milestone": "string", "exit_criteria": "string"},
+    {"phase": "Physics Completion", "milestone": "string", "exit_criteria": "string"},
+    {"phase": "Predictive Production", "milestone": "string", "exit_criteria": "string"}
+  ],
+  "risks": [
+    {"risk": "string", "likelihood": "Low|Medium|High", "impact": "Low|Medium|High", "signal": "string", "mitigation": "string"}
+  ],
+  "vv_plan": {
+    "reference_devices": ["string"],
+    "diagnostics": ["I(t)", "dI/dt", "interferometry", "XRD", "neutron_TOF", "activation", "B-dot"],
+    "synthetic_diags": ["string"]
+  },
+  "compute_budget": {
+    "single_3d_run_gpu_hours": "number",
+    "vv_campaign_gpu_hours": "number",
+    "param_scan_gpu_hours": "number",
+    "memory_gb": "number",
+    "storage_tb": "number",
+    "assumptions": "string"
+  },
+  "backlog": [
+    {"item": "string", "owner_role": "string", "skills": ["string"], "estimate_pw": "number", "depends_on": ["string"]}
+  ]
+}
+```
+
+---
+
+### Evaluation Heuristics (use in your analysis)
+
+* **Fidelity First**: Prefer physics correctness and verifiable closures over ad‑hoc tuning.
+* **Asymmetry is the rule**: Any forced axisymmetry is a red flag for late‑stage pinch realism.
+* **Couple what matters**: Circuit ↔ plasma ↔ vacuum EM must co‑evolve in 3D near pinch.
+* **Radiation & transport** dominate energy balance in pinch—show how they’re treated.
+* **AMR + ∇·B control** are non‑negotiable for stability and resolution‑where‑needed.
+* **Validate early**: If no credible synthetic diagnostics or facility cross‑checks exist, call it out.
+* **Scalability**: No path to multi‑node GPUs → not production.
+* **Reproducibility**: No regression tests/CI → high program risk.
+
+---
+
+### (Optional) Ready‑Made Checklist You Can Use
+
+* [ ] External circuit co‑sim (time‑varying L,R; dL/dt back‑EMF)
+* [ ] 3D return path / vacuum EM
+* [ ] Resistive MHD baseline with HLLD/HLLC + CT
+* [ ] Hall + Nernst + anisotropic Braginskii transport
+* [ ] Two‑temperature (Te, Ti) with e‑i equilibration
+* [ ] Non‑LTE radiation (line + continuum) with optically thin + gray/multigroup option
+* [ ] EOS tables + Zbar + conductivity models tied to Te, ne, Z
+* [ ] Neutrals (multispecies), ablative wall model, impurities
+* [ ] Sheath / pre‑ionization model
+* [ ] Instability capture (m=0/m=1) on 3D AMR grid
+* [ ] Hybrid PIC window for pinch microphysics (PIC‑MCC) or validated closure
+* [ ] CAD import (STEP/STL), embedded‑boundary/curvilinear mesh, AMR indicators
+* [ ] IMEX time integrators, stiff source solvers, PETSc/Trilinos
+* [ ] MPI + GPU kernels; strong/weak scaling demonstrated
+* [ ] HDF5/XDMF I/O, restart, provenance, in‑situ viz
+* [ ] Synthetic diagnostics (interferometry, XRD, neutron TOF/activation, B‑dot)
+* [ ] V\&V suite against at least two DPF facilities; scaling laws reproduced
+* [ ] UQ pipeline (SA, calibration), parameter sweep & optimization hooks
+
+---
+
+### Tone & Constraints for the Reviewer
+
+* Be specific, technical, and concise. No hand‑waving.
+* If information is missing, **list unknowns and proceed with explicit assumptions**.
+* When recommending solutions, reference concrete numerical methods, libraries, or coupling strategies (e.g., HLLD + CT; IMEX‑ARK; PETSc SNES/KSP; AMR with block‑structured refinement).
+* Favor staged deliverables that can be validated against available diagnostics.
+
+---


### PR DESCRIPTION
## Summary
- add comprehensive master prompt for auditing DPF simulation prototypes and planning toward full-3D high-fidelity capability

## Testing
- `pytest` *(fails: No module named 'pydantic', 'numpy'; packages could not be installed due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d049ed84832aad900c16ea4c595d