### PR TITLE
Add collisional-radiative ionization model and energy sink

### DIFF
--- a/dpf2/ionization.py
+++ b/dpf2/ionization.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Simple ionization model with equilibrium solver and collisional-radiative ODE."""
+
+import math
+
+# Physical constants
+E_CHARGE = 1.602176634e-19  # Coulombs
+K_B = 1.380649e-23  # Boltzmann constant (J/K)
+IONIZATION_ENERGY_EV = 13.6  # Hydrogen ionization energy in eV
+
+
+def _k_ion(T: float) -> float:
+    """Electron impact ionization rate coefficient [m^3/s].
+
+    A crude Arrhenius form is used merely for testing purposes.
+    """
+
+    return 5e-14 * math.exp(-IONIZATION_ENERGY_EV * E_CHARGE / (K_B * T))
+
+
+def _k_rec(T: float) -> float:
+    """Radiative recombination rate coefficient [m^3/s]."""
+
+    # Simple power-law fit for demonstration purposes
+    return 1e-16 * (T / 1.0e4) ** -0.7
+
+
+def collisional_radiative_rhs(ne: float, n_total: float, T: float) -> float:
+    """Time derivative of electron density for a minimal CR model."""
+
+    ion = _k_ion(T) * ne * (n_total - ne)
+    rec = _k_rec(T) * ne ** 2
+    return ion - rec
+
+
+def equilibrium_electron_density(
+    n_total: float, T: float, *, tol: float = 1e-6, max_iter: int = 100
+) -> float:
+    """Solve for the equilibrium electron density using bisection.
+
+    Parameters
+    ----------
+    n_total:
+        Total particle density [m^-3].
+    T:
+        Electron temperature [K].
+    tol:
+        Absolute tolerance for the root-solver.
+    max_iter:
+        Maximum number of bisection iterations.
+    """
+
+    lo, hi = 0.0, float(n_total)
+    for _ in range(max_iter):
+        mid = 0.5 * (lo + hi)
+        fmid = collisional_radiative_rhs(mid, n_total, T)
+        if abs(fmid) < tol:
+            return mid
+        if fmid > 0.0:
+            lo = mid
+        else:
+            hi = mid
+    return mid
+
+
+def ionization_energy_sink(ne: float, n_total: float, T: float) -> float:
+    """Energy loss rate due to ionization [J/m^3/s]."""
+
+    rate = _k_ion(T) * ne * (n_total - ne)
+    return rate * IONIZATION_ENERGY_EV * E_CHARGE
+
+
+__all__ = [
+    "equilibrium_electron_density",
+    "collisional_radiative_rhs",
+    "ionization_energy_sink",
+]

--- a/physics_models.py
+++ b/physics_models.py
@@ -47,6 +47,13 @@ from core_schema import (
 )
 from units_settings import UnitsSettings
 
+# Lightweight ionization model utilities
+from dpf2.ionization import (
+    equilibrium_electron_density as _equilibrium_electron_density,
+    collisional_radiative_rhs,
+    ionization_energy_sink as _ionization_energy_sink,
+)
+
 
 def to_camel_case(string: str) -> str:
     parts = string.split("_")
@@ -265,6 +272,35 @@ class PhysicsModels(ConfigSectionBase):
         if band is not None:
             band = (band[0] * scale, band[1] * scale)
         return self.model_copy(update={"sxr_bandpass_nm": band})
+
+    # ------------------------------------------------------------------
+    def equilibrium_electron_density(self, n_total: float, temperature: float) -> float:
+        """Return the equilibrium electron density for given conditions."""
+
+        if self.ionization_model is IonizationModel.NONE:
+            return 0.0
+        return _equilibrium_electron_density(n_total, temperature)
+
+    def electron_density_rate(self, ne: float, n_total: float, temperature: float) -> float:
+        """Time derivative d(ne)/dt from the CR model."""
+
+        if self.ionization_model is IonizationModel.NONE:
+            return 0.0
+        return collisional_radiative_rhs(ne, n_total, temperature)
+
+    def update_electron_density(
+        self, ne: float, n_total: float, temperature: float, dt: float
+    ) -> float:
+        """Advance the electron density using a forward-Euler step."""
+
+        return ne + self.electron_density_rate(ne, n_total, temperature) * dt
+
+    def ionization_energy_sink(self, ne: float, n_total: float, temperature: float) -> float:
+        """Energy sink due to ionization (J/m^3/s)."""
+
+        if self.ionization_model is IonizationModel.NONE:
+            return 0.0
+        return _ionization_energy_sink(ne, n_total, temperature)
 
     # ------------------------------------------------------------------
     @model_validator(mode="after")

--- a/tests/test_ionization_energy.py
+++ b/tests/test_ionization_energy.py
@@ -1,0 +1,31 @@
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "ionization", Path(__file__).resolve().parents[1] / "dpf2" / "ionization.py"
+)
+ionization = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ionization)  # type: ignore[attr-defined]
+
+from physics_models import PhysicsModels
+
+
+def test_equilibrium_root_solver():
+    n_total = 1e20  # m^-3
+    T = 2e4  # K
+    ne = ionization.equilibrium_electron_density(n_total, T)
+    # check bounds and near-zero derivative
+    assert 0.0 <= ne <= n_total
+    assert abs(ionization.collisional_radiative_rhs(ne, n_total, T)) < 1e-3 * n_total
+
+
+def test_physics_model_energy_sink_update():
+    model = PhysicsModels.with_defaults()
+    n_total = 1e20
+    T = 1e4
+    ne0 = 0.1 * n_total
+    dt = 1e-9
+    ne1 = model.update_electron_density(ne0, n_total, T, dt)
+    assert ne1 != ne0
+    sink = model.ionization_energy_sink(ne1, n_total, T)
+    assert sink >= 0.0


### PR DESCRIPTION
## Summary
- implement simple ionization module with equilibrium root solver and energy loss calculation
- update `PhysicsModels` to evolve electron density and compute ionization energy sink
- add tests for equilibrium solver and energy sink integration

## Testing
- `venv/bin/python -m pytest tests/test_ionization_energy.py`


------
https://chatgpt.com/codex/tasks/task_e_689f50cc1d00832a98316a1ae9f7bc0a