### PR TITLE
Extend MHD module to 3D with advanced physics

### DIFF
--- a/src/dpf2/physics/mhd.py
+++ b/src/dpf2/physics/mhd.py
@@ -1,133 +1,244 @@
-"""Resistive MHD equations in 2D cylindrical geometry."""
+"""Three-dimensional resistive magnetohydrodynamics utilities.
+
+This module provides a light–weight representation of the conservative
+three–dimensional resistive MHD equations.  The formulation implemented here
+extends the original two–dimensional system used in the project to full
+``x-y-z`` support and incorporates a number of diffusive and geometric
+processes that are frequently required in plasma simulations:
+
+* Anisotropic viscosity and thermal conduction (coefficients may be zero to
+  recover the ideal system).
+* Simple resistive (Ohmic) dissipation.
+* Optional geometric source terms for cylindrical coordinates.
+* Hyperbolic divergence cleaning following the approach of Dedner et al.
+
+The implementation is intentionally compact; it is *not* intended to be a
+high–performance solver but rather to supply the minimal building blocks for
+unit and integration tests throughout the code base.
+"""
+
 from __future__ import annotations
 
+from dataclasses import dataclass
 import numpy as np
 
 
+@dataclass
 class ResistiveMHD:
-    """Minimal representation of resistive MHD equations.
+    """Conservative 3‑D resistive MHD system with optional physics extensions."""
 
-    The formulation implemented here follows the ideal MHD equations with an
-    additional simple resistive (Ohmic) contribution.  Only the radial and
-    axial momenta are evolved which is sufficient for the 2D ``r-z`` geometry
-    used throughout the code base.  The azimuthal magnetic field ``B_phi`` is
-    retained as it plays an important role in plasma pinches.
-    """
+    gamma: float = 5 / 3
+    eta: float = 0.0
+    mu_parallel: float = 0.0
+    mu_perp: float = 0.0
+    kappa_parallel: float = 0.0
+    kappa_perp: float = 0.0
+    c_h: float = 0.0
+    c_p: float = 0.0
 
-    def __init__(self, gamma: float = 5 / 3, eta: float = 0.0) -> None:
-        """Create a new resistive MHD system.
-
-        Parameters
-        ----------
-        gamma:
-            Ratio of specific heats.
-        eta:
-            Scalar resistivity used for Ohmic heating and magnetic field decay.
-        """
-
-        self.gamma = gamma
-        self.eta = eta
+    def __post_init__(self) -> None:
+        # Order of the conservative variables used throughout the class.
         self.equations = [
             "density",
-            "momentum_r",
+            "momentum_x",
+            "momentum_y",
             "momentum_z",
             "energy",
-            "B_r",
+            "B_x",
+            "B_y",
             "B_z",
-            "B_phi",
+            "psi",  # divergence cleaning variable
         ]
 
+    # ------------------------------------------------------------------
+    # Primitive ↔ conservative conversions
+    # ------------------------------------------------------------------
     def conservative_variables(self, primitives: np.ndarray) -> np.ndarray:
         """Convert primitive variables to conservative form.
 
-        The primitive state is expected to be ``[rho, v_r, v_z, p, B_r, B_z,
-        B_phi]``.  The returned conservative vector is
-        ``[rho, rho*v_r, rho*v_z, E, B_r, B_z, B_phi]`` where ``E`` is the
-        total energy density.
+        Parameters
+        ----------
+        primitives:
+            Array of ``[rho, v_x, v_y, v_z, p, B_x, B_y, B_z]``.  The cleaning
+            variable ``psi`` is assumed to be zero in primitive form and is
+            appended automatically.
         """
 
