### PR TITLE
Handle mixture fractions in EOS selector

### DIFF
--- a/Simulation/eos.py
+++ b/Simulation/eos.py
@@ -1,6 +1,7 @@
 import numpy as np
 import h5py
 import logging
+from typing import Dict, Optional
 from scipy.interpolate import RegularGridInterpolator
 
 logger = logging.getLogger(__name__)
@@ -14,13 +15,20 @@ class TabulatedEOS:
     as functions of density and temperature.
     """
 
-    def __init__(self, filename):
-        """
-        Initializes the TabulatedEOS with data from an HDF5 file.
+    def __init__(self, filename, mixture_fractions: Optional[Dict[str, float]] = None):
+        """Initializes the TabulatedEOS with data from an HDF5 file.
 
         Args:
             filename (str): Path to the HDF5 file containing the EOS data.
+            mixture_fractions (Optional[Dict[str, float]]): Optional mixture
+                composition. Mixtures are not currently supported and will
+                result in a :class:`NotImplementedError` if provided.
         """
+        if mixture_fractions:
+            raise NotImplementedError(
+                "Mixture EOS is not implemented for TabulatedEOS"
+            )
+
         try:
             with h5py.File(filename, 'r') as f:
                 if not all(key in f for key in ['rho', 'T', 'p', 'e']):
@@ -29,9 +37,16 @@ class TabulatedEOS:
                 self.T_grid = f['T'][:]
                 self.p_table = f['p'][:]
                 self.e_table = f['e'][:]
-                if not (self.rho_grid.ndim == 1 and self.T_grid.ndim == 1 and self.p_table.ndim == 2 and self.e_table.ndim == 2):
+                if not (
+                    self.rho_grid.ndim == 1
+                    and self.T_grid.ndim == 1
+                    and self.p_table.ndim == 2
+                    and self.e_table.ndim == 2
+                ):
                     raise ValueError("EOS table has incorrect dimensions.")
-                if self.p_table.shape != (len(self.rho_grid), len(self.T_grid)) or self.e_table.shape != (len(self.rho_grid), len(self.T_grid)):
+                if self.p_table.shape != (len(self.rho_grid), len(self.T_grid)) or self.e_table.shape != (
+                    len(self.rho_grid), len(self.T_grid)
+                ):
                     raise ValueError("EOS table has inconsistent dimensions.")
             self.p_interp = RegularGridInterpolator((self.rho_grid, self.T_grid), self.p_table)
             self.e_interp = RegularGridInterpolator((self.rho_grid, self.T_grid), self.e_table)

--- a/Simulation/eos_selector.py
+++ b/Simulation/eos_selector.py
@@ -3,22 +3,96 @@
 Selects and initializes the appropriate Equation of State (EOS) model.
 """
 import logging
-from typing import Optional, Dict, Any
-from eos import TabulatedEOS # Assuming TabulatedEOS is the primary implementation
+from typing import Optional, Dict, Any, Union
+from eos import TabulatedEOS  # Assuming TabulatedEOS is the primary implementation
 
 logger = logging.getLogger(__name__)
 
 # Define an EOS base class if strict typing/interface is desired, otherwise rely on duck typing
 # from models import PhysicsModule # Example if EOS should conform to PhysicsModule
 
-def select_eos(backend: str, table_file: Optional[str] = None, mixture_fractions: Optional[Dict[str, float]] = None, **kwargs: Any) -> Any:
+def _parse_mixture_fractions(mixture_fractions: Union[str, Dict[str, float]]) -> Dict[str, float]:
+    """Parse mixture fraction input into a validated dictionary.
+
+    Args:
+        mixture_fractions (Union[str, Dict[str, float]]): Definition of mixture fractions
+            either as a dictionary or as a comma separated string of
+            ``species:fraction`` pairs.
+
+    Returns:
+        Dict[str, float]: Normalized mixture fraction dictionary.
+
+    Raises:
+        ValueError: If the provided definition is invalid or fractions do not
+            sum to one.
+        TypeError: If ``mixture_fractions`` is not a string or dictionary.
+    """
+
+    if mixture_fractions is None:
+        return {}
+
+    parsed: Dict[str, float] = {}
+
+    if isinstance(mixture_fractions, str):
+        for part in mixture_fractions.split(','):
+            part = part.strip()
+            if not part:
+                continue
+            try:
+                species, frac = part.split(':')
+            except ValueError as exc:  # not enough values to unpack
+                raise ValueError(
+                    "Mixture fractions must be in 'species:fraction' format"
+                ) from exc
+            species = species.strip()
+            if not species:
+                raise ValueError("Species name in mixture fractions cannot be empty")
+            try:
+                parsed[species] = float(frac)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Invalid fraction value for species '{species}': {frac}"
+                ) from exc
+    elif isinstance(mixture_fractions, dict):
+        for species, frac in mixture_fractions.items():
+            species = str(species)
+            try:
+                parsed[species] = float(frac)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Invalid fraction value for species '{species}': {frac}"
+                ) from exc
+    else:
+        raise TypeError("mixture_fractions must be a dict or a string")
+
+    if not parsed:
+        raise ValueError("No valid mixture fractions provided")
+
+    if any(frac < 0.0 for frac in parsed.values()):
+        raise ValueError("Mixture fractions must be non-negative")
+
+    total = sum(parsed.values())
+    if abs(total - 1.0) > 1e-6:
+        raise ValueError("Mixture fractions must sum to 1")
+
+    return parsed
+
+
+def select_eos(
+    backend: str,
+    table_file: Optional[str] = None,
+    mixture_fractions: Optional[Union[str, Dict[str, float]]] = None,
+    **kwargs: Any,
+) -> Any:
     """
     Selects and returns an initialized Equation of State object.
 
     Args:
         backend (str): The type of EOS backend to use (e.g., 'tabulated').
         table_file (Optional[str]): Path to the HDF5 file for tabulated EOS.
