### PR TITLE
Add plasma inductance coupling and implicit circuit solver

### DIFF
--- a/Simulation/diagnostics.py
+++ b/Simulation/diagnostics.py
@@ -256,6 +256,8 @@ class Diagnostics:
 
             I = circuit.get_current()
             V = circuit.get_voltage()
+            coupled_currents = getattr(circuit, "get_coupled_currents", lambda: None)()
+            coupled_voltages = getattr(circuit, "get_coupled_voltages", lambda: None)()
 
             # compute dI/dt synthetic Rogowski
             if self._last_time is None:
@@ -306,6 +308,10 @@ class Diagnostics:
                 'timing': tdict,
                 'checkpoint': checkpoint_id
             }
+            if coupled_currents is not None:
+                rec['coupled_currents'] = coupled_currents
+            if coupled_voltages is not None:
+                rec['coupled_voltages'] = coupled_voltages
             self.summary.append(rec)
 
             # Call each diagnostic

--- a/circuit_config.py
+++ b/circuit_config.py
@@ -103,6 +103,23 @@ class CircuitConfig(ConfigSectionBase):
         ..., alias="switchDelay", metadata={"units": "ns", "category": "Circuit", "group": "LRC"}
     )
 
+    # --- Coupling & Plasma Effects ------------------------------------
+    plasma_inductance_profile: Optional[TimeVoltageProfile] = Field(
+        None,
+        alias="plasmaInductanceProfile",
+        metadata={"units": ["μs", "μH"], "category": "Circuit", "group": "Coupling"},
+    )
+    mutual_inductance_profile: Optional[TimeVoltageProfile] = Field(
+        None,
+        alias="mutualInductanceProfile",
+        metadata={"units": ["μs", "μH"], "category": "Circuit", "group": "Coupling"},
+    )
+    mutual_current_profile: Optional[TimeVoltageProfile] = Field(
+        None,
+        alias="mutualCurrentProfile",
+        metadata={"units": ["μs", "kA"], "category": "Circuit", "group": "Coupling"},
+    )
+
     # --- Switching Behavior --------------------------------------------
     switching_model: Literal["ideal", "jittered", "multi-bank"] = Field(
         ..., alias="switchingModel", metadata={"category": "Circuit", "group": "Switching"}
@@ -206,7 +223,23 @@ class CircuitConfig(ConfigSectionBase):
         wf = None
         if self.waveform_profile is not None:
             wf = [(t * scale, v * scale) for t, v in self.waveform_profile]
-        return self.model_copy(update={"waveform_profile": wf})
+        lp = None
+        if self.plasma_inductance_profile is not None:
+            lp = [(t * scale, L) for t, L in self.plasma_inductance_profile]
+        mp = None
+        if self.mutual_inductance_profile is not None:
+            mp = [(t * scale, L) for t, L in self.mutual_inductance_profile]
+        mc = None
+        if self.mutual_current_profile is not None:
+            mc = [(t * scale, i) for t, i in self.mutual_current_profile]
+        return self.model_copy(
+            update={
+                "waveform_profile": wf,
+                "plasma_inductance_profile": lp,
+                "mutual_inductance_profile": mp,
+                "mutual_current_profile": mc,
+            }
+        )
 
     # ------------------------------------------------------------------
     @model_validator(mode="after")

--- a/dpf2/hall_mhd_solver.py
+++ b/dpf2/hall_mhd_solver.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import numpy as np
+from scipy.constants import mu_0
 
 from .core import PlasmaSolverBase
 
@@ -159,3 +160,26 @@ class HallMHDSolver(PlasmaSolverBase):
             Te=None if state.Te is None else state.Te.copy(),
             Ti=None if state.Ti is None else state.Ti.copy(),
         )
+
+    def compute_plasma_inductance(self, state: MHDState, current: float, cell_volume: float = 1.0) -> float:
+        """Estimate plasma inductance from magnetic energy.
+
+        Parameters
+        ----------
+        state : MHDState
+            Current plasma state.
+        current : float
+            Circuit current in amperes.
+        cell_volume : float, optional
+            Volume of a single cell, by default 1.0.
+
+        Returns
+        -------
+        float
+            Estimated inductance in henries.
+        """
+        B2 = np.sum(state.B ** 2)
+        magnetic_energy = B2 * cell_volume / (2 * mu_0)
+        if current == 0.0:
+            return 0.0
+        return 2 * magnetic_energy / (current ** 2)