-        rho, v_r, v_z, p, B_r, B_z, B_phi = primitives
-        kinetic = 0.5 * rho * (v_r ** 2 + v_z ** 2)
-        magnetic = 0.5 * (B_r ** 2 + B_z ** 2 + B_phi ** 2)
+        rho, v_x, v_y, v_z, p, B_x, B_y, B_z = primitives
+        kinetic = 0.5 * rho * (v_x ** 2 + v_y ** 2 + v_z ** 2)
+        magnetic = 0.5 * (B_x ** 2 + B_y ** 2 + B_z ** 2)
         energy = p / (self.gamma - 1.0) + kinetic + magnetic
-        return np.array([rho, rho * v_r, rho * v_z, energy, B_r, B_z, B_phi])
+        return np.array(
+            [rho, rho * v_x, rho * v_y, rho * v_z, energy, B_x, B_y, B_z, 0.0]
+        )
 
     def _pressure(self, U: np.ndarray) -> float:
         """Return the thermal pressure from conservative variables."""
 
-        rho, m_r, m_z, E, B_r, B_z, B_phi = U
-        v_r = m_r / rho
+        rho, m_x, m_y, m_z, E, B_x, B_y, B_z, _ = U
+        v_x = m_x / rho
+        v_y = m_y / rho
         v_z = m_z / rho
-        v2 = v_r ** 2 + v_z ** 2
-        B2 = B_r ** 2 + B_z ** 2 + B_phi ** 2
+        v2 = v_x ** 2 + v_y ** 2 + v_z ** 2
+        B2 = B_x ** 2 + B_y ** 2 + B_z ** 2
         return (E - 0.5 * rho * v2 - 0.5 * B2) * (self.gamma - 1.0)
 
+    # ------------------------------------------------------------------
+    # Fluxes
+    # ------------------------------------------------------------------
     def flux_function(self, U: np.ndarray, direction: str) -> np.ndarray:
-        """Compute ideal MHD fluxes in the given ``direction``.
+        """Compute MHD fluxes in the requested ``direction``.
+
+        The returned array has the same length as the conservative state
+        vector.  Divergence cleaning is incorporated via the ``psi`` variable
+        whose flux couples to the magnetic field components.
+        """
+
+        rho, m_x, m_y, m_z, E, B_x, B_y, B_z, psi = U
+        v_x = m_x / rho
+        v_y = m_y / rho
+        v_z = m_z / rho
+        v = np.array([v_x, v_y, v_z])
+        B = np.array([B_x, B_y, B_z])
+        B2 = np.dot(B, B)
+        p = self._pressure(U)
+        total_p = p + 0.5 * B2
+        Bdotv = np.dot(B, v)
+
+        F = np.zeros_like(U)
+
+        if direction == "x":
+            F[0] = m_x
+            F[1] = m_x * v_x + total_p - B_x ** 2
+            F[2] = m_y * v_x - B_x * B_y
+            F[3] = m_z * v_x - B_x * B_z
+            F[4] = (E + total_p) * v_x - B_x * Bdotv
+            F[5] = psi
+            F[6] = v_y * B_x - v_x * B_y
+            F[7] = v_z * B_x - v_x * B_z
+            F[8] = self.c_h ** 2 * B_x
+            return F
+
+        if direction == "y":
+            F[0] = m_y
+            F[1] = m_x * v_y - B_y * B_x
+            F[2] = m_y * v_y + total_p - B_y ** 2
+            F[3] = m_z * v_y - B_y * B_z
+            F[4] = (E + total_p) * v_y - B_y * Bdotv
+            F[5] = v_x * B_y - v_y * B_x
+            F[6] = psi
+            F[7] = v_z * B_y - v_y * B_z
+            F[8] = self.c_h ** 2 * B_y
+            return F
+
+        if direction == "z":
+            F[0] = m_z
+            F[1] = m_x * v_z - B_z * B_x
+            F[2] = m_y * v_z - B_z * B_y
+            F[3] = m_z * v_z + total_p - B_z ** 2
+            F[4] = (E + total_p) * v_z - B_z * Bdotv
+            F[5] = v_x * B_z - v_z * B_x
+            F[6] = v_y * B_z - v_z * B_y
+            F[7] = psi
+            F[8] = self.c_h ** 2 * B_z
+            return F
+
+        raise ValueError("direction must be 'x', 'y' or 'z'")
+
+    # ------------------------------------------------------------------
+    # Characteristic speeds (for Rusanov fluxes used in tests)
+    # ------------------------------------------------------------------
+    def max_speed(self, U: np.ndarray, direction: str) -> float:
+        """Return an estimate of the fastest signal speed in ``direction``."""
+
+        rho, m_x, m_y, m_z, _, B_x, B_y, B_z, _ = U
+        v = {
+            "x": m_x / rho,
+            "y": m_y / rho,
+            "z": m_z / rho,
+        }[direction]
+        p = self._pressure(U)
+        a = np.sqrt(self.gamma * p / rho)
+        B2 = B_x ** 2 + B_y ** 2 + B_z ** 2
+        c_a = np.sqrt(B2 / rho)
+        return abs(v) + np.sqrt(a ** 2 + c_a ** 2)
+
+    # ------------------------------------------------------------------
+    # Source terms
+    # ------------------------------------------------------------------
+    def source_terms(
+        self,
+        U: np.ndarray,
+        *,
+        grad_v: np.ndarray | None = None,
+        grad_T: np.ndarray | None = None,
+        geometry: str | None = None,
+        coord: float | None = None,
+    ) -> np.ndarray:
+        """Return diffusive and geometric source terms.
 
         Parameters
         ----------
         U:
             Conservative state vector.
