### PR TITLE
Implement wall functions for turbulence model

### DIFF
--- a/Simulation/turbulence_model.py
+++ b/Simulation/turbulence_model.py
@@ -179,15 +179,62 @@ class TurbulenceModel(PhysicsModule):
         self.epsilon[:, :, -g:] = epsilon_boundary_value
 
     def _apply_wall_functions(self, state):
-        """Applies wall functions to k and epsilon near walls."""
-        # Example: logarithmic law of the wall
-        # This is a very basic implementation and needs to be adapted to your specific geometry
+        """Applies wall functions to the velocity, k and epsilon fields.
+
+        The implementation here is intentionally simple – it only operates on
+        cells adjacent to the ``x``-normal boundaries and assumes a uniform grid.
+        It is sufficient for unit testing and can be expanded for more complex
+        geometries.
+        """
+
+        # Basic validation of required state fields
+        if state.velocity is None or state.viscosity is None or state.density is None:
+            raise ValueError("State must contain velocity, viscosity and density for wall functions")
+        if self.k is None or self.epsilon is None:
+            raise ValueError("Turbulence fields k and epsilon must be initialized before applying wall functions")
+
+        g = getattr(state, "ghost", 1)
+        nu = state.viscosity / np.maximum(state.density, 1e-30)
+        nx = state.velocity.shape[0]
+
         if self.wall_function_type == "log_law":
-            # ... (implementation for log-law wall functions) ...
-            pass
+            # Logarithmic law of the wall
+            kappa = self.wall_function_kappa
+            E = self.wall_function_E
+
+            # Left boundary (x_lo)
+            k_cell = self.k[g, :, :]
+            u_tau = (self.C_mu ** 0.25) * np.sqrt(k_cell)
+            y = 0.5 * state.dx
+            y_plus = y * u_tau / np.maximum(nu[g, :, :], 1e-30)
+            u_plus = (1.0 / kappa) * np.log(np.maximum(E * y_plus, 1.0))
+            state.velocity[g, :, :, 0] = u_plus * u_tau
+            # Update k and epsilon at the wall-adjacent cell
+            self.k[g, :, :] = u_tau ** 2 / np.sqrt(self.C_mu)
+            self.epsilon[g, :, :] = (u_tau ** 3) / (kappa * y)
+
+            # Right boundary (x_hi)
+            k_cell = self.k[nx - g - 1, :, :]
+            u_tau = (self.C_mu ** 0.25) * np.sqrt(k_cell)
+            y_plus = y * u_tau / np.maximum(nu[nx - g - 1, :, :], 1e-30)
+            u_plus = (1.0 / kappa) * np.log(np.maximum(E * y_plus, 1.0))
+            state.velocity[nx - g - 1, :, :, 0] = u_plus * u_tau
+            self.k[nx - g - 1, :, :] = u_tau ** 2 / np.sqrt(self.C_mu)
+            self.epsilon[nx - g - 1, :, :] = (u_tau ** 3) / (kappa * y)
+
         elif self.wall_function_type == "power_law":
-            # ... (implementation for power-law wall functions) ...
-            pass
+            # Simple power-law relation (1/7th power law)
+            n = 7.0
+            y = 0.5 * state.dx
+
+            # Left boundary uses velocity from the next interior cell
+            U_edge = state.velocity[g + 1, :, :, 0]
+            state.velocity[g, :, :, 0] = U_edge * (y / state.dx) ** (1.0 / n)
+
+            # Right boundary uses velocity from the previous interior cell
+            U_edge = state.velocity[nx - g - 2, :, :, 0]
+            state.velocity[nx - g - 1, :, :, 0] = U_edge * (y / state.dx) ** (1.0 / n)
+
         else:
             raise ValueError(f"Unknown wall function type: {self.wall_function_type}")
 

--- a/tests/test_turbulence_model.py
+++ b/tests/test_turbulence_model.py
@@ -1,0 +1,83 @@
+import os
+import sys
+import numpy as np
+import pytest
+
+
+# Make Simulation modules importable
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "Simulation"))
+
+from config_schema import TurbulenceConfig
+from turbulence_model import TurbulenceModel
+from utils import SimulationState
+
+
+def _basic_state(grid_shape=(5, 1, 1), dx=0.01):
+    """Create a minimal SimulationState with required fields."""
+
+    density = np.ones(grid_shape)
+    velocity = np.zeros(grid_shape + (3,))
+    viscosity = np.ones(grid_shape) * 1e-5
+    bc = {"x_lo": "wall", "x_hi": "wall"}
+    state = SimulationState(
+        grid_shape, dx, dx, dx, (0.0, 0.0, 0.0), bc,
+        density=density, velocity=velocity, viscosity=viscosity, ghost=1
+    )
+    return state
+
+
+def test_log_law_wall_function_adjusts_velocity_and_fields():
+    cfg = TurbulenceConfig(wall_function_type="log_law")
+    model = TurbulenceModel(cfg)
+    state = _basic_state()
+
+    model.k = np.ones_like(state.density) * 0.1
+    model.epsilon = np.ones_like(state.density) * 0.01
+
+    g = state.ghost
+    k0 = model.k[g, 0, 0]
+    nu = state.viscosity[g, 0, 0] / state.density[g, 0, 0]
+    u_tau = (model.C_mu ** 0.25) * np.sqrt(k0)
+    y = 0.5 * state.dx
+    y_plus = y * u_tau / nu
+    u_plus = (1.0 / model.wall_function_kappa) * np.log(model.wall_function_E * y_plus)
+    expected_velocity = u_plus * u_tau
+    expected_k = u_tau ** 2 / np.sqrt(model.C_mu)
+    expected_epsilon = (u_tau ** 3) / (model.wall_function_kappa * y)
+
+    model._apply_wall_functions(state)
+
+    assert np.isclose(state.velocity[g, 0, 0, 0], expected_velocity)
+    assert np.isclose(model.k[g, 0, 0], expected_k)
+    assert np.isclose(model.epsilon[g, 0, 0], expected_epsilon)
+
+
+def test_power_law_wall_function_adjusts_velocity():
+    cfg = TurbulenceConfig(wall_function_type="power_law")
+    model = TurbulenceModel(cfg)
+    state = _basic_state()
+
+    model.k = np.ones_like(state.density) * 0.1
+    model.epsilon = np.ones_like(state.density) * 0.01
+
+    g = state.ghost
+    state.velocity[g + 1, 0, 0, 0] = 5.0
+    expected = 5.0 * (0.5 * state.dx / state.dx) ** (1.0 / 7.0)
+
+    model._apply_wall_functions(state)
+
+    assert np.isclose(state.velocity[g, 0, 0, 0], expected)
+
+
+def test_wall_function_validation():
+    cfg = TurbulenceConfig(wall_function_type="log_law")
+    model = TurbulenceModel(cfg)
+    state = _basic_state()
+    state.viscosity = None
+
+    model.k = np.ones_like(state.density) * 0.1
+    model.epsilon = np.ones_like(state.density) * 0.01
+
+    with pytest.raises(ValueError):
+        model._apply_wall_functions(state)
+


### PR DESCRIPTION
## Summary
- Implement log-law and power-law wall function handling in turbulence model
- Add validation of required state fields for wall function application
- Introduce unit tests covering log-law, power-law, and validation paths

## Testing
- `pytest tests/test_turbulence_model.py::test_log_law_wall_function_adjusts_velocity_and_fields -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aa390e61d4832ab171699f2198d504