-        mixture_fractions (Optional[Dict[str, float]]): Fractions for mixture EOS (currently not implemented).
+        mixture_fractions (Optional[Union[str, Dict[str, float]]]): Fractions for
+            mixture EOS. Can be provided as a dictionary or as a comma separated
+            string in the form ``"species1:frac1,species2:frac2"``.
         **kwargs: Additional arguments specific to the EOS backend.
 
     Returns:
@@ -35,13 +109,9 @@ def select_eos(backend: str, table_file: Optional[str] = None, mixture_fractions
             logger.error("Tabulated EOS backend selected, but 'table_file' not provided.")
             raise ValueError("Missing 'table_file' for tabulated EOS backend.")
         try:
-            eos_instance = TabulatedEOS(filename=table_file)
+            parsed_mixture = _parse_mixture_fractions(mixture_fractions) if mixture_fractions is not None else None
+            eos_instance = TabulatedEOS(filename=table_file, mixture_fractions=parsed_mixture)
             logger.info(f"Instantiated TabulatedEOS from file: {table_file}")
-
-            if mixture_fractions is not None:
-                logger.warning("Mixture fractions provided but not currently implemented in TabulatedEOS.")
-                # raise NotImplementedError("Mixture EOS is not implemented yet.")
-
             return eos_instance
         except FileNotFoundError:
             logger.error(f"EOS table file not found: {table_file}")

--- a/tests/test_eos_selector.py
+++ b/tests/test_eos_selector.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+# Ensure Simulation modules are importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "Simulation"))
+from eos_selector import select_eos  # type: ignore
+
+
+def _create_dummy_eos_file(tmp_path: Path) -> Path:
+    file_path = tmp_path / "eos.h5"
+    with h5py.File(file_path, "w") as f:
+        f.create_dataset("rho", data=np.array([1.0, 2.0]))
+        f.create_dataset("T", data=np.array([3.0, 4.0]))
+        f.create_dataset("p", data=np.ones((2, 2)))
+        f.create_dataset("e", data=np.ones((2, 2)))
+    return file_path
+
+
+def test_select_eos_valid_mixture(tmp_path):
+    file_path = _create_dummy_eos_file(tmp_path)
+    with pytest.raises(NotImplementedError):
+        select_eos(
+            "tabulated",
+            table_file=str(file_path),
+            mixture_fractions="A:0.5,B:0.5",
+        )
+
+
+def test_select_eos_mixture_missing_data(tmp_path):
+    file_path = _create_dummy_eos_file(tmp_path)
+    with pytest.raises(ValueError):
+        select_eos(
+            "tabulated",
+            table_file=str(file_path),
+            mixture_fractions="A:0.5",
+        )


### PR DESCRIPTION
## Summary
- Parse and validate mixture fractions for EOS selection
- Wire mixture info into `TabulatedEOS` initialization and raise clear error when unsupported
- Add unit tests covering valid mixtures and missing mixture data

## Testing
- `venv/bin/python -m pytest tests/test_eos_selector.py -q`
- `venv/bin/python -m pytest tests/test_plasma_eos.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa3912f25c832abe490da3610e62eb