### PR TITLE
Add non-Maxwellian electron flux and improved sheath drop

### DIFF
--- a/Simulation/config_schema.py
+++ b/Simulation/config_schema.py
@@ -191,6 +191,15 @@ class SheathConfig(BaseModel):
     plasma_edge_potential: float = Field(0.0, description="Potential at the plasma edge")
     opacity_model: str = Field("constant", description="Model for opacity calculation")
     opacity_params: Dict[str, Any] = Field(default_factory=dict, description="Parameters for opacity model")
+    secondary_emission_coefficient: float = Field(0.0, description="Secondary electron emission coefficient")
+    electron_distribution: str = Field(
+        "maxwellian",
+        description="Electron distribution model ('maxwellian', 'analytic')",
+    )
+    electron_distribution_params: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Parameters for electron distribution function",
+    )
     # Add other parameters as needed
 
 class TurbulenceConfig(BaseModel):

--- a/Simulation/sheath_model.py
+++ b/Simulation/sheath_model.py
@@ -61,6 +61,9 @@ class PlasmaSheathFormation(PhysicsModule):
         self.bohm_velocity = 0.0
         self.checkpoint_data = {}
         self.plasma_edge_potential = config.plasma_edge_potential
+        self.secondary_emission_coefficient = config.secondary_emission_coefficient
+        self.electron_distribution = config.electron_distribution
+        self.electron_distribution_params = config.electron_distribution_params
 
         logger.info("PlasmaSheathFormation initialized.")
 
@@ -165,15 +168,26 @@ class PlasmaSheathFormation(PhysicsModule):
             return np.zeros_like(self.x_grid), np.zeros_like(self.x_grid)
 
     def _non_maxwellian_electron_flux(self):
-        """
-        Computes the electron flux to the surface using a more accurate approximation.
-        """
+        """Compute electron flux using a potentially non-Maxwellian distribution."""
         try:
-            # Example: Use a more accurate approximation based on the electron distribution function
-            # This is a placeholder; replace with a more sophisticated model
-            electron_velocity = np.sqrt(e_charge * self.electron_temperature / (m_e))
-            electron_flux = 0.5 * self.electron_density * electron_velocity * np.exp(-0.5)  # Example correction
-            return electron_flux
+            if self.electron_distribution == "analytic":
+                dist_fn = self.electron_distribution_params.get("distribution_fn")
+                if dist_fn is None:
+                    raise ValueError("distribution_fn must be provided for analytic distribution")
+                v_max = self.electron_distribution_params.get("v_max", 1e7)
+                num = self.electron_distribution_params.get("num_points", 1000)
+                v = np.linspace(0.0, v_max, num)
+                f = dist_fn(v)
+                # Normalize distribution to unity density
+                density_norm = np.trapz(4 * np.pi * v**2 * f, v)
+                if density_norm <= 0:
+                    return 0.0
+                flux = np.pi * np.trapz(v**3 * f, v)
+                return self.electron_density * flux / density_norm
+            else:
+                # Default Maxwellian result
+                v_th = np.sqrt(8 * e_charge * self.electron_temperature / (np.pi * m_e))
+                return 0.25 * self.electron_density * v_th
         except Exception as e:
             logger.error(f"Error computing non-Maxwellian electron flux: {e}")
             return 0.0
@@ -373,15 +387,16 @@ class PlasmaSheathFormation(PhysicsModule):
             logger.error(f"Error during restart: {e}")
 
     def analytic_sheath_drop(self):
-        """
-        Estimates the sheath potential drop using an analytical approximation.
-        (Simplified for now, needs refinement)
-        """
+        """Estimate the sheath potential drop using flux balance."""
         try:
-            # Simplified analytical estimate (needs improvement)
-            # This is just a placeholder and should be replaced with a more accurate formula
-            # (e.g., considering ion and electron temperatures, secondary emission, etc.)
-            sheath_drop = -2.5 * self.electron_temperature  # Rough estimate
+            Te = self.electron_temperature
+            Ti = self.ion_temperature
+            mi = self.ion_mass
+            delta = getattr(self, "secondary_emission_coefficient", 0.0)
+
+            c_s = np.sqrt(e_charge * (Te + Ti) / mi)
+            v_th = np.sqrt(8 * e_charge * Te / (np.pi * m_e))
+            sheath_drop = Te * np.log((1 - delta) * 4 * c_s / v_th)
             return sheath_drop
         except Exception as e:
             logger.error(f"Error computing analytical sheath drop: {e}")

--- a/tests/test_sheath_model.py
+++ b/tests/test_sheath_model.py
@@ -1,0 +1,50 @@
+import numpy as np
+from Simulation.sheath_model import PlasmaSheathFormation, e_charge, m_e
+from Simulation.config_schema import SheathConfig
+
+
+def maxwellian_distribution(v, Te):
+    return np.exp(-m_e * v**2 / (2 * e_charge * Te))
+
+
+def make_config(**kwargs):
+    base = dict(
+        ion_density=1e18,
+        electron_density=1e18,
+        sheath_voltage=0.0,
+        ion_temperature=0.0,
+        electron_temperature=10.0,
+        ion_mass=1.67e-27,
+        dx=1e-5,
+        max_sheath_thickness=1e-3,
+        num_grid_points=50,
+        plasma_edge_potential=0.0,
+    )
+    base.update(kwargs)
+    return SheathConfig(**base)
+
+
+def test_non_maxwellian_flux_matches_maxwellian():
+    cfg = make_config(
+        electron_distribution="analytic",
+        electron_distribution_params={
+            "distribution_fn": lambda v: maxwellian_distribution(v, 10.0),
+            "v_max": 5e7,
+            "num_points": 5000,
+        },
+    )
+    sheath = PlasmaSheathFormation(cfg)
+    flux = sheath.compute_electron_flux()
+    v_th = np.sqrt(8 * e_charge * cfg.electron_temperature / (np.pi * m_e))
+    expected = 0.25 * cfg.electron_density * v_th
+    assert np.isclose(flux, expected, rtol=1e-2)
+
+
+def test_analytic_sheath_drop_reduces_to_standard():
+    cfg = make_config(secondary_emission_coefficient=0.0)
+    sheath = PlasmaSheathFormation(cfg)
+    drop = sheath.analytic_sheath_drop()
+    c_s = np.sqrt(e_charge * (cfg.electron_temperature + cfg.ion_temperature) / cfg.ion_mass)
+    v_th = np.sqrt(8 * e_charge * cfg.electron_temperature / (np.pi * m_e))
+    expected = cfg.electron_temperature * np.log(4 * c_s / v_th)
+    assert np.isclose(drop, expected, rtol=1e-12)


### PR DESCRIPTION
## Summary
- support configurable electron distribution and secondary emission in sheath modeling
- compute electron flux using arbitrary distribution functions
- derive sheath potential drop from ion/electron temps and emission
- add tests for flux and sheath drop analytic limits

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pydantic -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68a9edf2f814832aa0043e79efce3b77