### PR TITLE
Add time-stepping loop and outputs to core simulation

### DIFF
--- a/src/dpf2/core/__init__.py
+++ b/src/dpf2/core/__init__.py
@@ -1,1 +1,13 @@
+"""Core components for simplified DPF simulations."""
+
 from .config import DPFConfig
+from .simulation import DPFSimulation
+from .bases import PlasmaSolverBase, CircuitSolverBase, DiagnosticsBase
+
+__all__ = [
+    "DPFConfig",
+    "DPFSimulation",
+    "PlasmaSolverBase",
+    "CircuitSolverBase",
+    "DiagnosticsBase",
+]

--- a/src/dpf2/core/bases.py
+++ b/src/dpf2/core/bases.py
@@ -1,0 +1,39 @@
+"""Abstract base classes for solver components."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class PlasmaSolverBase(ABC):
+    """Interface for plasma solvers."""
+
+    @abstractmethod
+    def step(self, state: Any, dt: float) -> Any:
+        """Advance the plasma state by ``dt`` seconds."""
+        raise NotImplementedError
+
+
+class CircuitSolverBase(ABC):
+    """Interface for external circuit solvers."""
+
+    @abstractmethod
+    def step(self, current: float, voltage: float, dt: float) -> tuple[float, float]:
+        """Return updated (current, voltage) after ``dt`` seconds."""
+        raise NotImplementedError
+
+
+class DiagnosticsBase(ABC):
+    """Interface for simulation diagnostics."""
+
+    @abstractmethod
+    def record(self, state: Any, time: float) -> None:
+        """Record the simulation ``state`` at ``time``."""
+        raise NotImplementedError
+
+
+__all__ = [
+    "PlasmaSolverBase",
+    "CircuitSolverBase",
+    "DiagnosticsBase",
+]

--- a/src/dpf2/core/simulation.py
+++ b/src/dpf2/core/simulation.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from ..mesh import Mesh2D
 from .config import DPFConfig
@@ -11,10 +12,23 @@ from ..io.data_writer import DataWriter
 class DPFSimulation:
     """Main class orchestrating a DPF simulation."""
 
-    def __init__(self, config: DPFConfig) -> None:
+    def __init__(
+        self,
+        config: DPFConfig,
+        plasma_solver: Any | None = None,
+        circuit_solver: Any | None = None,
+    ) -> None:
         self.config = config
         self.mesh = self._setup_mesh()
-        self.writer = DataWriter("output")
+        self.plasma_solver = plasma_solver
+        self.circuit_solver = circuit_solver
+        self.writer: DataWriter | None = None
+
+        # Runtime state variables
+        self.time = 0.0
+        self.plasma_state: Any = 0.0
+        self.current = 0.0
+        self.voltage = self.config.charging_voltage
 
     def _setup_mesh(self) -> Mesh2D:
         cfg = self.config
@@ -27,10 +41,54 @@ class DPFSimulation:
             cfg.nz_cells,
         )
 
-    def run(self, end_time: float | None = None, output_dir: str | None = None) -> None:
-        """Placeholder main loop."""
+    def run(
+        self,
+        end_time: float | None = None,
+        output_dir: str | None = None,
+        output_interval: float | None = None,
+    ) -> None:
+        """Advance the simulation until ``end_time``.
+
+        Parameters
+        ----------
+        end_time:
+            Optional final time.  Defaults to ``self.config.end_time``.
+        output_dir:
+            Directory where output files are written.
+        output_interval:
+            Time between data dumps.  Defaults to ``end_time`` (only final
+            state).
+        """
+
         end = end_time or self.config.end_time
         out = output_dir or "output"
+        interval = output_interval or end
+
         Path(out).mkdir(parents=True, exist_ok=True)
-        # Placeholder for future time loop
-        self.writer.write_hdf5({}, time=0.0)
+        self.writer = DataWriter(out)
+
+        # Write initial state
+        self.writer.write_hdf5({"current": self.current, "voltage": self.voltage}, time=self.time)
+        last_output = self.time
+
+        while self.time < end:
+            dt = min(
+                self.config.cfl_number * min(self.mesh.dr, self.mesh.dz),
+                end - self.time,
+            )
+
+            if self.plasma_solver is not None:
+                self.plasma_state = self.plasma_solver.step(self.plasma_state, dt)
+            if self.circuit_solver is not None:
+                self.current, self.voltage = self.circuit_solver.step(
+                    self.current, self.voltage, dt
+                )
+
+            self.time += dt
+
+            if (self.time - last_output) >= interval or self.time >= end:
+                self.writer.write_hdf5(
+                    {"current": self.current, "voltage": self.voltage},
+                    time=self.time,
+                )
+                last_output = self.time

--- a/tests/test_core_simulation.py
+++ b/tests/test_core_simulation.py
@@ -1,0 +1,107 @@
+import sys
+import types
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_simulation(monkeypatch):
+    """Load DPFSimulation with minimal dependency stubs."""
+    # Stub numpy with basic linspace
+    numpy_stub = types.ModuleType("numpy")
+
+    def linspace(start, stop, num):
+        if num <= 1:
+            return [start]
+        step = (stop - start) / (num - 1)
+        return [start + i * step for i in range(num)]
+
+    numpy_stub.linspace = linspace
+    monkeypatch.setitem(sys.modules, "numpy", numpy_stub)
+
+    # Stub h5py to write simple text files
+    class _FakeH5:
+        class File:
+            def __init__(self, fname, mode):
+                self.fname = fname
+                self.data = {}
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                with open(self.fname, "w") as f:
+                    for k, v in self.data.items():
+                        f.write(f"{k}:{v}\n")
+
+            def create_dataset(self, key, data):
+                self.data[key] = data
+
+    monkeypatch.setitem(sys.modules, "h5py", _FakeH5())
+
+    # Stub config module to avoid pydantic
+    config_stub = types.ModuleType("dpf2.core.config")
+    class DPFConfig:  # minimal placeholder
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+    config_stub.DPFConfig = DPFConfig
+    monkeypatch.setitem(sys.modules, "dpf2.core.config", config_stub)
+
+    # Create dummy package structure
+    repo_root = Path(__file__).resolve().parents[1]
+    pkg = types.ModuleType("dpf2")
+    pkg.__path__ = [str(repo_root / "src" / "dpf2")]
+    core_pkg = types.ModuleType("dpf2.core")
+    core_pkg.__path__ = [str(repo_root / "src" / "dpf2" / "core")]
+    monkeypatch.setitem(sys.modules, "dpf2", pkg)
+    monkeypatch.setitem(sys.modules, "dpf2.core", core_pkg)
+
+    spec = importlib.util.spec_from_file_location(
+        "dpf2.core.simulation", repo_root / "src" / "dpf2" / "core" / "simulation.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "dpf2.core.simulation", module)
+    spec.loader.exec_module(module)
+    return module.DPFSimulation
+
+
+def test_simulation_advances_and_writes(tmp_path, monkeypatch):
+    DPFSimulation = _load_simulation(monkeypatch)
+
+    class SimpleConfig:
+        anode_radius = 0.025
+        electrode_length = 0.10
+        nr_cells = 10
+        nz_cells = 10
+        cfl_number = 1e-3
+        end_time = 1e-6
+        charging_voltage = 15000.0
+
+    class DummyPlasmaSolver:
+        def __init__(self):
+            self.calls = 0
+
+        def step(self, state, dt):
+            self.calls += 1
+            return (state or 0.0) + dt
+
+    class DummyCircuitSolver:
+        def step(self, current, voltage, dt):
+            return current + dt, voltage - dt
+
+    cfg = SimpleConfig()
+    plasma = DummyPlasmaSolver()
+    circuit = DummyCircuitSolver()
+    sim = DPFSimulation(cfg, plasma_solver=plasma, circuit_solver=circuit)
+    sim.run(output_dir=str(tmp_path), output_interval=5e-7)
+
+    # state should evolve
+    assert plasma.calls > 0
+    assert sim.current > 0.0
+    assert sim.voltage < cfg.charging_voltage
+
+    # output files should be written
+    files = sorted(tmp_path.glob("data_*.h5"))
+    assert len(files) >= 2


### PR DESCRIPTION
## Summary
- Implement iterative time-stepping in `DPFSimulation` to advance plasma and circuit solvers and emit output files at configurable intervals
- Expose solver base classes and simulation via core package init
- Add integration test validating state evolution and data file creation

## Testing
- `pytest tests/test_core_simulation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9edf3ac10832a978326c7842c1ff8