### PR TITLE
Use raw docstring for plasma inductance

### DIFF
--- a/Simulation/circuit.py
+++ b/Simulation/circuit.py
@@ -281,7 +281,7 @@ class CircuitModel:
         logger.info("CircuitModel initialized.")
 
     def plasma_inductance(self, state: SimulationState) -> float:
-        """Compute the inductance of the plasma column.
+        r"""Compute the inductance of the plasma column.
 
         The model assumes a perfectly conducting, cylindrically symmetric plasma
         sheath propagating axially between coaxial electrodes of radii ``self.a``


### PR DESCRIPTION
## Summary
- Prefix plasma_inductance docstring with `r` to treat backslashes literally and avoid SyntaxWarnings

## Testing
- `python -Wall -m py_compile Simulation/circuit.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68a9f623423c832a9fbf9e745407efdf