### PR TITLE
Add anisotropic conduction and Hall effects

### DIFF
--- a/physics_models.py
+++ b/physics_models.py
@@ -98,6 +98,27 @@ class PhysicsModels(ConfigSectionBase):
         metadata={"category": "PhysicsModels", "group": "Resistivity"},
     )
 
+    anisotropic_conductivity_enabled: bool = Field(
+        False,
+        alias="anisotropicConductivityEnabled",
+        metadata={"category": "PhysicsModels", "group": "Transport"},
+    )
+    conductivity_parallel: Optional[float] = Field(
+        None,
+        alias="conductivityParallel",
+        metadata={"units": "S/m", "category": "PhysicsModels", "group": "Transport"},
+    )
+    conductivity_perpendicular: Optional[float] = Field(
+        None,
+        alias="conductivityPerpendicular",
+        metadata={"units": "S/m", "category": "PhysicsModels", "group": "Transport"},
+    )
+    hall_parameter: Optional[float] = Field(
+        None,
+        alias="hallParameter",
+        metadata={"category": "PhysicsModels", "group": "Transport"},
+    )
+
     ionization_model: IonizationModel = Field(
         IonizationModel.SAHA,
         alias="ionizationModel",
@@ -283,6 +304,12 @@ class PhysicsModels(ConfigSectionBase):
             raise ValueError("opacity_table_path is required for MonteCarlo radiation transport")
         if values.eos_model is EOSModel.TABULATED and values.eos_table_path is None:
             raise ValueError("eos_table_path must be provided when eos_model is 'tabulated'")
+        if values.anisotropic_conductivity_enabled and (
+            values.conductivity_parallel is None or values.conductivity_perpendicular is None
+        ):
+            raise ValueError(
+                "conductivity_parallel and conductivity_perpendicular must be set when anisotropic conductivity is enabled"
+            )
 
         # Context-based validation omitted for compatibility with Pydantic v1
         return values

--- a/src/dpf2/physics/mhd.py
+++ b/src/dpf2/physics/mhd.py
@@ -5,10 +5,23 @@ import numpy as np
 
 
 class ResistiveMHD:
-    """Minimal representation of resistive MHD equations."""
+    """Minimal representation of resistive MHD equations.
 
-    def __init__(self, gamma: float = 5 / 3) -> None:
+    Extended with an anisotropic conductivity tensor and a simple Hall term to
+    demonstrate cross-field heat conduction and Hall-induced currents.
+    """
+
+    def __init__(
+        self,
+        gamma: float = 5 / 3,
+        sigma_parallel: float = 1.0,
+        sigma_perp: float = 1.0,
+        hall_param: float = 0.0,
+    ) -> None:
         self.gamma = gamma
+        self.sigma_parallel = sigma_parallel
+        self.sigma_perp = sigma_perp
+        self.hall_param = hall_param
         self.equations = [
             "density",
             "momentum_r",
@@ -18,6 +31,21 @@ class ResistiveMHD:
             "B_z",
             "B_phi",
         ]
+
+    def conductivity_tensor(self) -> np.ndarray:
+        """Return the anisotropic conductivity tensor."""
+        return np.diag([self.sigma_perp, self.sigma_perp, self.sigma_parallel])
+
+    def cross_field_conduction(self, grad_T: np.ndarray, B: np.ndarray) -> np.ndarray:
+        """Compute heat flux with anisotropic conductivity."""
+        b = B / (np.linalg.norm(B) + 1e-12)
+        grad_par = np.dot(grad_T, b) * b
+        grad_perp = grad_T - grad_par
+        return -self.sigma_parallel * grad_par - self.sigma_perp * grad_perp
+
+    def hall_current(self, J: np.ndarray, B: np.ndarray) -> np.ndarray:
+        """Return current including Hall-induced contribution."""
+        return J + self.hall_param * np.cross(J, B)
 
     def conservative_variables(self, primitives: np.ndarray) -> np.ndarray:
         """Convert primitive variables to conservative form."""

--- a/tests/test_anisotropic_conduction.py
+++ b/tests/test_anisotropic_conduction.py
@@ -1,0 +1,42 @@
+import numpy as np
+import importlib.util
+from pathlib import Path
+
+from physics_models import PhysicsModels
+from core_schema import EOSModel
+
+# Load ResistiveMHD directly to avoid package import side effects
+_mhd_spec = importlib.util.spec_from_file_location(
+    "mhd", Path(__file__).resolve().parent.parent / "src" / "dpf2" / "physics" / "mhd.py"
+)
+mhd = importlib.util.module_from_spec(_mhd_spec)
+_mhd_spec.loader.exec_module(mhd)  # type: ignore
+ResistiveMHD = mhd.ResistiveMHD
+
+
+def test_anisotropic_conductivity_fields():
+    cfg = PhysicsModels(
+        eos_model=EOSModel.IDEAL,
+        gamma=1.4,
+        anisotropic_conductivity_enabled=True,
+        conductivity_parallel=10.0,
+        conductivity_perpendicular=1.0,
+        hall_parameter=0.5,
+    )
+    assert cfg.anisotropic_conductivity_enabled is True
+    assert cfg.conductivity_parallel == 10.0
+    assert cfg.conductivity_perpendicular == 1.0
+    assert cfg.hall_parameter == 0.5
+
+
+def test_cross_field_conduction_and_hall_current():
+    model = ResistiveMHD(sigma_parallel=10.0, sigma_perp=1.0, hall_param=0.5)
+    grad_T = np.array([1.0, 2.0, 3.0])
+    B = np.array([0.0, 0.0, 1.0])
+    J = np.array([1.0, 0.0, 0.0])
+
+    q = model.cross_field_conduction(grad_T, B)
+    assert np.allclose(q, np.array([-1.0, -2.0, -30.0]))
+
+    hall_J = model.hall_current(J, B)
+    assert np.allclose(hall_J, np.array([1.0, -0.5, 0.0]))


### PR DESCRIPTION
## Summary
- extend physics configuration with anisotropic conductivity tensor and Hall parameter
- implement cross-field conduction and Hall current utilities in minimal MHD solver
- add regression tests for anisotropic conduction setup and Hall-induced currents

## Testing
- `venv/bin/pytest tests/test_anisotropic_conduction.py -q`
- `venv/bin/pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f50d416d0832a8678f56adbecc089