### PR TITLE
Add MHDPinchModel and integrate with engine

### DIFF
--- a/dpf2/cli.py
+++ b/dpf2/cli.py
@@ -20,7 +20,7 @@ def build_parser() -> argparse.ArgumentParser:
     sim.add_argument("--method", choices=["analytical", "ode"], default="analytical", help="Circuit solver method")
     sim.add_argument(
         "--pinch-model",
-        choices=["analytic", "semi-analytic"],
+        choices=["analytic", "semi-analytic", "mhd"],
         default="analytic",
         help="Pinch dynamics model",
     )

--- a/dpf2/pinch_models.py
+++ b/dpf2/pinch_models.py
@@ -8,8 +8,15 @@ from scipy.integrate import solve_ivp
 
 from .eos import RealGasEOS
 from .fusion import bosch_hale_dd
+from .hall_mhd_solver import HallMHDSolver, MHDState
 
-__all__ = ["PinchModelBase", "PinchResult", "AnalyticPinchModel", "SemiAnalyticPinchModel"]
+__all__ = [
+    "PinchModelBase",
+    "PinchResult",
+    "AnalyticPinchModel",
+    "SemiAnalyticPinchModel",
+    "MHDPinchModel",
+]
 
 
 @dataclass
@@ -20,6 +27,7 @@ class PinchResult:
     pressure: np.ndarray
     neutron_yield: float
     axial_position: np.ndarray | None = None
+    energy: np.ndarray | None = None
 
 
 class PinchModelBase:
@@ -93,4 +101,88 @@ class SemiAnalyticPinchModel(PinchModelBase):
         rate = 0.25 * n_i ** 2 * reactivity * volume
         neutron_yield = float(np.trapz(rate, t))
         return PinchResult(t, r, temperature, pressure, neutron_yield, axial_position=z)
+
+
+class MHDPinchModel(PinchModelBase):
+    """Pinch model driven by the simplified Hall-MHD solver."""
+
+    def __init__(
+        self,
+        grid_shape: tuple[int, int, int] = (8, 8, 8),
+        init_density: float = 1.0,
+        init_pressure: float = 1e5,
+        current_norm: float = 1e4,
+    ) -> None:
+        self.grid_shape = grid_shape
+        self.init_density = init_density
+        self.init_pressure = init_pressure
+        self.current_norm = current_norm
+        nx, ny, nz = grid_shape
+        x = np.arange(nx) - nx / 2
+        y = np.arange(ny) - ny / 2
+        z = np.arange(nz) - nz / 2
+        X, Y, _ = np.meshgrid(x, y, z, indexing="ij")
+        self.r2 = X**2 + Y**2
+        self.volume = float(nx * ny * nz)
+
+    def run(self, time: Iterable[float], current: Iterable[float]) -> PinchResult:
+        t = np.asarray(time)
+        I = np.asarray(current)
+        gamma = 5.0 / 3.0
+        solver = HallMHDSolver()
+
+        rho = np.full(self.grid_shape, self.init_density)
+        mom = np.zeros(self.grid_shape + (3,))
+        B_pattern = np.zeros(self.grid_shape + (3,))
+        B_pattern[..., 2] = 1.0
+        B = B_pattern * (I[0] / self.current_norm)
+        p0 = np.full(self.grid_shape, self.init_pressure)
+        internal = p0 / (gamma - 1.0)
+        energy = internal + 0.5 * np.sum(B**2, axis=-1)
+        state = MHDState(rho=rho, mom=mom, energy=energy, B=B)
+
+        def diagnostics(s: MHDState) -> tuple[float, float, float, float]:
+            v = s.mom / s.rho[..., None]
+            kinetic = 0.5 * s.rho * np.sum(v**2, axis=-1)
+            magnetic = 0.5 * np.sum(s.B**2, axis=-1)
+            internal = s.energy - kinetic - magnetic
+            p = (gamma - 1.0) * internal
+            T = p / s.rho
+            rad = np.sqrt(np.sum(s.rho * self.r2) / np.sum(s.rho))
+            return rad, float(np.mean(T)), float(np.mean(p)), float(np.sum(s.energy))
+
+        radius = []
+        temperature = []
+        pressure = []
+        energy_hist = []
+
+        rad, temp, pres, Etot = diagnostics(state)
+        radius.append(rad)
+        temperature.append(temp)
+        pressure.append(pres)
+        energy_hist.append(Etot)
+
+        neutron_yield = 0.0
+        for k in range(len(t) - 1):
+            dt = t[k + 1] - t[k]
+            state = solver.step(state, dt)
+            rad, temp, pres, Etot = diagnostics(state)
+            radius.append(rad)
+            temperature.append(temp)
+            pressure.append(pres)
+            energy_hist.append(Etot)
+            n_i = np.mean(state.rho) / (3.344e-27)
+            reactivity = bosch_hale_dd(max(temp, 0.0) / 1e3)
+            mag = np.mean(np.sum(state.B**2, axis=-1))
+            rate = 0.25 * n_i**2 * reactivity * mag * self.volume
+            neutron_yield += rate * dt
+
+        return PinchResult(
+            time=t,
+            radius=np.asarray(radius),
+            temperature=np.asarray(temperature),
+            pressure=np.asarray(pressure),
+            neutron_yield=float(neutron_yield),
+            energy=np.asarray(energy_hist),
+        )
 

