### PR TITLE
Add AMReX grid management and openPMD diagnostics

### DIFF
--- a/Simulation/dpf_simulator_amrex_backend.py
+++ b/Simulation/dpf_simulator_amrex_backend.py
@@ -3,6 +3,12 @@ import adios2
 import resource
 import logging
 import time
+import argparse
+import json
+try:  # pragma: no cover - optional MPI
+    from mpi4py import MPI  # type: ignore
+except Exception:  # pragma: no cover
+    MPI = None
 from catalyst import CatalystPipeline
 from dpf_simulator_full_backend import DPFSimulatorBackend
 from fluid_solver_high_order import FluidSolver3DAMReX
@@ -13,14 +19,50 @@ from circuit import CircuitModel
 from diagnostics import Diagnostics, mu0
 from sheath_model import PlasmaSheathFormation
 from load_balance_metrics import LoadBalanceMetrics
+from openpmd_io import OpenPMDWriter
 from utils import FieldManager, SimulationState  # Import FieldManager and SimulationState
 
 logger = logging.getLogger(__name__)
+
+
+class AMReXGridManager:
+    """Minimal grid manager emulating AMReX refinement"""
+
+    def __init__(self, grid_shape, max_level=1, criteria=None):
+        self.grid_shape = tuple(grid_shape)
+        self.max_level = max_level
+        self.criteria = criteria or {}
+        self.levels = [np.zeros(self.grid_shape)]
+
+    def refine(self, density):
+        thr = self.criteria.get("density")
+        if thr is None:
+            return
+        if np.any(density > thr) and len(self.levels) < self.max_level:
+            new_shape = tuple(s * 2 for s in self.grid_shape)
+            self.levels.append(np.zeros(new_shape))
+
+    def num_levels(self):
+        return len(self.levels)
+
 
 class DPFSimulatorAMReXBackend(DPFSimulatorBackend):
     def __init__(self, config: dict, field_manager: FieldManager): # Add field_manager
         super().__init__(config)
         io_cfg = config.get('io', {})
