### PR TITLE
Implement Yee-style derivatives and add analytic field tests

### DIFF
--- a/Simulation/utils.py
+++ b/Simulation/utils.py
@@ -64,23 +64,91 @@ class FieldManager:
         """Returns the current density."""
         return self.J
 
+    # ------------------------------------------------------------------
+    # Finite-difference utilities
+    # ------------------------------------------------------------------
+    def _yee_derivative(self,
+                        f: np.ndarray,
+                        axis: int,
+                        h: float,
+                        bc_lo: str,
+                        bc_hi: str) -> np.ndarray:
+        """Compute a Yee-style derivative along a given axis.
+
+        A central difference is used in the interior while the
+        boundaries honour the specified boundary conditions.
+
+        Args:
+            f: Field component to differentiate.
+            axis: Axis along which to take the derivative.
+            h: Grid spacing for the axis.
+            bc_lo: Boundary condition on the low side ('periodic',
+                'neumann', 'dirichlet', or 'outflow').
+            bc_hi: Boundary condition on the high side.
+
+        Returns:
+            Array of the same shape as ``f`` containing df/dx_axis.
+        """
+
+        # Start with periodic central differences using ``np.roll``
+        df = (np.roll(f, -1, axis=axis) - np.roll(f, 1, axis=axis)) / (2 * h)
+
+        # Helper to index first/last cell along ``axis``
+        def slc(idx):
+            s = [slice(None)] * f.ndim
+            s[axis] = idx
+            return tuple(s)
+
+        # Low-side boundary
+        if bc_lo == 'dirichlet':
+            df[slc(0)] = (f[slc(1)] - 0.0) / h
+        elif bc_lo in {'neumann', 'outflow'}:
+            df[slc(0)] = (f[slc(1)] - f[slc(0)]) / h
+
+        # High-side boundary
+        if bc_hi == 'dirichlet':
+            df[slc(-1)] = (0.0 - f[slc(-2)]) / h
+        elif bc_hi in {'neumann', 'outflow'}:
+            df[slc(-1)] = (f[slc(-1)] - f[slc(-2)]) / h
+
+        return df
+
     def compute_divergence(self, field: np.ndarray) -> np.ndarray:
-        """Computes the divergence of a field."""
-        # Implement divergence calculation here
-        # This is a placeholder; replace with a more accurate calculation
-        div = np.gradient(field[0], self.dx, axis=0) + \
-              np.gradient(field[1], self.dy, axis=1) + \
-              np.gradient(field[2], self.dz, axis=2)
-        return div
+        """Computes the divergence of a field using Yee-style differences."""
+        bx_lo = self.boundary_conditions.get('x_lo', 'periodic')
+        bx_hi = self.boundary_conditions.get('x_hi', 'periodic')
+        by_lo = self.boundary_conditions.get('y_lo', 'periodic')
+        by_hi = self.boundary_conditions.get('y_hi', 'periodic')
+        bz_lo = self.boundary_conditions.get('z_lo', 'periodic')
+        bz_hi = self.boundary_conditions.get('z_hi', 'periodic')
+
+        div_x = self._yee_derivative(field[0], 0, self.dx, bx_lo, bx_hi)
+        div_y = self._yee_derivative(field[1], 1, self.dy, by_lo, by_hi)
+        div_z = self._yee_derivative(field[2], 2, self.dz, bz_lo, bz_hi)
+
+        return div_x + div_y + div_z
 
     def compute_curl(self, field: np.ndarray) -> np.ndarray:
