### PR TITLE
Add Thomson scattering spectrum diagnostics with HDF5 export

### DIFF
--- a/Simulation/diagnostics.py
+++ b/Simulation/diagnostics.py
@@ -3,10 +3,13 @@ import h5py
 import json
 import logging
 import time
-from scipy.constants import c, m_n, m_e, mu_0, e
+from scipy.constants import c, m_n, m_e, mu_0, e, epsilon_0, k as k_B
 from scipy.interpolate import interp1d
 from pyevtk.hl import imageToVTK
-from utils import FieldManager, SimulationState # Import FieldManager and SimulationState
+from utils import FieldManager, SimulationState  # Import FieldManager and SimulationState
+
+# Classical electron radius (m)
+r_e = e ** 2 / (4 * np.pi * epsilon_0 * m_e * c ** 2)
 
 logger = logging.getLogger(__name__)
 
@@ -154,19 +157,64 @@ class ThomsonScattering(Diagnostic):
         self.scattering_angle = scattering_angle
         self.position = np.array(position)
         self.data = []
+        # Precompute geometry factor for differential cross-section
+        self._geom_factor = (1 + np.cos(self.scattering_angle) ** 2) / 2
+        # Spectral grid will be created on first record
+        self._wavelength_grid = None
 
     def record(self, t, circuit, fluid, pic=None, radiation=None, state: SimulationState = None):
-        # Placeholder for Thomson scattering calculation
-        # This would involve calculating the scattered power spectrum
-        # based on electron density and temperature at the specified position.
-        # This is a complex calculation and is left as a placeholder here.
-        # You would need to implement the full Thomson scattering theory here.
-        self.data.append({'time': t, 'signal': 0.0})
+        """Calculate a simplified Thomson scattering spectrum.
+
+        The spectrum is approximated as a Gaussian profile whose width is
+        determined by the electron temperature (thermal broadening) and whose
+        amplitude scales with the local electron density and scattering
+        geometry.
+        """
+
+        if state is None:
+            return
+
+        # Extract local electron density and temperature
+        ne_grid = getattr(state, "electron_density", None)
+        if ne_grid is None:
+            ne_grid = getattr(state, "ion_density", state.density)
+        Te_grid = getattr(state, "electron_temperature", None)
+
+        dx, dy, dz = state.dx, state.dy, state.dz
+        x0, y0, z0 = state.domain_lo
+        xi = int((self.position[0] - x0) / dx)
+        yi = int((self.position[1] - y0) / dy)
+        zi = int((self.position[2] - z0) / dz)
+        ne = float(ne_grid[xi, yi, zi])
+        Te = float(Te_grid[xi, yi, zi]) if Te_grid is not None else 0.0
+
+        # Thermal broadening of wavelength
+        delta_lambda = self.laser_wavelength * np.sqrt(2 * k_B * max(Te, 1e-6) / m_e) / c
+        if self._wavelength_grid is None:
+            self._wavelength_grid = np.linspace(
+                self.laser_wavelength - 5 * delta_lambda,
+                self.laser_wavelength + 5 * delta_lambda,
+                100,
+            )
+        wl = self._wavelength_grid
+        width = delta_lambda if delta_lambda > 0 else self.laser_wavelength * 1e-9
+        spectrum = (
+            ne
+            * r_e ** 2
+            * self._geom_factor
+            * np.exp(-0.5 * ((wl - self.laser_wavelength) / width) ** 2)
+        )
+
+        self.data.append({"time": t, "wavelength": wl, "spectrum": spectrum})
 
     def to_hdf5(self, hdf5_group):
         grp = hdf5_group.create_group(self.name)
-        grp.create_dataset('time', data=[d['time'] for d in self.data])
-        grp.create_dataset('signal', data=[d['signal'] for d in self.data])
+        times = [d["time"] for d in self.data]
+        grp.create_dataset("time", data=times)
+        if self.data:
+            grp.create_dataset("wavelength", data=self.data[0]["wavelength"])
+            spectra = np.array([d["spectrum"] for d in self.data])
+            grp.create_dataset("spectrum", data=spectra)
 
 # --- Main Diagnostics Class ---
 class Diagnostics:

--- a/tests/test_thomson_scattering.py
+++ b/tests/test_thomson_scattering.py
@@ -1,0 +1,66 @@
+import numpy as np
+import h5py
+from pathlib import Path
+import importlib.util
+import sys
+
+SIM_DIR = Path(__file__).resolve().parents[1] / "Simulation"
+sys.path.insert(0, str(SIM_DIR))
+
+# Dynamically load modules from the Simulation directory to avoid conflicts
+diag_spec = importlib.util.spec_from_file_location("sim_diag", SIM_DIR / "diagnostics.py")
+diag_module = importlib.util.module_from_spec(diag_spec)
+diag_spec.loader.exec_module(diag_module)
+
+utils_spec = importlib.util.spec_from_file_location("sim_utils", SIM_DIR / "utils.py")
+utils_module = importlib.util.module_from_spec(utils_spec)
+utils_spec.loader.exec_module(utils_module)
+
+ThomsonScattering = diag_module.ThomsonScattering
+FieldManager = utils_module.FieldManager
+SimulationState = utils_module.SimulationState
+
+
+def make_state(ne, Te):
+    """Create a minimal SimulationState with uniform fields."""
+    grid_shape = (1, 1, 1)
+    dx = dy = dz = 1.0
+    domain_lo = (0.0, 0.0, 0.0)
+    fm = FieldManager(grid_shape, dx, dy, dz, domain_lo, {})
+    state = SimulationState(
+        grid_shape,
+        dx,
+        dy,
+        dz,
+        domain_lo,
+        {},
+        electron_density=np.full(grid_shape, ne),
+        electron_temperature=np.full(grid_shape, Te),
+    )
+    return fm, state
+
+
+def test_thomson_scattering_spectrum(tmp_path):
+    fm, state = make_state(1e20, 1e5)
+    diag = ThomsonScattering(
+        "TS",
+        laser_wavelength=532e-9,
+        scattering_angle=np.pi / 2,
+        position=(0.5, 0.5, 0.5),
+        field_manager=fm,
+    )
+
+    diag.record(0.0, None, None, state=state)
+
+    assert diag.data, "No diagnostic data recorded"
+    entry = diag.data[0]
+    assert entry["wavelength"].shape == entry["spectrum"].shape
+    assert np.all(entry["spectrum"] >= 0)
+
+    with h5py.File(tmp_path / "out.h5", "w") as h5:
+        diag.to_hdf5(h5)
+        grp = h5["TS"]
+        assert "wavelength" in grp
+        assert "spectrum" in grp
+        spec = grp["spectrum"][:]
+        assert spec.shape[0] == 1


### PR DESCRIPTION
## Summary
- compute Thomson scattering spectra from local electron density/temperature and geometry
- persist wavelength grids and spectra in diagnostic data and HDF5 output
- add unit test for scattering spectrum export

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9edf03d90832a8426fc370d104090