-        direction:
-            Either ``"r"`` or ``"z"`` selecting the spatial direction of the
-            flux.
+        grad_v:
+            Optional velocity gradient ``\nabla v`` used for anisotropic
+            viscosity.  It should be a ``3x3`` array where ``grad_v[i,j]`` is
+            ``∂v_i/∂x_j``.
+        grad_T:
+            Optional temperature gradient used for anisotropic thermal
+            conduction.
+        geometry:
+            If ``"cylindrical"`` a minimal set of geometric source terms are
+            applied using ``coord`` as the radial coordinate.
+        coord:
+            Radial coordinate when ``geometry`` is ``"cylindrical"``.
         """
 
-        rho, m_r, m_z, E, B_r, B_z, B_phi = U
-        v_r = m_r / rho
-        v_z = m_z / rho
-        B2 = B_r ** 2 + B_z ** 2 + B_phi ** 2
-        p = self._pressure(U)
-        total_p = p + 0.5 * B2
-        Bdotv = B_r * v_r + B_z * v_z
+        rho, m_x, m_y, m_z, E, B_x, B_y, B_z, psi = U
+        v = np.array([m_x, m_y, m_z]) / rho
+        B = np.array([B_x, B_y, B_z])
+        src = np.zeros_like(U)
 
-        if direction == "r":
-            return np.array(
-                [
-                    m_r,
-                    m_r * v_r + total_p - B_r ** 2,
-                    m_z * v_r - B_r * B_z,
-                    (E + total_p) * v_r - B_r * Bdotv,
-                    0.0,
-                    v_z * B_r - v_r * B_z,
-                    B_phi * v_r,
-                ]
-            )
+        # Resistive dissipation
+        B2 = np.dot(B, B)
+        src[4] += self.eta * B2
+        src[5:8] -= self.eta * B
 
-        if direction == "z":
-            return np.array(
-                [
-                    m_z,
-                    m_r * v_z - B_r * B_z,
-                    m_z * v_z + total_p - B_z ** 2,
-                    (E + total_p) * v_z - B_z * Bdotv,
-                    v_r * B_z - v_z * B_r,
-                    0.0,
-                    B_phi * v_z,
-                ]
-            )
+        # Divergence cleaning damping
+        src[8] -= self.c_p ** 2 * psi
 
-        raise ValueError("direction must be 'r' or 'z'")
+        # Anisotropic viscosity
+        if grad_v is not None and (self.mu_parallel or self.mu_perp):
+            grad_v = np.asarray(grad_v)
+            b_hat = B / (np.linalg.norm(B) + 1.0e-20)
+            grad_para = np.outer(b_hat, grad_v @ b_hat)
+            grad_perp = grad_v - grad_para
+            visc_tensor = self.mu_parallel * grad_para + self.mu_perp * grad_perp
+            force = np.sum(visc_tensor, axis=1)
+            src[1:4] += force
+            src[4] += np.dot(force, v)
 
-    def source_terms(self, U: np.ndarray) -> np.ndarray:
-        """Return resistive source terms.
+        # Anisotropic thermal conduction
+        if grad_T is not None and (self.kappa_parallel or self.kappa_perp):
+            grad_T = np.asarray(grad_T)
+            b_hat = B / (np.linalg.norm(B) + 1.0e-20)
+            grad_para_T = np.dot(grad_T, b_hat) * b_hat
+            grad_perp_T = grad_T - grad_para_T
+            heat_flux = -self.kappa_parallel * grad_para_T - self.kappa_perp * grad_perp_T
+            src[4] -= np.sum(heat_flux)
 
