### PR TITLE
feat: add opacity models and tests

### DIFF
--- a/Simulation/radiation_model.py
+++ b/Simulation/radiation_model.py
@@ -284,11 +284,20 @@ class RadiationModel(PhysicsModule):
         if self.opacity_model == "constant":
             return np.array(self.opacity_params.get("constant_opacity", 1.0))
         elif self.opacity_model == "temperature_dependent":
-            # ... (implementation for temperature-dependent opacity) ...
-            pass
+            base = self.opacity_params.get("base", 0.0)
+            alpha = self.opacity_params.get("alpha", 1.0)
+            beta = self.opacity_params.get("beta", 1.0)
+            return np.array(base + alpha * np.power(Te, beta))
         elif self.opacity_model == "density_dependent":
-            # ... (implementation for density-dependent opacity) ...
-            pass
+            base = self.opacity_params.get("base", 0.0)
+            alpha = self.opacity_params.get("alpha", 1.0)
+            if self.opacity_params.get("use_Z", False):
+                exponent = self.opacity_params.get("Z_exponent", 1.0)
+                quantity = Z
+            else:
+                exponent = self.opacity_params.get("ne_exponent", 1.0)
+                quantity = ne
+            return np.array(base + alpha * np.power(quantity, exponent))
         else:
             raise ValueError(f"Unknown opacity model: {self.opacity_model}")
 

--- a/tests/test_radiation_opacity.py
+++ b/tests/test_radiation_opacity.py
@@ -1,0 +1,52 @@
+import sys
+import types
+import numpy as np
+
+# Stub out dependencies not needed for opacity calculations
+sys.modules.setdefault("amrex", types.ModuleType("amrex"))
+models_stub = types.ModuleType("models")
+models_stub.PhysicsModule = object
+models_stub.SimulationState = object
+sys.modules.setdefault("models", models_stub)
+config_stub = types.ModuleType("config_schema")
+config_stub.RadiationConfig = object
+sys.modules.setdefault("config_schema", config_stub)
+
+from Simulation.radiation_model import RadiationModel
+
+
+def _make_model(model, params):
+    rm = RadiationModel.__new__(RadiationModel)
+    rm.opacity_model = model
+    rm.opacity_params = params
+    return rm
+
+
+def test_constant_opacity():
+    rm = _make_model("constant", {"constant_opacity": 2.5})
+    out = rm._compute_opacity(Te=0.0, ne=0.0, Z=0.0)
+    assert np.allclose(out, np.array(2.5))
+
+
+def test_temperature_dependent_opacity():
+    rm = _make_model("temperature_dependent", {"base": 1.0, "alpha": 0.5, "beta": 2.0})
+    Te = 3.0
+    expected = 1.0 + 0.5 * Te ** 2.0
+    out = rm._compute_opacity(Te=Te, ne=0.0, Z=0.0)
+    assert np.allclose(out, expected)
+
+
+def test_density_dependent_opacity_ne():
+    rm = _make_model("density_dependent", {"base": 0.1, "alpha": 0.2, "ne_exponent": 1.5})
+    ne = 4.0
+    expected = 0.1 + 0.2 * ne ** 1.5
+    out = rm._compute_opacity(Te=0.0, ne=ne, Z=0.0)
+    assert np.allclose(out, expected)
+
+
+def test_density_dependent_opacity_Z():
+    rm = _make_model("density_dependent", {"alpha": 0.3, "Z_exponent": 2.0, "use_Z": True})
+    Z = 5.0
+    expected = 0.3 * Z ** 2.0
+    out = rm._compute_opacity(Te=0.0, ne=0.0, Z=Z)
+    assert np.allclose(out, expected)


### PR DESCRIPTION
## Summary
- implement temperature- and density-dependent opacity calculations
- add unit tests validating constant, temperature-dependent, and density-dependent models

## Testing
- `venv/bin/pytest tests/test_radiation_opacity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa390fcd1c832a9c997178c60fd324