### PR TITLE
Add insulator sleeve geometry and ablation model

### DIFF
--- a/device_profiles.py
+++ b/device_profiles.py
@@ -39,6 +39,22 @@ if not hasattr(BaseModel, "model_copy"):
 from core_schema import ConfigSectionBase, to_camel_case
 
 
+class InsulatorSleeve(BaseModel):
+    """Geometry specification for the insulator sleeve."""
+
+    inner_radius_cm: float = Field(..., alias="innerRadiusCm", ge=0.0)
+    thickness_cm: float = Field(..., alias="thicknessCm", ge=0.0)
+    length_cm: float = Field(..., alias="lengthCm", ge=0.0)
+    material: Optional[str] = Field(None, alias="material")
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        extra="forbid",
+        alias_generator=to_camel_case,
+        populate_by_name=True,
+        validate_default=True,
+    )
+
+
 class DeviceEntry(BaseModel):
     """Single device entry describing geometry and circuit parameters."""
 
@@ -52,6 +68,9 @@ class DeviceEntry(BaseModel):
     anode_length_cm: float = Field(..., alias="anodeLengthCm", ge=0.0)
     insulator_length_cm: float = Field(..., alias="insulatorLengthCm", ge=0.0)
     insulator_material: Optional[str] = Field(None, alias="insulatorMaterial")
+    insulator_sleeve: Optional[InsulatorSleeve] = Field(
+        None, alias="insulatorSleeve"
+    )
     breakdown_voltage_kV: Optional[float] = Field(
         None, alias="breakdownVoltageKV", ge=0.0
     )
@@ -88,6 +107,14 @@ class DeviceEntry(BaseModel):
             values.anode_length_cm,
             values.insulator_length_cm,
         ]
+        if values.insulator_sleeve:
+            geom.extend(
+                [
+                    values.insulator_sleeve.inner_radius_cm,
+                    values.insulator_sleeve.thickness_cm,
+                    values.insulator_sleeve.length_cm,
+                ]
+            )
         if any(g <= 0 for g in geom):
             raise ValueError("geometry dimensions must be positive")
         return values
@@ -128,6 +155,12 @@ class DeviceProfiles(ConfigSectionBase):
                     "anodeLengthCm": 16.0,
                     "insulatorLengthCm": 5.0,
                     "insulatorMaterial": "alumina",
+                    "insulatorSleeve": {
+                        "innerRadiusCm": 2.5,
+                        "thicknessCm": 0.5,
+                        "lengthCm": 5.0,
+                        "material": "alumina",
+                    },
                     "breakdownVoltageKV": 25.0,
                     "fuelMixture": {"D": 0.9, "Ar": 0.1},
                     "regimeCategory": "MJ_scale",
@@ -157,12 +190,22 @@ class DeviceProfiles(ConfigSectionBase):
         factor = 0.01 if spatial_units == "m" else 1.0
         scaled: Dict[str, DeviceEntry] = {}
         for k, d in self.devices.items():
+            sleeve_scaled = None
+            if d.insulator_sleeve:
+                sleeve_scaled = d.insulator_sleeve.model_copy(
+                    update={
+                        "inner_radius_cm": d.insulator_sleeve.inner_radius_cm * factor,
+                        "thickness_cm": d.insulator_sleeve.thickness_cm * factor,
+                        "length_cm": d.insulator_sleeve.length_cm * factor,
+                    }
+                )
             scaled[k] = d.model_copy(
                 update={
                     "anode_radius_cm": d.anode_radius_cm * factor,
                     "cathode_radius_cm": d.cathode_radius_cm * factor,
                     "anode_length_cm": d.anode_length_cm * factor,
                     "insulator_length_cm": d.insulator_length_cm * factor,
+                    "insulator_sleeve": sleeve_scaled,
                 }
             )
         return self.model_copy(update={"devices": scaled})