+        self.refinement_criteria = config.get('refinement_criteria', {})
+        self.grid_manager = AMReXGridManager(
+            config.get('grid_shape', (1, 1, 1)),
+            config.get('amr_levels', 1),
+            self.refinement_criteria,
+        )
+
+        # MPI and GPU configuration
+        self.comm = MPI.COMM_WORLD if MPI else None
+        self.rank = self.comm.Get_rank() if self.comm else 0
+        self.nprocs = self.comm.Get_size() if self.comm else 1
+        self.use_gpu = config.get('performance', {}).get('use_gpu', False)
+        self._decompose_domain()
 
         # Telemetry variables (now configurable)
         self.telemetry_vars = config.get('telemetry', {}).get('variables', [
@@ -44,6 +86,15 @@ class DPFSimulatorAMReXBackend(DPFSimulatorBackend):
         self.fine_plotfile_variables = io_cfg.get('fine_plotfile_variables', ['rho', 'B', 'mom', 'energy'])
         self.next_coarse = self.coarse_interval
         self.next_highres = self.highres_interval
+
+        # openPMD output control
+        self.openpmd_interval = io_cfg.get('openpmd_interval', 0)
+        self.next_openpmd = self.openpmd_interval
+        self.openpmd_writer = (
+            OpenPMDWriter(io_cfg.get('openpmd_filename', 'openpmd.h5'))
+            if self.openpmd_interval
+            else None
+        )
 
         # ADIOS2 for telemetry
         self.adios = adios2.ADIOS()
@@ -87,6 +138,8 @@ class DPFSimulatorAMReXBackend(DPFSimulatorBackend):
         self.load_balance_metrics = None
         if config.get('enable_load_balance_metrics', False):
             self.load_balance_metrics = LoadBalanceMetrics(self.fluid_solver)
+            if self.comm:
+                self.load_balance_metrics.set_mpi_comm(self.comm)
 
         # Instantiate hybrid controller
         if self.mode=='hybrid':
@@ -113,6 +166,16 @@ class DPFSimulatorAMReXBackend(DPFSimulatorBackend):
             field_manager=self.field_manager # Pass FieldManager to Diagnostics
         )
         self.provenance = config.get('provenance', {})
+
+    def _decompose_domain(self):
+        if self.comm:
+            nx = self.grid_shape[0]
+            chunk = max(1, nx // self.nprocs)
+            start = self.rank * chunk
+            end = nx if self.rank == self.nprocs - 1 else (self.rank + 1) * chunk
+            self.subdomain = (slice(start, end), slice(None), slice(None))
+        else:
+            self.subdomain = (slice(None), slice(None), slice(None))
 
     def run(self):
         self.t = getattr(self, 'time', 0.0)
@@ -141,6 +204,7 @@ class DPFSimulatorAMReXBackend(DPFSimulatorBackend):
             else:
                 while self.t < self.sim_time:
                     dt = self.compute_global_dt()
+                    self.grid_manager.refine(self.state.density)
                     # Circuit half-step
                     if self.mode=='fluid':
                         Lp, Rp = self.fluid_solver.compute_plasma_LR()
@@ -200,11 +264,11 @@ class DPFSimulatorAMReXBackend(DPFSimulatorBackend):
             # neutron yield
             tel['cumulative_neutron_count'] = sum(self.diagnostics.get_latest()['histogram']) if self.diagnostics.get_latest() and 'histogram' in self.diagnostics.get_latest() else 0
             # AMR & dt
-            tel['amr_levels'] = self.fluid_solver.num_levels()
+            tel['amr_levels'] = self.grid_manager.num_levels()
             tel['dt'] = dt or self.dt_base
             # load balance metrics
             if self.load_balance_metrics:
-                lb = self.load_balance_metrics.get_metrics()
+                lb = self.load_balance_metrics.update()
                 tel['cell_balance_min'] = lb['cell_min']
                 tel['cell_balance_max'] = lb['cell_max']
                 if hasattr(self, 'pic_solver'):
@@ -224,6 +288,18 @@ class DPFSimulatorAMReXBackend(DPFSimulatorBackend):
 
             # In-situ Catalyst
             self.catalyst.execute(self.fluid_solver, getattr(self,'pic_solver',None))
+
+            # openPMD output
+            if self.openpmd_writer and self.t >= self.next_openpmd:
+                fields = {'E': self.field_manager.get_E(), 'B': self.field_manager.get_B()}
+                particles = {}
+                if self.mode!='fluid' and hasattr(self.pic_solver, 'get_particle_data'):
+                    particles = self.pic_solver.get_particle_data()
+                step = int(self.t / (dt or self.dt_base))
+                self.openpmd_writer.write_fields(step, fields)
+                if particles:
+                    self.openpmd_writer.write_particles(step, particles)
+                self.next_openpmd += self.openpmd_interval
 
             # Hierarchical outputs
             if self.t >= self.next_coarse:
@@ -247,6 +323,8 @@ class DPFSimulatorAMReXBackend(DPFSimulatorBackend):
 
     def _finalize(self):
         self.bp_engine.Close()
+        if self.openpmd_writer:
+            self.openpmd_writer.close()
         self.diagnostics.to_hdf5()
         logger.info(f"[AMReX Backend] Simulation complete at t={self.t:.3e}")
 
@@ -257,3 +335,38 @@ class DPFSimulatorAMReXBackend(DPFSimulatorBackend):
         state = super().get_state()
         state['provenance'] = self.provenance
         return state
+
+
+def _parse_cli(args=None):
+    parser = argparse.ArgumentParser(description="DPF AMReX backend")
+    parser.add_argument("config", help="Simulation configuration JSON file")
+    parser.add_argument(
+        "--diag-frequency",
+        type=int,
+        dest="diag_frequency",
+        default=None,
+        help="openPMD diagnostic frequency",
+    )
+    return parser.parse_args(args=args)
+
+
+def main():
+    args = _parse_cli()
+    with open(args.config) as f:
+        cfg = json.load(f)
+    if args.diag_frequency is not None:
+        cfg.setdefault('io', {})['openpmd_interval'] = args.diag_frequency
+    fm = FieldManager(
+        tuple(cfg['grid_shape']),
+        cfg.get('dx', 1.0),
+        cfg.get('dy', cfg.get('dx', 1.0)),
+        cfg.get('dz', cfg.get('dx', 1.0)),
+        tuple(cfg.get('domain_lo', (0.0, 0.0, 0.0))),
+        cfg.get('boundary_conditions', {}),
+    )
+    sim = DPFSimulatorAMReXBackend(cfg, fm)
+    sim.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/Simulation/load_balance_metrics.py
+++ b/Simulation/load_balance_metrics.py
@@ -1,0 +1,55 @@
+import numpy as np
+try:
+    from mpi4py import MPI  # type: ignore
+except Exception:  # pragma: no cover - mpi4py optional
+    MPI = None
+
+
+class LoadBalanceMetrics:
+    """Compute simple cell and particle balance metrics across MPI ranks."""
+
+    def __init__(self, solver):
+        self.solver = solver
+        self.comm = MPI.COMM_WORLD if MPI else None
+        self.last = {}
+
+    def set_mpi_comm(self, comm):
+        """Allow external injection of an MPI communicator."""
+        self.comm = comm
+
+    def _gather(self, value):
+        if self.comm:
+            return self.comm.allgather(value)
+        return [value]
+
+    def _get_cell_counts(self):
+        if hasattr(self.solver, "get_cell_count"):
+            local = self.solver.get_cell_count()
+        else:
+            local = 0
+        return self._gather(local)
+
+    def _get_particle_counts(self):
+        if hasattr(self.solver, "get_particle_count"):
+            local = self.solver.get_particle_count()
+        else:
+            local = 0
+        return self._gather(local)
+
+    def update(self):
+        """Update cached metrics for the current iteration."""
+        cells = self._get_cell_counts()
+        parts = self._get_particle_counts()
+        self.last = {
+            "cell_min": int(np.min(cells)) if cells else 0,
+            "cell_max": int(np.max(cells)) if cells else 0,
+            "particle_min": int(np.min(parts)) if parts else 0,
+            "particle_max": int(np.max(parts)) if parts else 0,
+        }
+        return self.last
+
+    def get_metrics(self):
+        """Return the most recently computed metrics."""
+        if not self.last:
+            return self.update()
+        return self.last

--- a/Simulation/openpmd_io.py
+++ b/Simulation/openpmd_io.py
@@ -1,0 +1,41 @@
+import h5py
+import numpy as np
+from typing import Dict, Any
+
+
+class OpenPMDWriter:
+    """Minimal openPMD-compliant writer for field and particle data."""
+
+    def __init__(self, filename: str):
+        self.filename = str(filename)
+        self._file = h5py.File(self.filename, "w")
+        self._file.attrs.update(
+            {
+                "openPMD": "1.1.0",
+                "basePath": "/data/%T/",
+                "iterationEncoding": "groupBased",
+                "iterationFormat": "%T",
+                "software": "dpf-simulator",
+            }
+        )
+
+    def write_fields(self, iteration: int, fields: Dict[str, np.ndarray]):
+        grp = self._file.require_group(f"data/{iteration}")
+        for name, arr in fields.items():
+            ds = grp.create_dataset(name, data=np.asarray(arr))
+            ds.attrs["unitSI"] = 1.0
+        self._file.flush()
+
+    def write_particles(self, iteration: int, particles: Dict[str, Dict[str, Any]]):
+        grp = self._file.require_group(f"data/{iteration}/particles")
+        for species, comps in particles.items():
+            sgrp = grp.require_group(species)
+            for comp, arr in comps.items():
+                ds = sgrp.create_dataset(comp, data=np.asarray(arr))
+                ds.attrs["unitSI"] = 1.0
+        self._file.flush()
+
+    def close(self):
+        if self._file:
+            self._file.close()
+            self._file = None

--- a/docs/scaling_results.md
+++ b/docs/scaling_results.md
@@ -1,0 +1,14 @@
+# Scalability Studies
+
+Synthetic scripts in `scripts/scaling_tests.py` provide helper functions to
+estimate ideal weak and strong scaling.  Generated data can be written to a
+markdown report using `document_results`.
+
+Example:
+
+```python
+from scripts.scaling_tests import weak_scaling, strong_scaling, document_results
+weak = weak_scaling([1, 2, 4])
+strong = strong_scaling([1, 2, 4])
+document_results("scaling_report.md", weak, strong)
+```

--- a/scripts/scaling_tests.py
+++ b/scripts/scaling_tests.py
@@ -1,0 +1,31 @@
+"""Utility functions to generate synthetic scaling data.
+
+These routines mimic weak and strong scaling studies and can be used to
+produce documentation figures.  They do not run the full simulation but
+serve as placeholders for HPC environments.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Dict
+
+
+def weak_scaling(sizes: Iterable[int]) -> Dict[int, float]:
+    """Return ideal weak scaling times for given problem sizes."""
+    return {n: 1.0 for n in sizes}
+
+
+def strong_scaling(sizes: Iterable[int]) -> Dict[int, float]:
+    """Return ideal strong scaling times for given core counts."""
+    return {n: 1.0 / n for n in sizes}
+
+
+def document_results(path, weak: Dict[int, float], strong: Dict[int, float]):
+    """Write scaling results to a simple markdown file."""
+    with open(path, "w") as f:
+        f.write("# Scaling Results\n\n")
+        f.write("## Weak Scaling\n")
+        for n, t in weak.items():
+            f.write(f"- size {n}: {t:.2f} s\n")
+        f.write("\n## Strong Scaling\n")
+        for n, t in strong.items():
+            f.write(f"- {n} cores: {t:.2f} s\n")

--- a/tests/test_cli_diag_frequency.py
+++ b/tests/test_cli_diag_frequency.py
@@ -1,0 +1,7 @@
+from Simulation.dpf_simulator_amrex_backend import _parse_cli
+
+
+def test_parse_cli():
+    args = _parse_cli(["config.json", "--diag-frequency", "7"])
+    assert args.diag_frequency == 7
+    assert args.config == "config.json"

--- a/tests/test_load_balance_metrics.py
+++ b/tests/test_load_balance_metrics.py
@@ -1,0 +1,18 @@
+from Simulation.load_balance_metrics import LoadBalanceMetrics
+
+
+class DummySolver:
+    def get_cell_count(self):
+        return 100
+
+    def get_particle_count(self):
+        return 50
+
+
+def test_metrics_basic():
+    lb = LoadBalanceMetrics(DummySolver())
+    metrics = lb.get_metrics()
+    assert metrics["cell_min"] == 100
+    assert metrics["cell_max"] == 100
+    assert metrics["particle_min"] == 50
+    assert metrics["particle_max"] == 50

--- a/tests/test_openpmd_io.py
+++ b/tests/test_openpmd_io.py
@@ -1,0 +1,17 @@
+import h5py
+import numpy as np
+from Simulation.openpmd_io import OpenPMDWriter
+
+
+def test_openpmd_writer(tmp_path):
+    path = tmp_path / "out.h5"
+    writer = OpenPMDWriter(path)
+    fields = {"E": np.zeros((3, 2, 2, 2)), "B": np.ones((3, 2, 2, 2))}
+    writer.write_fields(0, fields)
+    particles = {"e": {"x": np.array([0.0, 1.0])}}
+    writer.write_particles(0, particles)
+    writer.close()
+    with h5py.File(path, "r") as f:
+        assert f.attrs["openPMD"] == "1.1.0"
+        assert "data/0/E" in f
+        assert "particles" in f["data/0"]

--- a/tests/test_scaling_tests.py
+++ b/tests/test_scaling_tests.py
@@ -1,0 +1,9 @@
+from scripts.scaling_tests import weak_scaling, strong_scaling, document_results
+
+def test_scaling_functions(tmp_path):
+    weak = weak_scaling([1, 2, 4])
+    strong = strong_scaling([1, 2, 4])
+    assert weak[1] == 1.0 and strong[4] == 0.25
+    report = tmp_path / "report.md"
+    document_results(report, weak, strong)
+    assert report.exists()


### PR DESCRIPTION
## Summary
- add minimal AMReX grid manager with MPI/GPU hooks in `dpf_simulator_amrex_backend`
- provide openPMD writer and CLI control for diagnostic frequency
- introduce load balancing metrics and scalability utilities

## Testing
- `pytest tests/test_load_balance_metrics.py tests/test_openpmd_io.py` *(failed: ModuleNotFoundError: No module named 'numpy')*
- `pytest tests/test_scaling_tests.py tests/test_cli_diag_frequency.py` *(failed: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68aa21748318832aaf4ae5eb12ba6acb