--- a/rlc_solver.py
+++ b/rlc_solver.py
@@ -5,13 +5,28 @@ from typing import Tuple
 from circuit_config import CircuitConfig
 
 
-def run_circuit_simulation(cfg: CircuitConfig, t_end: float, num_points: int = 1000) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Run simple RLC discharge using cfg parameters.
+def _profile_to_interp(profile, t_scale: float, y_scale: float):
+    """Return interpolation functions for profile value and derivative."""
+    if profile is None:
+        return (lambda t: 0.0, lambda t: 0.0)
+    arr = np.asarray(profile, dtype=float)
+    t = arr[:, 0] * t_scale
+    y = arr[:, 1] * y_scale
+    dy_dt = np.gradient(y, t, edge_order=2)
+    def val(tt):
+        return np.interp(tt, t, y, left=y[0], right=y[-1])
+    def deriv(tt):
+        return np.interp(tt, t, dy_dt, left=dy_dt[0], right=dy_dt[-1])
+    return val, deriv
+
+
+def run_circuit_simulation(cfg: CircuitConfig, t_end: float, num_points: int = 1000) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Run RLC discharge with optional plasma and mutual inductance.
 
     Parameters
     ----------
     cfg : CircuitConfig
-        Circuit configuration with L_ext [uH], R_ext [mOhm], C_ext [uF], V0 [kV].
+        Circuit configuration including optional coupling profiles.
     t_end : float
         End time in microseconds.
     num_points : int, optional