@@ -203,4 +246,4 @@ class DeviceProfiles(ConfigSectionBase):
         return values
 
 
-__all__ = ["DeviceProfiles", "DeviceEntry"]
+__all__ = ["DeviceProfiles", "DeviceEntry", "InsulatorSleeve"]

--- a/dpf2/ablation.py
+++ b/dpf2/ablation.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import math
+
+__all__ = ["insulator_sleeve_area", "ablation_mass_energy_source"]
+
+
+def insulator_sleeve_area(inner_radius: float, length: float) -> float:
+    """Return inner surface area of cylindrical insulator sleeve.
+
+    Parameters
+    ----------
+    inner_radius: float
+        Inner radius in meters.
+    length: float
+        Sleeve length in meters.
+    Returns
+    -------
+    float
+        Surface area in square meters.
+    """
+    return 2.0 * math.pi * inner_radius * length
+
+
+def ablation_mass_energy_source(ablation_rate: float, area: float, latent_heat: float) -> tuple[float, float]:
+    """Compute mass and energy source due to insulator ablation.
+
+    Parameters
+    ----------
+    ablation_rate: float
+        Mass flux in kg/(m^2*s).
+    area: float
+        Ablating surface area in m^2.
+    latent_heat: float
+        Specific energy required for ablation in J/kg.
+
+    Returns
+    -------
+    tuple
+        (mass_source [kg/s], energy_source [W]).
+    """
+    mass_source = ablation_rate * area
+    energy_source = mass_source * latent_heat
+    return mass_source, energy_source

--- a/dpf2/plasma_model.py
+++ b/dpf2/plasma_model.py
@@ -7,5 +7,13 @@ from .pinch_models import (
     SemiAnalyticPinchModel,
     PinchModelBase,
 )
+from .ablation import ablation_mass_energy_source, insulator_sleeve_area
 
-__all__ = ["AnalyticPinchModel", "PinchResult", "SemiAnalyticPinchModel", "PinchModelBase"]
+__all__ = [
+    "AnalyticPinchModel",
+    "PinchResult",
+    "SemiAnalyticPinchModel",
+    "PinchModelBase",
+    "ablation_mass_energy_source",
+    "insulator_sleeve_area",
+]

--- a/tests/test_insulator_ablation.py
+++ b/tests/test_insulator_ablation.py
@@ -1,0 +1,20 @@
+import pytest
+from device_profiles import DeviceProfiles
+from dpf2.ablation import insulator_sleeve_area, ablation_mass_energy_source
+
+
+def test_device_profile_has_insulator_sleeve():
+    cfg = DeviceProfiles.with_defaults()
+    sleeve = cfg.devices["PF1000"].insulator_sleeve
+    assert sleeve is not None
+    assert sleeve.inner_radius_cm == pytest.approx(cfg.devices["PF1000"].anode_radius_cm)
+    assert sleeve.length_cm == pytest.approx(cfg.devices["PF1000"].insulator_length_cm)
+
+
+def test_ablation_mass_energy_source():
+    cfg = DeviceProfiles.with_defaults()
+    sleeve = cfg.devices["PF1000"].insulator_sleeve
+    area = insulator_sleeve_area(sleeve.inner_radius_cm * 1e-2, sleeve.length_cm * 1e-2)
+    m_dot, e_dot = ablation_mass_energy_source(1e-5, area, 2e6)
+    assert m_dot == pytest.approx(1e-5 * area)
+    assert e_dot == pytest.approx(m_dot * 2e6)


### PR DESCRIPTION
## Summary
- define `InsulatorSleeve` geometry in device profiles and provide PF1000 defaults
- add ablation mass/energy source utilities and expose via plasma model
- test insulator sleeve configuration and ablation source calculation

## Testing
- `venv/bin/pytest tests/test_insulator_ablation.py tests/test_device_profiles.py`


------
https://chatgpt.com/codex/tasks/task_e_689f50cdc090832a9218f5efcdac03ac