### PR TITLE
Add PhysicsModule import to module registry

### DIFF
--- a/Simulation/module_registry.py
+++ b/Simulation/module_registry.py
@@ -8,6 +8,7 @@ from abc import ABC
 from typing import Dict, Type, Any, List, Optional
 from pydantic import BaseModel, ValidationError
 from utils import FieldManager
+from Simulation.models import PhysicsModule
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- ensure ModuleRegistry can reference PhysicsModule by importing it

## Testing
- `venv/bin/python -m py_compile Simulation/module_registry.py`
- `venv/bin/python - <<'PY'
import sys, os, tempfile
sys.path.append(os.path.join(os.getcwd(), 'Simulation'))
from Simulation.module_registry import ModuleRegistry
import tempfile
import os
from Simulation.models import PhysicsModule
pkg_dir = tempfile.mkdtemp()
os.makedirs(os.path.join(pkg_dir, 'temp_plugin'))
open(os.path.join(pkg_dir, 'temp_plugin', '__init__.py'), 'w').close()
with open(os.path.join(pkg_dir, 'temp_plugin', 'mod.py'), 'w') as f:
    f.write('from Simulation.models import PhysicsModule\nclass TestPlugin(PhysicsModule):\n    def apply(self, state, dt):\n        pass\n')
sys.path.insert(0, pkg_dir)
mr = ModuleRegistry()
mr.discover_plugins('temp_plugin')
print('registered', [cls.__name__ for cls in mr.modules])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68aa390d4998832a9a7425269da8950a