### PR TITLE
Add deterministic diagnostics stub export

### DIFF
--- a/advanced_options.py
+++ b/advanced_options.py
@@ -162,6 +162,36 @@ class AdvancedOptions(ConfigSectionBase):
         serialized = json.dumps(data, sort_keys=True, default=str)
         return hashlib.sha256(serialized.encode()).hexdigest()
 
+    def export_diagnostics_stub_files(self, output_dir: Path) -> List[Path]:
+        """Write deterministic stub diagnostics for tooling or CI.
+
+        Parameters
+        ----------
+        output_dir:
+            Directory where stub files will be written. Created if necessary.
+
+        Returns
+        -------
+        List[Path]
+            Paths to the generated files, or an empty list if stubs are disabled.
+        """
+        if not self.export_diagnostics_stub:
+            return []
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        summary_path = output_dir / "summary.json"
+        waveform_path = output_dir / "current.csv"
+
+        summary_data = {
+            "neutron_yield": 0.0,
+            "max_b_field_T": 0.0,
+            "pinch_time_ns": 0.0,
+        }
+        summary_path.write_text(json.dumps(summary_data, indent=2, sort_keys=True))
+        waveform_path.write_text("time_ns,current_kA\n0,0\n")
+        return [summary_path, waveform_path]
+
     # ------------------------------------------------------------------
     @model_validator(mode="after")
     def check_rules(cls, values: "AdvancedOptions") -> "AdvancedOptions":

--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -4,7 +4,6 @@ import pytest
 
 from advanced_options import AdvancedOptions
 
-
 def test_disable_validators_requires_reason():
     data = AdvancedOptions.with_defaults().model_dump(by_alias=True)
     data["disableAllValidators"] = True
@@ -50,3 +49,28 @@ def test_round_trip_serialization():
     dumped = json.loads(cfg.model_dump_json(by_alias=True))
     loaded = AdvancedOptions.model_validate(dumped)
     assert loaded == cfg
+
+
+def test_export_diagnostics_stub_toggle(tmp_path: Path):
+    cfg = AdvancedOptions.with_defaults().model_copy(update={"export_diagnostics_stub": True})
+    created = cfg.export_diagnostics_stub_files(tmp_path)
+
+    summary = tmp_path / "summary.json"
+    waveform = tmp_path / "current.csv"
+    assert summary.exists() and waveform.exists()
+    assert set(created) == {summary, waveform}
+
+    data = json.loads(summary.read_text())
+    assert data == {
+        "neutron_yield": 0.0,
+        "max_b_field_T": 0.0,
+        "pinch_time_ns": 0.0,
+    }
+    lines = waveform.read_text().splitlines()
+    assert lines == ["time_ns,current_kA", "0,0"]
+
+    cfg_off = cfg.model_copy(update={"export_diagnostics_stub": False})
+    out = tmp_path / "off"
+    result = cfg_off.export_diagnostics_stub_files(out)
+    assert result == []
+    assert not out.exists()


### PR DESCRIPTION
## Summary
- add `export_diagnostics_stub_files` helper to generate deterministic diagnostics summary and waveform files
- test stub generation and flag toggle behavior in advanced options

## Testing
- `pip install pydantic -q` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest tests/test_advanced_options.py::test_export_diagnostics_stub_toggle -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68a9edea066c832a9d5e4d144393d6b7