### PR TITLE
Add plasma inductance/resistance utilities and expose pinch density

### DIFF
--- a/dpf2/pinch_models.py
+++ b/dpf2/pinch_models.py
@@ -17,6 +17,7 @@ class PinchResult:
     time: np.ndarray
     radius: np.ndarray
     temperature: np.ndarray
+    density: np.ndarray
     pressure: np.ndarray
     neutron_yield: float
     axial_position: np.ndarray | None = None
@@ -42,9 +43,14 @@ class AnalyticPinchModel(PinchModelBase):
         radius = self.initial_radius * np.exp(-t / self.tau)
         pressure = 0.5 * (I ** 2) * 1e-6  # arbitrary scaling
         temperature = 1e3 * (I / 1e4) ** 2
+        # crude density model: assumes mass conservation with constant length
+        length = 0.1  # m
+        mass = 1e-6  # kg
+        volume = np.pi * radius**2 * length
+        density = np.full_like(radius, mass / (np.maximum(volume, 1e-12)))
         yield_integrand = (temperature / 1e3) ** 3 * I ** 2
         neutron_yield = float(np.trapz(yield_integrand, t) * 1e-20)
-        return PinchResult(t, radius, temperature, pressure, neutron_yield)
+        return PinchResult(t, radius, temperature, density, pressure, neutron_yield)
 
 
 class SemiAnalyticPinchModel(PinchModelBase):
@@ -92,5 +98,5 @@ class SemiAnalyticPinchModel(PinchModelBase):
         reactivity = bosch_hale_dd(temperature / 1e3)
         rate = 0.25 * n_i ** 2 * reactivity * volume
         neutron_yield = float(np.trapz(rate, t))
-        return PinchResult(t, r, temperature, pressure, neutron_yield, axial_position=z)
+        return PinchResult(t, r, temperature, density, pressure, neutron_yield, axial_position=z)
 

--- a/dpf2/simulation_engine.py
+++ b/dpf2/simulation_engine.py
@@ -22,6 +22,7 @@ class SimulationResults:
     current: np.ndarray
     radius: np.ndarray
     temperature: np.ndarray
+    density: np.ndarray
     pressure: np.ndarray
     neutron_yield: float
     axial_position: np.ndarray | None = None
@@ -32,6 +33,7 @@ class SimulationResults:
             "current": self.current.tolist(),
             "pinch_radius": self.radius.tolist(),
             "temperature": self.temperature.tolist(),
+            "density": self.density.tolist(),
             "pressure": self.pressure.tolist(),
             "neutron_yield": self.neutron_yield,
             **({"axial_position": self.axial_position.tolist()} if self.axial_position is not None else {}),
@@ -76,6 +78,7 @@ class SimulationEngine:
             current=current,
             radius=pres.radius,
             temperature=pres.temperature,
+             density=pres.density,
             pressure=pres.pressure,
             neutron_yield=pres.neutron_yield,
             axial_position=pres.axial_position,

--- a/rlc_solver.py
+++ b/rlc_solver.py
@@ -1,8 +1,100 @@
+"""Simple RLC solver with optional dynamic plasma contributions.
+
+The helper functions implemented here provide crude estimates of the
+additional inductance and resistance introduced by the plasma column in a
+Dense Plasma Focus device.  They are intentionally lightweight and
+analytic so that unit tests can exercise the coupling between the pinch
+model and the circuit without requiring a full MHD simulation.
+"""
+
 import numpy as np
 from scipy.integrate import solve_ivp
 from typing import Tuple
 
 from circuit_config import CircuitConfig