--- a/dpf2/simulation_engine.py
+++ b/dpf2/simulation_engine.py
@@ -11,7 +11,12 @@ from dpf_config import DPFConfig
 from circuit_config import CircuitConfig
 
 from .circuit_solver import RLCCircuit, CircuitSolver
-from .pinch_models import AnalyticPinchModel, SemiAnalyticPinchModel, PinchModelBase
+from .pinch_models import (
+    AnalyticPinchModel,
+    SemiAnalyticPinchModel,
+    PinchModelBase,
+    MHDPinchModel,
+)
 
 __all__ = ["SimulationEngine"]
 
@@ -67,8 +72,12 @@ class SimulationEngine:
             plasma: PinchModelBase = AnalyticPinchModel()
         elif pinch_model == "semi-analytic":
             plasma = SemiAnalyticPinchModel()
+        elif pinch_model == "mhd":
+            plasma = MHDPinchModel()
         else:
-            raise ValueError("pinch_model must be 'analytic' or 'semi-analytic'")
+            raise ValueError(
+                "pinch_model must be 'analytic', 'semi-analytic', or 'mhd'"
+            )
         pres = plasma.run(t, current)
 
         return SimulationResults(

--- a/tests/test_pinch_models.py
+++ b/tests/test_pinch_models.py
@@ -1,5 +1,6 @@
 import numpy as np
-from dpf2.pinch_models import AnalyticPinchModel, SemiAnalyticPinchModel
+import pytest
+from dpf2.pinch_models import AnalyticPinchModel, SemiAnalyticPinchModel, MHDPinchModel
 
 
 def test_analytic_model():
@@ -18,3 +19,23 @@ def test_semi_analytic_model():
     res = model.run(t, I)
     assert res.radius.size == t.size
     assert res.axial_position is not None
+
+
+def test_mhd_model_energy_conservation():
+    model = MHDPinchModel(grid_shape=(4, 4, 4))
+    t = np.linspace(0, 1e-7, 5)
+    I = np.ones_like(t) * 1e4
+    res = model.run(t, I)
+    assert res.energy is not None
+    assert np.isclose(res.energy[0], res.energy[-1], rtol=1e-3)
+
+
+def test_mhd_model_yield_scaling():
+    t = np.linspace(0, 1e-7, 5)
+    I1 = np.ones_like(t) * 1e4
+    I2 = np.ones_like(t) * 2e4
+    model = MHDPinchModel(grid_shape=(4, 4, 4))
+    res1 = model.run(t, I1)
+    res2 = model.run(t, I2)
+    assert res2.neutron_yield > res1.neutron_yield
+    assert res2.neutron_yield == pytest.approx(res1.neutron_yield * 4, rel=0.5)


### PR DESCRIPTION
## Summary
- add MHDPinchModel leveraging Hall-MHD solver and expose energy history
- allow SimulationEngine and CLI to select the Hall-MHD pinch model
- test MHD pinch dynamics for energy conservation and yield scaling

## Testing
- `venv/bin/pytest tests/test_pinch_models.py -q`
- `venv/bin/pytest tests/test_simulation_engine.py::test_engine_runs -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa216f0410832a82e7a80b2dad0bd9