-        """Computes the curl of a field."""
-        # Implement curl calculation here
-        # This is a placeholder; replace with a more accurate calculation
-        curl = np.array([np.gradient(field[2], self.dy, axis=1) - np.gradient(field[1], self.dz, axis=2),
-                         np.gradient(field[0], self.dz, axis=2) - np.gradient(field[2], self.dx, axis=0),
-                         np.gradient(field[1], self.dx, axis=0) - np.gradient(field[0], self.dy, axis=1)])
-        return curl
+        """Computes the curl of a field using Yee-style differences."""
+        bx_lo = self.boundary_conditions.get('x_lo', 'periodic')
+        bx_hi = self.boundary_conditions.get('x_hi', 'periodic')
+        by_lo = self.boundary_conditions.get('y_lo', 'periodic')
+        by_hi = self.boundary_conditions.get('y_hi', 'periodic')
+        bz_lo = self.boundary_conditions.get('z_lo', 'periodic')
+        bz_hi = self.boundary_conditions.get('z_hi', 'periodic')
+
+        dFz_dy = self._yee_derivative(field[2], 1, self.dy, by_lo, by_hi)
+        dFy_dz = self._yee_derivative(field[1], 2, self.dz, bz_lo, bz_hi)
+        dFx_dz = self._yee_derivative(field[0], 2, self.dz, bz_lo, bz_hi)
+        dFz_dx = self._yee_derivative(field[2], 0, self.dx, bx_lo, bx_hi)
+        dFy_dx = self._yee_derivative(field[1], 0, self.dx, bx_lo, bx_hi)
+        dFx_dy = self._yee_derivative(field[0], 1, self.dy, by_lo, by_hi)
+
+        curl_x = dFz_dy - dFy_dz
+        curl_y = dFx_dz - dFz_dx
+        curl_z = dFy_dx - dFx_dy
+
+        return np.array([curl_x, curl_y, curl_z])
 
     def apply_boundary_conditions(self, state: "SimulationState"):
         """Applies boundary conditions to the fields."""

--- a/tests/test_field_derivatives.py
+++ b/tests/test_field_derivatives.py
@@ -1,0 +1,55 @@
+import numpy as np
+from Simulation.utils import FieldManager
+
+
+def test_divergence_and_curl_periodic():
+    nx = ny = nz = 16
+    L = 2 * np.pi
+    dx = dy = dz = L / nx
+    boundaries = {f"{ax}_{side}": "periodic" for ax in ['x', 'y', 'z'] for side in ['lo', 'hi']}
+    fm = FieldManager((nx, ny, nz), dx, dy, dz, (0.0, 0.0, 0.0), boundaries)
+    x = np.linspace(0, L, nx, endpoint=False)
+    y = np.linspace(0, L, ny, endpoint=False)
+    z = np.linspace(0, L, nz, endpoint=False)
+    X, Y, Z = np.meshgrid(x, y, z, indexing='ij')
+
+    field_div = np.zeros((3, nx, ny, nz))
+    field_div[0] = np.sin(X)
+    field_div[1] = np.sin(Y)
+    field_div[2] = np.sin(Z)
+    div_numeric = fm.compute_divergence(field_div)
+    div_analytic = np.cos(X) + np.cos(Y) + np.cos(Z)
+    assert np.allclose(div_numeric, div_analytic, atol=1e-1)
+
+    field_curl = np.zeros((3, nx, ny, nz))
+    field_curl[0] = np.sin(Y)
+    field_curl[1] = np.sin(Z)
+    field_curl[2] = np.sin(X)
+    curl_numeric = fm.compute_curl(field_curl)
+    curl_analytic = np.array([
+        -np.cos(Z),
+        -np.cos(X),
+        -np.cos(Y),
+    ])
+    assert np.allclose(curl_numeric, curl_analytic, atol=1e-1)
+
+
+def test_dirichlet_boundary_handling():
+    nx, ny, nz = 16, 4, 4
+    L = 1.0
+    dx = L / (nx - 1)
+    dy = dz = 1.0
+    boundaries = {
+        'x_lo': 'dirichlet', 'x_hi': 'dirichlet',
+        'y_lo': 'periodic', 'y_hi': 'periodic',
+        'z_lo': 'periodic', 'z_hi': 'periodic'
+    }
+    fm = FieldManager((nx, ny, nz), dx, dy, dz, (0.0, 0.0, 0.0), boundaries)
+    x = np.linspace(0, L, nx)
+    X = x[:, None, None]
+
+    field = np.zeros((3, nx, ny, nz))
+    field[0] = np.sin(np.pi * X / L)
+    div_numeric = fm.compute_divergence(field)
+    div_analytic = (np.pi / L) * np.cos(np.pi * X / L)
+    assert np.allclose(div_numeric, div_analytic, atol=1e-1)


### PR DESCRIPTION
## Summary
- Replace `np.gradient` with Yee-style derivative helper supporting boundary conditions
- Use new derivatives to compute divergence and curl
- Add tests comparing numeric divergence/curl to analytic fields and checking Dirichlet BCs

## Testing
- `venv/bin/python -m pytest tests/test_field_derivatives.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9edee4b8c832abc64ae45e076c20a