### PR TITLE
Add thread-safe simulation interface and API lifecycle tests

### DIFF
--- a/Simulation/dpf_simulator_server.py
+++ b/Simulation/dpf_simulator_server.py
@@ -42,16 +42,85 @@ class ExportError(ServerError):
 
 # ——— Simulation Interface ———
 class SimulationInterface:
-    def __init__(self, config: Dict[str, Any]):
-        pass
-    def run(self):
-        raise NotImplementedError
-    def stop(self):
-        raise NotImplementedError
+    """Thread safe wrapper around :class:`DPFSimulation`.
+
+    The interface exposes a minimal set of controls used by the API
+    server while delegating attribute access to the underlying
+    ``DPFSimulation`` instance.  A re-entrant lock is used to guard
+    mutable state so that the simulation may be queried safely from
+    different threads.
+    """
+
+    def __init__(self, config: Dict[str, Any], field_manager: FieldManager | None = None):
+        self._lock = threading.RLock()
+        # Underlying simulation object
+        if field_manager is not None:
+            self._sim = DPFSimulation(config, field_manager=field_manager)
+        else:
+            self._sim = DPFSimulation(config)
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        """Execute the simulation.
+
+        The simulation is run in the current thread.  Any exception is
+        logged and the simulation is finalised to ensure resources are
+        released.
+        """
+        try:
+            self._sim.run()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Simulation run failed: %s", exc)
+        finally:
+            if hasattr(self._sim, "finalize"):
+                try:
+                    self._sim.finalize()
+                except Exception:  # pragma: no cover - defensive
+                    logger.exception("Simulation finalization failed")
+
+    # ------------------------------------------------------------------
+    def stop(self) -> None:
+        """Request the simulation to stop.
+
+        Many components check ``config.sim_time`` each iteration.  By
+        updating this value to the current simulation time we ensure the
+        loop exits at the next check.
+        """
+        with self._lock:
+            if hasattr(self._sim, "config") and hasattr(self._sim, "current_time"):
+                try:
+                    self._sim.config.sim_time = self._sim.current_time
+                except Exception:  # pragma: no cover - defensive
+                    logger.debug("Unable to adjust sim_time during stop")
+
+    # ------------------------------------------------------------------
     def get_diagnostics(self):
-        raise NotImplementedError
+        """Return diagnostics object from the simulation, if available."""
+        with self._lock:
+            diag = getattr(self._sim, "diagnostics", None)
+            if diag is None and hasattr(self._sim, "modules"):
+                diag = self._sim.modules.get("diagnostics")
+            return diag
+
+    # ------------------------------------------------------------------
     def get_state(self):
-        raise NotImplementedError
+        """Return current simulation state, if available."""
+        with self._lock:
+            return getattr(self._sim, "state", None)
+
+    # ------------------------------------------------------------------
+    def __getattr__(self, item):  # pragma: no cover - simple delegation
+        """Delegate attribute access to the underlying simulation."""
+        return getattr(self._sim, item)
+
+    # Convenience properties -------------------------------------------------
+    @property
+    def diagnostics(self):  # pragma: no cover - thin wrapper
+        return self.get_diagnostics()
+
+    @property
+    def state(self):  # pragma: no cover - thin wrapper
+        return self.get_state()
 
 # ——— Simulation Manager ———
 class SimulationManager:
@@ -72,7 +141,7 @@ class SimulationManager:
                 domain_lo=tuple(config['domain_lo']),
                 boundary_conditions=field_manager_config.get('boundary_conditions', {})
             )
-            sim = DPFSimulation(config, field_manager=field_manager) # Pass FieldManager to DPFSimulation
+            sim = SimulationInterface(config, field_manager=field_manager)
             self.simulations[sim_id] = sim
             logger.info(f"Simulation {sim_id} created with parameters: {config}")
             return sim_id
@@ -92,7 +161,7 @@ class SimulationManager:
         if not sim:
             raise SimulationError(f"Simulation {sim_id} not found")
         logger.info(f"Stopping simulation {sim_id}...")
-        sim.sim_time = sim.current_time
+        sim.stop()
 
     def get_simulation(self, sim_id: str) -> SimulationInterface:
         sim = self.simulations.get(sim_id)

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,56 @@
+import base64
+import time
+from werkzeug.security import generate_password_hash
+
+from Simulation.dpf_simulator_server import app, simulation_manager
+
+
+def _auth_headers():
+    token = base64.b64encode(b"admin:secret").decode("utf-8")
+    return {"Authorization": f"Basic {token}"}
+
+
+def _setup_app():
+    app.config['ADMIN_USERNAME'] = 'admin'
+    app.config['ADMIN_PASSWORD_HASH'] = generate_password_hash('secret')
+    app.config['MAX_SIMULTANEOUS_SIMULATIONS'] = 2
+    app.config['TELEMETRY_INTERVAL'] = 0.01
+
+
+def test_start_stop_and_retrieve_state():
+    _setup_app()
+    client = app.test_client()
+    config = {
+        'dx': 1.0,
+        'dy': 1.0,
+        'dz': 1.0,
+        'sim_time': 0.05,
+        'dt_init': 0.01,
+        'grid_shape': [1, 1, 1],
+        'domain_lo': [0.0, 0.0, 0.0],
+        'circuit': {
+            'C': 1.0,
+            'V0': 1.0,
+            'L0': 1.0,
+            'R0': 0.1,
+            'anode_radius': 0.01,
+            'cathode_radius': 0.02,
+        },
+    }
+    resp = client.post('/api/simulate', json=config, headers=_auth_headers())
+    assert resp.status_code == 202
+    sim_id = resp.get_json()['sim_id']
+
+    # Allow the simulation thread to start
+    time.sleep(0.05)
+    stop_resp = client.post(f'/api/stop/{sim_id}', headers=_auth_headers())
+    assert stop_resp.status_code == 204
+
+    # Ensure we can access state and diagnostics through the interface
+    sim = simulation_manager.get_simulation(sim_id)
+    sim.get_state()
+    sim.get_diagnostics()
+
+    # Join background thread to avoid leaking resources
+    thread = simulation_manager.get_simulation_thread(sim_id)
+    thread.join(timeout=1)


### PR DESCRIPTION
## Summary
- Wrap `DPFSimulation` in a new `SimulationInterface` providing thread-safe run/stop and state/diagnostic access
- Update `SimulationManager` to use the interface
- Add tests exercising start/stop endpoints and retrieval methods

## Testing
- `pytest tests/test_api_endpoints.py -q` *(fails: No module named 'werkzeug')*


------
https://chatgpt.com/codex/tasks/task_e_68a9edf57950832aa696cdec3a8f3e74