@@ -20,40 +35,51 @@ def run_circuit_simulation(cfg: CircuitConfig, t_end: float, num_points: int = 1
     Returns
     -------
     tuple of ndarray
-        time [s], current [A], capacitor voltage [V].
+        time [s], current [A], capacitor voltage [V], mutual current [A],
+        mutual-induced voltage [V].
     """
-    # convert to SI units
-    L = cfg.L_ext * 1e-6
+    L_ext = cfg.L_ext * 1e-6
     R = cfg.R_ext * 1e-3
     C = cfg.C_ext * 1e-6
     V0 = cfg.V0 * 1e3
     delay = cfg.switch_delay * 1e-9
 
-    def rlc_ode(t, y):
+    lp_func, dlpdt_func = _profile_to_interp(cfg.plasma_inductance_profile, 1e-6, 1e-6)
+    m_func, _ = _profile_to_interp(cfg.mutual_inductance_profile, 1e-6, 1e-6)
+    im_func, dim_dt_func = _profile_to_interp(cfg.mutual_current_profile, 1e-6, 1e3)
+
+    def circuit_ode(t, y):
         I, Q = y
-        dIdt = -(R / L) * I - Q / (L * C)
+        Lp = lp_func(t)
+        dLpdt = dlpdt_func(t)
+        M = m_func(t)
+        dI_mutual_dt = dim_dt_func(t)
+        Ltot = L_ext + Lp
+        V_mutual = -M * dI_mutual_dt
+        dIdt = (V0 + V_mutual - R * I - Q / C - dLpdt * I) / Ltot
         dQdt = I
         return [dIdt, dQdt]
 
-    # time grid in seconds
     t_total = np.linspace(0.0, t_end * 1e-6, num_points)
 
     if t_end * 1e-6 <= delay:
-        # switch never closes
         current = np.zeros_like(t_total)
         voltage = np.full_like(t_total, V0)
-        return t_total, current, voltage
+        i_mutual = im_func(t_total)
+        v_mutual = -m_func(t_total) * dim_dt_func(t_total)
+        return t_total, current, voltage, i_mutual, v_mutual
 
-    # before switch closes
     mask_before = t_total < delay
     current = np.zeros_like(t_total)
     voltage = np.full_like(t_total, V0)
+    i_mutual = im_func(t_total)
+    v_mutual = -m_func(t_total) * dim_dt_func(t_total)
 
-    # integrate after delay
     t_eval = t_total[~mask_before]
     q0 = C * V0
-    sol = solve_ivp(rlc_ode, (delay, t_total[-1]), [0.0, q0], t_eval=t_eval, method="RK45")
+    sol = solve_ivp(circuit_ode, (delay, t_total[-1]), [0.0, q0], t_eval=t_eval, method="BDF")
+
     current[~mask_before] = sol.y[0]
     voltage[~mask_before] = sol.y[1] / C
 
-    return t_total, current, voltage
+    return t_total, current, voltage, i_mutual, v_mutual

--- a/synthetic_diagnostics.py
+++ b/synthetic_diagnostics.py
@@ -86,6 +86,12 @@ class SyntheticDiagnostics(ConfigSectionBase):
     # Enabled diagnostics
     synthetic_current_waveform_enabled: bool = Field(True, alias="syntheticCurrentWaveformEnabled")
     synthetic_voltage_waveform_enabled: bool = Field(True, alias="syntheticVoltageWaveformEnabled")
+    synthetic_coupled_current_waveform_enabled: bool = Field(
+        False, alias="syntheticCoupledCurrentWaveformEnabled"
+    )
+    synthetic_coupled_voltage_waveform_enabled: bool = Field(
+        False, alias="syntheticCoupledVoltageWaveformEnabled"
+    )
     synthetic_rogowski_signal_enabled: bool = Field(True, alias="syntheticRogowskiSignalEnabled")
     synthetic_bdot_signal_enabled: bool = Field(True, alias="syntheticBdotSignalEnabled")
     synthetic_neutron_tof_enabled: bool = Field(True, alias="syntheticNeutronTofEnabled")
@@ -155,6 +161,8 @@ class SyntheticDiagnostics(ConfigSectionBase):
         diag_flags = [
             (self.synthetic_current_waveform_enabled, "Current"),
             (self.synthetic_voltage_waveform_enabled, "Voltage"),
+            (self.synthetic_coupled_current_waveform_enabled, "CoupledCurrent"),
+            (self.synthetic_coupled_voltage_waveform_enabled, "CoupledVoltage"),
             (self.synthetic_rogowski_signal_enabled, "Rogowski"),
             (self.synthetic_bdot_signal_enabled, "B-dot"),
             (self.synthetic_neutron_tof_enabled, "TOF"),

--- a/tests/test_rlc_solver.py
+++ b/tests/test_rlc_solver.py
@@ -5,8 +5,41 @@ from rlc_solver import run_circuit_simulation
 
 def test_rlc_solver_runs():
     cfg = CircuitConfig.with_defaults()
-    t, i, v = run_circuit_simulation(cfg, t_end=10.0)
-    assert len(t) == len(i) == len(v)
-    # basic sanity: current should start at 0 and eventually decrease
+    t, i, v, im, vm = run_circuit_simulation(cfg, t_end=10.0)
+    assert len(t) == len(i) == len(v) == len(im) == len(vm)
     assert np.isclose(i[0], 0.0)
     assert v[0] > v[-1]
+
+
+def test_linear_plasma_inductance():
+    cfg = CircuitConfig.with_defaults().model_copy(
+        update={
+            "switch_delay": 0.0,
+            "R_ext": 0.0,
+            "C_ext": 1e9,
+            "plasma_inductance_profile": [(0.0, 0.0), (10.0, 1.0)],
+        }
+    )
+    t, i, v, im, vm = run_circuit_simulation(cfg, t_end=10.0)
+    L_ext = cfg.L_ext * 1e-6
+    V0 = cfg.V0 * 1e3
+    expected = V0 * t / (L_ext + 0.1 * t)
+    assert np.allclose(i, expected, rtol=1e-2, atol=1e-3)
+
+
+def test_mutual_inductance_drive():
+    cfg = CircuitConfig.with_defaults().model_copy(
+        update={
+            "switch_delay": 0.0,
+            "R_ext": 0.0,
+            "C_ext": 1e9,
+            "V0": 0.0,
+            "mutual_inductance_profile": [(0.0, 0.5), (10.0, 0.5)],
+            "mutual_current_profile": [(0.0, 0.0), (10.0, 10.0)],
+        }
+    )
+    t, i, v, im, vm = run_circuit_simulation(cfg, t_end=10.0)
+    L_ext = cfg.L_ext * 1e-6
+    M = 0.5e-6
+    expected = -(M / L_ext) * im
+    assert np.allclose(i, expected, rtol=1e-2, atol=1e-3)


### PR DESCRIPTION
## Summary
- expose plasma and mutual inductance profiles through `CircuitConfig`
- add inductance estimation to `HallMHDSolver`
- replace RLC solver with implicit time-varying inductance and mutual coupling
- extend diagnostics and synthetic diagnostics to record coupled traces
- test analytic cases for variable and mutual inductance

## Testing
- `python -m py_compile circuit_config.py rlc_solver.py dpf2/hall_mhd_solver.py Simulation/diagnostics.py synthetic_diagnostics.py tests/test_rlc_solver.py`
- `pytest tests/test_rlc_solver.py::test_rlc_solver_runs -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aa217271d0832a9b59abf1ce276f1d