### PR TITLE
Add coverage tests for plasma, circuit, and neutron yield modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,5 +10,9 @@ jobs:
         with:
           python-version: '3.10'
       - run: pip install -e .
-      - run: pip install pytest
-      - run: pytest
+      - run: pip install pytest pytest-cov
+      - run: pytest --cov=. --cov-report=xml
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage.xml

--- a/tests/test_circuit_model.py
+++ b/tests/test_circuit_model.py
@@ -1,0 +1,60 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# Ensure Simulation modules are importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "Simulation"))
+from circuit import CircuitModel  # type: ignore
+
+
+class DummyCollision:
+    def spitzer_resistivity(self, *args, **kwargs):
+        return 0.0
+
+
+class DummyFieldManager:
+    pass
+
+
+def test_negative_parameters_raise():
+    with pytest.raises(ValueError, match="non-negative"):
+        CircuitModel(
+            C=-1.0,
+            L0=1.0,
+            R0=1.0,
+            anode_radius=0.01,
+            cathode_radius=0.02,
+            collision_model=DummyCollision(),
+            field_manager=DummyFieldManager(),
+        )
+
+
+def test_anode_radius_must_be_smaller():
+    with pytest.raises(ValueError, match="Anode radius must be smaller"):
+        CircuitModel(
+            C=1.0,
+            L0=1.0,
+            R0=1.0,
+            anode_radius=0.02,
+            cathode_radius=0.01,
+            collision_model=DummyCollision(),
+            field_manager=DummyFieldManager(),
+        )
+
+
+def test_collision_model_requires_spitzer():
+    class BadCollision:
+        pass
+
+    with pytest.raises(ValueError, match="spitzer_resistivity"):
+        CircuitModel(
+            C=1.0,
+            L0=1.0,
+            R0=1.0,
+            anode_radius=0.01,
+            cathode_radius=0.02,
+            collision_model=BadCollision(),
+            field_manager=DummyFieldManager(),
+        )

--- a/tests/test_neutron_yield_model.py
+++ b/tests/test_neutron_yield_model.py
@@ -95,3 +95,32 @@ neutronYield:
     assert cfg == cfg2
     summary = cfg.summarize()
     assert "Beam-target" in summary and "Thermonuclear" in summary
+
+def test_missing_reactivity_table_path_for_lookup():
+    data = base_data()
+    data["reactivitySource"] = "look-up"
+    data["reactivityTablePath"] = None
+    with pytest.raises(ValueError, match="reactivity_table_path required"):
+        NeutronYieldModel.model_validate(data)
+
+
+def test_cross_section_table_required_for_tabulated():
+    data = base_data()
+    data["fusionCrossSectionModel"] = "tabulated"
+    data["crossSectionTablePath"] = None
+    with pytest.raises(ValueError, match="cross_section_table_path required"):
+        NeutronYieldModel.model_validate(data)
+
+
+def test_invalid_spectrum_bin_order():
+    data = base_data()
+    data["spectrumEnergyBinsMeV"] = [2.0, 1.0]
+    with pytest.raises(ValueError, match="monotonically increasing"):
+        NeutronYieldModel.model_validate(data)
+
+
+def test_invalid_integration_window():
+    data = base_data()
+    data["yieldIntegrationWindowUs"] = [1.0, 0.5]
+    with pytest.raises(ValueError, match="start < end"):
+        NeutronYieldModel.model_validate(data)

--- a/tests/test_plasma_eos.py
+++ b/tests/test_plasma_eos.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+import pytest
+import h5py
+
+# Ensure Simulation modules are importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "Simulation"))
+from eos import TabulatedEOS  # type: ignore
+
+
+def test_tabulated_eos_missing_dataset(tmp_path):
+    file_path = tmp_path / "eos_missing.h5"
+    with h5py.File(file_path, "w") as f:
+        f.create_dataset("rho", data=[1.0, 2.0])
+        f.create_dataset("T", data=[3.0, 4.0])
+        # Intentionally omit the 'p' dataset
+        f.create_dataset("e", data=[[5.0, 6.0], [7.0, 8.0]])
+    with pytest.raises(ValueError, match="missing required datasets"):
+        TabulatedEOS(str(file_path))
+
+
+def test_tabulated_eos_inconsistent_dimensions(tmp_path):
+    file_path = tmp_path / "eos_bad.h5"
+    with h5py.File(file_path, "w") as f:
+        f.create_dataset("rho", data=[1.0, 2.0])
+        f.create_dataset("T", data=[3.0, 4.0])
+        f.create_dataset("p", data=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        f.create_dataset("e", data=[[7.0, 8.0], [9.0, 10.0]])
+    with pytest.raises(ValueError, match="inconsistent dimensions"):
+        TabulatedEOS(str(file_path))


### PR DESCRIPTION
## Summary
- add CI workflow to run tests with coverage and upload coverage.xml
- add TabulatedEOS validation tests for missing datasets and dimensional mismatches
- add CircuitModel exception tests for parameter validation
- expand NeutronYieldModel tests for missing configuration and invalid spectra

## Testing
- `pytest tests/test_plasma_eos.py tests/test_circuit_model.py tests/test_neutron_yield_model.py` *(fails: ModuleNotFoundError: No module named 'h5py', No module named 'numpy', No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689f50da1c6c832abc4552786523a2cb