-        A simple Ohmic model is employed where magnetic fields decay and the
-        lost magnetic energy appears as thermal energy.  Geometric source terms
-        are neglected for this minimal implementation.
-        """
+        # Geometric source terms (very simplified) for cylindrical coordinates
+        if geometry == "cylindrical" and coord is not None and coord != 0.0:
+            r = coord
+            v_x, v_y, v_z = v
+            p = self._pressure(U)
+            src[0] += -rho * v_x / r
+            src[1] += (rho * (v_y ** 2 + v_z ** 2) + 0.5 * (B_y ** 2 + B_z ** 2) - B_x ** 2 + p) / r
+            src[4] += ((E + p + 0.5 * B2) * v_x - B_x * (B @ v)) / r
 
-        _, _, _, _, B_r, B_z, B_phi = U
-        B2 = B_r ** 2 + B_z ** 2 + B_phi ** 2
-        return np.array(
-            [
-                0.0,
-                0.0,
-                0.0,
-                self.eta * B2,
-                -self.eta * B_r,
-                -self.eta * B_z,
-                -self.eta * B_phi,
-            ]
-        )
+        return src
+
+
+__all__ = ["ResistiveMHD"]
+

--- a/tests/test_mhd.py
+++ b/tests/test_mhd.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 import sys
 from pathlib import Path
 
@@ -9,53 +8,163 @@ from mhd import ResistiveMHD
 
 def test_conservative_variables():
     model = ResistiveMHD()
-    primitives = np.array([1.0, 2.0, -1.0, 0.5, 0.1, 0.2, 0.3])
+    primitives = np.array([1.0, 2.0, -1.0, 0.5, 0.5, 0.1, 0.2, 0.3])
     U = model.conservative_variables(primitives)
-    rho, v_r, v_z, p, B_r, B_z, B_phi = primitives
-    kinetic = 0.5 * rho * (v_r**2 + v_z**2)
-    magnetic = 0.5 * (B_r**2 + B_z**2 + B_phi**2)
+
+    rho, vx, vy, vz, p, Bx, By, Bz = primitives
+    kinetic = 0.5 * rho * (vx ** 2 + vy ** 2 + vz ** 2)
+    magnetic = 0.5 * (Bx ** 2 + By ** 2 + Bz ** 2)
     energy = p / (model.gamma - 1.0) + kinetic + magnetic
-    expected = np.array([rho, rho*v_r, rho*v_z, energy, B_r, B_z, B_phi])
+    expected = np.array([rho, rho * vx, rho * vy, rho * vz, energy, Bx, By, Bz, 0.0])
+
     assert np.allclose(U, expected)
 
 
 def test_flux_function():
     model = ResistiveMHD()
-    primitives = np.array([1.0, 2.0, -1.0, 0.5, 0.1, 0.2, 0.3])
+    primitives = np.array([1.0, 2.0, -1.0, 0.5, 0.5, 0.1, 0.2, 0.3])
     U = model.conservative_variables(primitives)
-    rho, v_r, v_z, p, B_r, B_z, B_phi = primitives
-    B2 = B_r**2 + B_z**2 + B_phi**2
+
+    rho, vx, vy, vz, p, Bx, By, Bz = primitives
+    B2 = Bx ** 2 + By ** 2 + Bz ** 2
     total_p = p + 0.5 * B2
-    Bdotv = B_r * v_r + B_z * v_z
-    E = U[3]
-    expected_r = np.array([
-        rho*v_r,
-        rho*v_r*v_r + total_p - B_r**2,
-        rho*v_z*v_r - B_r*B_z,
-        (E + total_p)*v_r - B_r*Bdotv,
+    Bdotv = Bx * vx + By * vy + Bz * vz
+    E = U[4]
+
+    expected_x = np.array([
+        rho * vx,
+        rho * vx * vx + total_p - Bx ** 2,
+        rho * vy * vx - Bx * By,
+        rho * vz * vx - Bx * Bz,
+        (E + total_p) * vx - Bx * Bdotv,
         0.0,
-        v_z*B_r - v_r*B_z,
-        B_phi*v_r,
+        vy * Bx - vx * By,
+        vz * Bx - vx * Bz,
+        0.0,
     ])
+
+    expected_y = np.array([
+        rho * vy,
+        rho * vx * vy - By * Bx,
+        rho * vy * vy + total_p - By ** 2,
+        rho * vz * vy - By * Bz,
+        (E + total_p) * vy - By * Bdotv,
+        vx * By - vy * Bx,
+        0.0,
+        vz * By - vy * Bz,
+        0.0,
+    ])
+
     expected_z = np.array([
-        rho*v_z,
-        rho*v_r*v_z - B_r*B_z,
-        rho*v_z*v_z + total_p - B_z**2,
-        (E + total_p)*v_z - B_z*Bdotv,
-        v_r*B_z - v_z*B_r,
+        rho * vz,
+        rho * vx * vz - Bz * Bx,
+        rho * vy * vz - Bz * By,
+        rho * vz * vz + total_p - Bz ** 2,
+        (E + total_p) * vz - Bz * Bdotv,
+        vx * Bz - vz * Bx,
+        vy * Bz - vz * By,
         0.0,
-        B_phi*v_z,
+        0.0,
     ])
-    assert np.allclose(model.flux_function(U, "r"), expected_r)
+
+    assert np.allclose(model.flux_function(U, "x"), expected_x)
+    assert np.allclose(model.flux_function(U, "y"), expected_y)
     assert np.allclose(model.flux_function(U, "z"), expected_z)
 
 
 def test_source_terms():
     eta = 0.05
-    model = ResistiveMHD(eta=eta)
-    primitives = np.array([1.0, 2.0, -1.0, 0.5, 0.1, 0.2, 0.3])
+    mu_par, mu_perp = 1.0, 0.5
+    kappa_par, kappa_perp = 2.0, 1.0
+    model = ResistiveMHD(
+        eta=eta,
+        mu_parallel=mu_par,
+        mu_perp=mu_perp,
+        kappa_parallel=kappa_par,
+        kappa_perp=kappa_perp,
+        c_p=1.0,
+    )
+
+    primitives = np.array([1.0, 2.0, -1.0, 0.5, 0.5, 0.1, 0.2, 0.3])
     U = model.conservative_variables(primitives)
-    B_r, B_z, B_phi = primitives[4:]
-    B2 = B_r**2 + B_z**2 + B_phi**2
-    expected = np.array([0.0, 0.0, 0.0, eta*B2, -eta*B_r, -eta*B_z, -eta*B_phi])
-    assert np.allclose(model.source_terms(U), expected)
+    grad_v = np.array([[0.1, 0.2, 0.3], [0.0, -0.1, 0.2], [0.3, 0.1, 0.0]])
+    grad_T = np.array([0.5, -0.2, 0.1])
+
+    src = model.source_terms(
+        U, grad_v=grad_v, grad_T=grad_T, geometry="cylindrical", coord=2.0
+    )
+
+    rho, vx, vy, vz, p, Bx, By, Bz = primitives
+    B = np.array([Bx, By, Bz])
+    B2 = Bx ** 2 + By ** 2 + Bz ** 2
+    expected = np.zeros_like(U)
+    expected[4] += eta * B2
+    expected[5:8] -= eta * B
+
+    b_hat = B / (np.linalg.norm(B) + 1.0e-20)
+    grad_para = np.outer(b_hat, grad_v @ b_hat)
+    grad_perp = grad_v - grad_para
+    visc_tensor = mu_par * grad_para + mu_perp * grad_perp
+    force = np.sum(visc_tensor, axis=1)
+    expected[1:4] += force
+    v = np.array([vx, vy, vz])
+    expected[4] += np.dot(force, v)
+
+    grad_para_T = np.dot(grad_T, b_hat) * b_hat
+    grad_perp_T = grad_T - grad_para_T
+    heat_flux = -kappa_par * grad_para_T - kappa_perp * grad_perp_T
+    expected[4] -= np.sum(heat_flux)
+
+    r = 2.0
+    p_th = model._pressure(U)
+    expected[0] += -rho * vx / r
+    expected[1] += (
+        rho * (vy ** 2 + vz ** 2) + 0.5 * (By ** 2 + Bz ** 2) - Bx ** 2 + p_th
+    ) / r
+    E = U[4]
+    expected[4] += ((E + p_th + 0.5 * B2) * vx - Bx * (B @ v)) / r
+
+    assert np.allclose(src, expected)
+
+
+def test_shock_capturing_and_energy_closure():
+    model = ResistiveMHD(c_h=1.0, c_p=1.0)
+    left = np.array([1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0])
+    right = np.array([0.125, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0])
+
+    U_left = model.conservative_variables(left)
+    U_right = model.conservative_variables(right)
+    U = np.vstack([U_left, U_right])
+    dx = 1.0
+    dt = 0.1 * dx / max(
+        model.max_speed(U_left, "x"), model.max_speed(U_right, "x")
+    )
+
+    div0 = abs(U[1, 5] - U[0, 5])
+
+    for _ in range(5):
+        F_L = model.flux_function(U[0], "x")
+        F_R = model.flux_function(U[1], "x")
+        smax = max(model.max_speed(U[0], "x"), model.max_speed(U[1], "x"))
+        flux = 0.5 * (F_L + F_R) - 0.5 * smax * (U[1] - U[0])
+        U[0] -= dt / dx * flux
+        U[1] += dt / dx * flux
+        U[0] += dt * model.source_terms(U[0])
+        U[1] += dt * model.source_terms(U[1])
+
+    # Shock capturing: density on right cell increases
+    assert U[1, 0] > right[0]
+
+    # Energy closure
+    for state in U:
+        p = model._pressure(state)
+        rho = state[0]
+        v2 = np.sum((state[1:4] / rho) ** 2)
+        B2 = np.sum(state[5:8] ** 2)
+        E_calc = p / (model.gamma - 1.0) + 0.5 * rho * v2 + 0.5 * B2
+        assert np.allclose(state[4], E_calc)
+
+    # Divergence cleaning reduces magnetic divergence
+    div1 = abs(U[1, 5] - U[0, 5])
+    assert div1 < div0
+


### PR DESCRIPTION
## Summary
- generalize resistive MHD system to full 3D with divergence cleaning
- add anisotropic viscosity, thermal conduction, and cylindrical geometry sources
- provide integration tests for fluxes, sources, and shock capturing energy closure

## Testing
- `venv/bin/python -m pytest tests/test_mhd.py -q`
- `venv/bin/python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'sympy')*


------
https://chatgpt.com/codex/tasks/task_e_68aa217124a0832abcd03f6de9b61dc8