### PR TITLE
Add resistive MHD primitive-conservative conversion, fluxes, and tests

### DIFF
--- a/src/dpf2/physics/mhd.py
+++ b/src/dpf2/physics/mhd.py
@@ -5,10 +5,28 @@ import numpy as np
 
 
 class ResistiveMHD:
-    """Minimal representation of resistive MHD equations."""
+    """Minimal representation of resistive MHD equations.
 
-    def __init__(self, gamma: float = 5 / 3) -> None:
+    The formulation implemented here follows the ideal MHD equations with an
+    additional simple resistive (Ohmic) contribution.  Only the radial and
+    axial momenta are evolved which is sufficient for the 2D ``r-z`` geometry
+    used throughout the code base.  The azimuthal magnetic field ``B_phi`` is
+    retained as it plays an important role in plasma pinches.
+    """
+
+    def __init__(self, gamma: float = 5 / 3, eta: float = 0.0) -> None:
+        """Create a new resistive MHD system.
+
+        Parameters
+        ----------
+        gamma:
+            Ratio of specific heats.
+        eta:
+            Scalar resistivity used for Ohmic heating and magnetic field decay.
+        """
+
         self.gamma = gamma
+        self.eta = eta
         self.equations = [
             "density",
             "momentum_r",
@@ -20,15 +38,96 @@ class ResistiveMHD:
         ]
 
     def conservative_variables(self, primitives: np.ndarray) -> np.ndarray:
-        """Convert primitive variables to conservative form."""
-        # Placeholder conversion
-        return primitives
+        """Convert primitive variables to conservative form.
+
+        The primitive state is expected to be ``[rho, v_r, v_z, p, B_r, B_z,
+        B_phi]``.  The returned conservative vector is
+        ``[rho, rho*v_r, rho*v_z, E, B_r, B_z, B_phi]`` where ``E`` is the
+        total energy density.
+        """
+
+        rho, v_r, v_z, p, B_r, B_z, B_phi = primitives
+        kinetic = 0.5 * rho * (v_r ** 2 + v_z ** 2)
+        magnetic = 0.5 * (B_r ** 2 + B_z ** 2 + B_phi ** 2)
+        energy = p / (self.gamma - 1.0) + kinetic + magnetic
+        return np.array([rho, rho * v_r, rho * v_z, energy, B_r, B_z, B_phi])
+
+    def _pressure(self, U: np.ndarray) -> float:
+        """Return the thermal pressure from conservative variables."""
+
+        rho, m_r, m_z, E, B_r, B_z, B_phi = U
+        v_r = m_r / rho
+        v_z = m_z / rho
+        v2 = v_r ** 2 + v_z ** 2
+        B2 = B_r ** 2 + B_z ** 2 + B_phi ** 2
+        return (E - 0.5 * rho * v2 - 0.5 * B2) * (self.gamma - 1.0)
 
     def flux_function(self, U: np.ndarray, direction: str) -> np.ndarray:
-        """Compute MHD fluxes."""
-        # Placeholder flux calculation
-        return np.zeros_like(U)
+        """Compute ideal MHD fluxes in the given ``direction``.
+
+        Parameters
+        ----------
+        U:
+            Conservative state vector.
+        direction:
+            Either ``"r"`` or ``"z"`` selecting the spatial direction of the
+            flux.
+        """
+
+        rho, m_r, m_z, E, B_r, B_z, B_phi = U
+        v_r = m_r / rho
+        v_z = m_z / rho
+        B2 = B_r ** 2 + B_z ** 2 + B_phi ** 2
+        p = self._pressure(U)
+        total_p = p + 0.5 * B2
+        Bdotv = B_r * v_r + B_z * v_z
+
+        if direction == "r":
+            return np.array(
+                [
+                    m_r,
+                    m_r * v_r + total_p - B_r ** 2,
+                    m_z * v_r - B_r * B_z,
+                    (E + total_p) * v_r - B_r * Bdotv,
+                    0.0,
+                    v_z * B_r - v_r * B_z,
+                    B_phi * v_r,
+                ]
+            )
+
+        if direction == "z":
+            return np.array(
+                [
+                    m_z,
+                    m_r * v_z - B_r * B_z,
+                    m_z * v_z + total_p - B_z ** 2,
+                    (E + total_p) * v_z - B_z * Bdotv,
+                    v_r * B_z - v_z * B_r,
+                    0.0,
+                    B_phi * v_z,
+                ]
+            )
+
+        raise ValueError("direction must be 'r' or 'z'")
 
     def source_terms(self, U: np.ndarray) -> np.ndarray:
