### PR TITLE
Wrap conditional config unpacks in Diagnostics

### DIFF
--- a/Simulation/dpf_simulator_amrex_backend.py
+++ b/Simulation/dpf_simulator_amrex_backend.py
@@ -104,8 +104,8 @@ class DPFSimulatorAMReXBackend(DPFSimulatorBackend):
         # Instantiate diagnostics
         self.diagnostics = Diagnostics(
             hdf5_filename=config['diagnostics_params']['hdf5_filename'],
-            config={**config['circuit_params'], **config['collision_params'] if config.get('collision_params') else {},
-                    **config['radiation_params'] if config.get('radiation_params') else {}, **config['pic_params'] if config.get('pic_params') else {}, **config['hybrid_params'] if config.get('hybrid_params') else {}},
+            config={**config['circuit_params'], **(config['collision_params'] if config.get('collision_params') else {}),
+                    **(config['radiation_params'] if config.get('radiation_params') else {}), **(config['pic_params'] if config.get('pic_params') else {}), **(config['hybrid_params'] if config.get('hybrid_params') else {})},
             domain_lo=self.domain_lo,
             grid_shape=self.grid_shape,
             dx=self.dx,


### PR DESCRIPTION
## Summary
- Wrap optional config dictionary unpacking in `Simulation/dpf_simulator_amrex_backend.py` so each conditional expansion is enclosed in parentheses

## Testing
- `pytest tests/test_advanced_options.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f61e5768832a9d3b03e703333c50