+
+
+MU_0 = 4e-7 * np.pi
+
+
+def dynamic_inductance(radius: np.ndarray, cathode_radius: float, length: float = 0.1) -> np.ndarray:
+    """Estimate plasma inductance from pinch radius.
+
+    Parameters
+    ----------
+    radius:
+        Instantaneous pinch radius [m].  Can be a scalar or array.
+    cathode_radius:
+        Cathode radius of the device [m].
+    length:
+        Effective length of the plasma column [m].
+
+    Returns
+    -------
+    ndarray
+        Plasma inductance [H] for each radius value.
+
+    Notes
+    -----
+    A simple coaxial geometry is assumed with the inductance given by
+    ``L = mu0 * length / (2*pi) * ln(b/r)``.  Radii are clipped to a
+    small positive value to avoid singularities as the pinch collapses.
+    """
+
+    r = np.clip(np.asarray(radius), 1e-9, None)
+    if cathode_radius <= 0 or length <= 0:
+        raise ValueError("cathode_radius and length must be positive")
+    return MU_0 * length / (2 * np.pi) * np.log(cathode_radius / r)
+
+
+def dynamic_resistance(
+    radius: np.ndarray,
+    density: np.ndarray,
+    temperature: np.ndarray,
+    length: float = 0.1,
+    ln_lambda: float = 10.0,
+    z_eff: float = 1.0,
+) -> np.ndarray:
+    """Crude Spitzer-like plasma resistance estimate.
+
+    Parameters
+    ----------
+    radius:
+        Pinch radius [m].
+    density:
+        Plasma mass density [kg/m^3].
+    temperature:
+        Electron temperature [K].
+    length:
+        Plasma column length [m].
+    ln_lambda:
+        Coulomb logarithm used in the resistivity estimate.
+    z_eff:
+        Effective charge state.
+
+    Returns
+    -------
+    ndarray
+        Plasma resistance [Ω] corresponding to the supplied state.
+
+    Notes
+    -----
+    The Spitzer resistivity is approximated by ``eta ≈ 1.65e-9 * Z *
+    lnΛ / T_e[eV]^{3/2}`` (Ω·m).  The resistance is then ``eta * length /
+    area`` where ``area = π r^2``.  Temperatures supplied in Kelvin are
+    converted to electron-volts using ``1 eV ≈ 11604 K``.
+    """
+
+    r = np.clip(np.asarray(radius), 1e-9, None)
+    rho = np.clip(np.asarray(density), 1e-30, None)
+    T = np.clip(np.asarray(temperature), 1e-9, None)
+
+    area = np.pi * r ** 2
+    # Convert temperature to eV for Spitzer formula
+    T_eV = T / 11604.0
+    n_e = rho / 1.6726219e-27  # electron density assuming deuterium
+    eta = 1.65e-9 * z_eff * ln_lambda / (np.power(T_eV, 1.5) * np.maximum(n_e, 1e6))
+    return eta * length / area
 
 
 def run_circuit_simulation(cfg: CircuitConfig, t_end: float, num_points: int = 1000) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:

--- a/tests/test_dynamic_inductance.py
+++ b/tests/test_dynamic_inductance.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from rlc_solver import dynamic_inductance, dynamic_resistance
+from dpf_config import DPFConfig
+from dpf2.simulation_engine import SimulationEngine
+
+
+def test_dynamic_inductance_and_resistance_trends():
+    r = np.array([1e-2, 5e-3])
+    L = dynamic_inductance(r, cathode_radius=2e-2, length=0.1)
+    # smaller radius -> larger inductance
+    assert L[1] > L[0]
+
+    radius = np.array([1e-3, 1e-3])
+    density = np.array([1e-3, 2e-3])
+    temperature = np.array([1e5, 1e5])
+    R = dynamic_resistance(radius, density, temperature, length=0.1)
+    assert R[1] < R[0]
+
+    # higher temperature should lower resistance
+    R_t = dynamic_resistance(radius, np.array([1e-3, 1e-3]), np.array([1e5, 2e5]), length=0.1)
+    assert R_t[1] < R_t[0]
+
+
+def test_simulation_engine_provides_density():
+    cfg = DPFConfig.with_defaults()
+    cfg = cfg.model_copy(update={
+        "simulation_control": cfg.simulation_control.model_copy(update={"time_end": 1e-6})
+    })
+    engine = SimulationEngine(cfg)
+    results = engine.run()
+    assert results.density.shape == results.radius.shape


### PR DESCRIPTION
## Summary
- add helper functions for plasma inductance and resistance in `rlc_solver`
- expose pinch density to circuit through `simulation_engine`
- supply density from pinch models and new tests for dynamic inductance behaviour

## Testing
- `pytest tests/test_dynamic_inductance.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689f50c968c8832ab9da387f6323f1e6