### PR TITLE
Refactor field boundary updates

### DIFF
--- a/Simulation/utils.py
+++ b/Simulation/utils.py
@@ -201,19 +201,18 @@ class FieldManager:
                 field = np.roll(field, shift=g, axis=axis)
             return field
 
-        # Apply boundary conditions to each field component
-        self.E = np.stack([apply_bc(self.E[i], f"{axis}_{side}", axis_num)
-                           for axis_num, axis in enumerate(['x', 'y', 'z'])
-                           for side in ['lo', 'hi']
-                           for i in range(3)], axis=0)
-        self.B = np.stack([apply_bc(self.B[i], f"{axis}_{side}", axis_num)
-                           for axis_num, axis in enumerate(['x', 'y', 'z'])
-                           for side in ['lo', 'hi']
-                           for i in range(3)], axis=0)
-        self.J = np.stack([apply_bc(self.J[i], f"{axis}_{side}", axis_num)
-                           for axis_num, axis in enumerate(['x', 'y', 'z'])
-                           for side in ['lo', 'hi']
-                           for i in range(3)], axis=0)
+        # Apply boundary conditions to each field component in-place
+        for field in (self.E, self.B, self.J):
+            for i in range(3):
+                for axis_num, axis in enumerate(['x', 'y', 'z']):
+                    for side in ['lo', 'hi']:
+                        field[i] = apply_bc(field[i], f"{axis}_{side}", axis_num)
+
+        # Verify field shapes remain intact after boundary application
+        expected_shape = (3, self.nx, self.ny, self.nz)
+        for name, field in (('E', self.E), ('B', self.B), ('J', self.J)):
+            if field.shape != expected_shape:
+                raise ValueError(f"{name} has invalid shape {field.shape}; expected {expected_shape}")
 
         # Coordinate with sheath and circuit BCs (example - needs adaptation)
         # if self.sheath_model:


### PR DESCRIPTION
## Summary
- refactor field boundary application to update components in-place
- add shape validation to ensure fields remain 3-component arrays

## Testing
- `venv/bin/python - <<'PY'
from Simulation.utils import FieldManager, SimulationState
import numpy as np

grid_shape=(4,4,4)
fm=FieldManager(grid_shape,1,1,1,(0,0,0),{})
state=SimulationState(grid_shape,1,1,1,(0,0,0),{})
fm.apply_boundary_conditions(state)
print('E',fm.E.shape)
print('B',fm.B.shape)
print('J',fm.J.shape)
PY`
- `venv/bin/pytest -q` *(fails: ModuleNotFoundError: No module named 'dpf2.core_schema')*

------
https://chatgpt.com/codex/tasks/task_e_68aa4239f40c832a81bd27c264a8aef8