-        """Return resistive and geometric source terms."""
-        return np.zeros_like(U)
+        """Return resistive source terms.
+
+        A simple Ohmic model is employed where magnetic fields decay and the
+        lost magnetic energy appears as thermal energy.  Geometric source terms
+        are neglected for this minimal implementation.
+        """
+
+        _, _, _, _, B_r, B_z, B_phi = U
+        B2 = B_r ** 2 + B_z ** 2 + B_phi ** 2
+        return np.array(
+            [
+                0.0,
+                0.0,
+                0.0,
+                self.eta * B2,
+                -self.eta * B_r,
+                -self.eta * B_z,
+                -self.eta * B_phi,
+            ]
+        )

--- a/tests/test_mhd.py
+++ b/tests/test_mhd.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src" / "dpf2" / "physics"))
+from mhd import ResistiveMHD
+
+
+def test_conservative_variables():
+    model = ResistiveMHD()
+    primitives = np.array([1.0, 2.0, -1.0, 0.5, 0.1, 0.2, 0.3])
+    U = model.conservative_variables(primitives)
+    rho, v_r, v_z, p, B_r, B_z, B_phi = primitives
+    kinetic = 0.5 * rho * (v_r**2 + v_z**2)
+    magnetic = 0.5 * (B_r**2 + B_z**2 + B_phi**2)
+    energy = p / (model.gamma - 1.0) + kinetic + magnetic
+    expected = np.array([rho, rho*v_r, rho*v_z, energy, B_r, B_z, B_phi])
+    assert np.allclose(U, expected)
+
+
+def test_flux_function():
+    model = ResistiveMHD()
+    primitives = np.array([1.0, 2.0, -1.0, 0.5, 0.1, 0.2, 0.3])
+    U = model.conservative_variables(primitives)
+    rho, v_r, v_z, p, B_r, B_z, B_phi = primitives
+    B2 = B_r**2 + B_z**2 + B_phi**2
+    total_p = p + 0.5 * B2
+    Bdotv = B_r * v_r + B_z * v_z
+    E = U[3]
+    expected_r = np.array([
+        rho*v_r,
+        rho*v_r*v_r + total_p - B_r**2,
+        rho*v_z*v_r - B_r*B_z,
+        (E + total_p)*v_r - B_r*Bdotv,
+        0.0,
+        v_z*B_r - v_r*B_z,
+        B_phi*v_r,
+    ])
+    expected_z = np.array([
+        rho*v_z,
+        rho*v_r*v_z - B_r*B_z,
+        rho*v_z*v_z + total_p - B_z**2,
+        (E + total_p)*v_z - B_z*Bdotv,
+        v_r*B_z - v_z*B_r,
+        0.0,
+        B_phi*v_z,
+    ])
+    assert np.allclose(model.flux_function(U, "r"), expected_r)
+    assert np.allclose(model.flux_function(U, "z"), expected_z)
+
+
+def test_source_terms():
+    eta = 0.05
+    model = ResistiveMHD(eta=eta)
+    primitives = np.array([1.0, 2.0, -1.0, 0.5, 0.1, 0.2, 0.3])
+    U = model.conservative_variables(primitives)
+    B_r, B_z, B_phi = primitives[4:]
+    B2 = B_r**2 + B_z**2 + B_phi**2
+    expected = np.array([0.0, 0.0, 0.0, eta*B2, -eta*B_r, -eta*B_z, -eta*B_phi])
+    assert np.allclose(model.source_terms(U), expected)


### PR DESCRIPTION
## Summary
- implement conversion between primitive and conservative variables
- add ideal/resistive MHD fluxes for radial and axial directions
- include simple Ohmic source terms
- add unit tests verifying conversions, fluxes, and source terms

## Testing
- `pytest tests/test_mhd.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9edebbf60832a84b1573e6d1142c1