### PR TITLE
Integrate simple radiation losses into pinch energy balance

### DIFF
--- a/docs/radiation.md
+++ b/docs/radiation.md
@@ -1,0 +1,40 @@
+# Radiation Loss Models
+
+The Dense Plasma Focus (DPF) pinch loses energy through several radiation
+mechanisms.  The simple models used in `dpf2` estimate the power density
+:math:`P` (in W/m^3) for each mechanism as a function of electron temperature
+``T_e`` [K] and densities ``n_e`` and ``n_i`` [m^-3]:
+
+## Bremsstrahlung
+
+Free–free emission from electron–ion collisions is approximated by
+
+\[
+P_{\text{brem}} \approx 1.69\times10^{-32} Z_{\text{eff}} n_e n_i \sqrt{T_e}.
+\]
+
+## Line Radiation
+
+Excited ions radiatively decay, modeled here with a crude exponential drop
+with temperature using the hydrogenic excitation energy of 13.6 eV:
+
+\[
+P_{\text{line}} \approx 10^{-31} n_e n_i \exp(-13.6 / T_{e,\text{eV}}).
+\]
+
+## Radiative Recombination
+
+When an electron recombines with an ion it emits a photon.  The associated
+power density is estimated by
+
+\[
+P_{\text{recomb}} \approx 1.7\times10^{-32} Z_{\text{eff}} n_e n_i / \sqrt{T_e}.
+\]
+
+These expressions are adapted from standard plasma-physics references and are
+valid only for rough order-of-magnitude estimates.
+
+## References
+
+- J. D. Huba, *NRL Plasma Formulary*, Naval Research Laboratory, 2016.
+- P. M. Bellan, *Fundamentals of Plasma Physics*, Cambridge University Press, 2008.

--- a/dpf2/radiation.py
+++ b/dpf2/radiation.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Simplified radiation loss models for DPF simulations.
+
+This module implements very approximate formulas for bremsstrahlung, line, and
+recombination radiation losses.  The expressions are intended for order of
+magnitude estimates and operate on cgs-like units:
+
+* ``T_e`` [K] – electron temperature
+* ``n_e``, ``n_i`` [m^-3] – electron and ion number densities
+* ``Z_eff`` – effective ion charge state
+
+References
+----------
+These simplified formulas are adapted from the NRL Plasma Formulary
+:footcite:`Huba2016` and basic plasma radiation theory :footcite:`Bellan2008`.
+
+The implementation purposefully favors clarity over accuracy; a more complete
+model would tabulate emissivities from detailed collisional–radiative
+calculations.
+"""
+
+from typing import Dict
+
+import numpy as np
+
+K_B = 1.380649e-23  # Boltzmann constant [J/K]
+
+
+def bremsstrahlung_loss(T_e: np.ndarray, n_e: np.ndarray, n_i: np.ndarray, Z_eff: float = 1.0) -> np.ndarray:
+    """Return bremsstrahlung power density ``P_brem`` [W/m^3].
+
+    Uses the non–relativistic approximation :math:`P \approx 1.69\times10^{-32}
+    Z_\mathrm{eff} n_e n_i \sqrt{T_e}` where ``T_e`` is in kelvin.
+    """
+
+    return 1.69e-32 * Z_eff * n_e * n_i * np.sqrt(T_e)
+
+
+def recombination_loss(T_e: np.ndarray, n_e: np.ndarray, n_i: np.ndarray, Z_eff: float = 1.0) -> np.ndarray:
+    """Return radiative recombination loss ``P_rec`` [W/m^3].
+
+    Approximated by :math:`P \approx 1.7\times10^{-32} Z_\mathrm{eff} n_e n_i / \sqrt{T_e}`.
+    """
+
+    return 1.7e-32 * Z_eff * n_e * n_i / np.sqrt(T_e)
+
+
+def line_loss(T_e: np.ndarray, n_e: np.ndarray, n_i: np.ndarray, Z_eff: float = 1.0) -> np.ndarray:
+    """Very crude line radiation estimate ``P_line`` [W/m^3].
+
+    Modeled as an exponential drop with temperature using an effective hydrogenic
+    excitation energy (13.6 eV).
+    """
+
+    T_e_eV = T_e / 11604.525
+    return 1e-31 * n_e * n_i * np.exp(-13.6 / np.maximum(T_e_eV, 1e-6))
+
+
+def total_radiation_loss(T_e: np.ndarray, n_e: np.ndarray, n_i: np.ndarray, Z_eff: float = 1.0) -> Dict[str, np.ndarray]:
+    """Return a dictionary containing individual and total radiation losses."""
+
+    brem = bremsstrahlung_loss(T_e, n_e, n_i, Z_eff)
+    line = line_loss(T_e, n_e, n_i, Z_eff)
+    recomb = recombination_loss(T_e, n_e, n_i, Z_eff)
+    total = brem + line + recomb
+    return {"bremsstrahlung": brem, "line": line, "recombination": recomb, "total": total}
+

--- a/dpf2/simulation_engine.py
+++ b/dpf2/simulation_engine.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, Optional
 
 import numpy as np
 
@@ -12,6 +12,7 @@ from circuit_config import CircuitConfig
 
 from .circuit_solver import RLCCircuit, CircuitSolver
 from .pinch_models import AnalyticPinchModel, SemiAnalyticPinchModel, PinchModelBase
+from .radiation import K_B, total_radiation_loss
 
 __all__ = ["SimulationEngine"]
 
@@ -25,6 +26,7 @@ class SimulationResults:
     pressure: np.ndarray
     neutron_yield: float
     axial_position: np.ndarray | None = None
+    radiation_losses: Optional[Dict[str, np.ndarray]] = None
 
     def to_dict(self) -> Dict[str, object]:
         return {
@@ -34,7 +36,16 @@ class SimulationResults:
             "temperature": self.temperature.tolist(),
             "pressure": self.pressure.tolist(),
             "neutron_yield": self.neutron_yield,
-            **({"axial_position": self.axial_position.tolist()} if self.axial_position is not None else {}),
+            **(
+                {"axial_position": self.axial_position.tolist()}
+                if self.axial_position is not None
+                else {}
+            ),
+            **(
+                {"radiation_losses": {k: v.tolist() for k, v in self.radiation_losses.items()}}
+                if self.radiation_losses is not None
+                else {}
+            ),
         }
 
 
@@ -71,12 +82,22 @@ class SimulationEngine:
             raise ValueError("pinch_model must be 'analytic' or 'semi-analytic'")
         pres = plasma.run(t, current)
 
+        zeff = getattr(plasma, "zeff", 1.0)
+        n_i = pres.pressure / ((zeff + 1.0) * K_B * pres.temperature)
+        n_e = zeff * n_i
+        losses = total_radiation_loss(pres.temperature, n_e, n_i, zeff)
+
+        dt_arr = np.diff(pres.time, prepend=pres.time[0])
+        dT = losses["total"] * dt_arr / (1.5 * (n_e + n_i) * K_B)
+        temperature = np.maximum(pres.temperature - np.cumsum(dT), 0.0)
+
         return SimulationResults(
             time=pres.time,
             current=current,
             radius=pres.radius,
-            temperature=pres.temperature,
+            temperature=temperature,
             pressure=pres.pressure,
             neutron_yield=pres.neutron_yield,
             axial_position=pres.axial_position,
+            radiation_losses=losses,
         )


### PR DESCRIPTION
## Summary
- implement bremsstrahlung, line and recombination loss models
- couple radiation losses into pinch temperature evolution
- document radiation physics with references

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689f50c37304832aab88ff526131b869