### PR TITLE
Maintain rho array in FieldManager and test charge deposition

### DIFF
--- a/Simulation/utils.py
+++ b/Simulation/utils.py
@@ -37,6 +37,8 @@ class FieldManager:
         self.E = np.zeros((3, self.nx, self.ny, self.nz))  # Electric field (3 components)
         self.B = np.zeros((3, self.nx, self.ny, self.nz))  # Magnetic field (3 components)
         self.J = np.zeros((3, self.nx, self.ny, self.nz))  # Current density (3 components)
+        if not hasattr(self, 'rho'):
+            self.rho = np.zeros((self.nx, self.ny, self.nz))  # Charge density
 
         logger.info("FieldManager initialized.")
 
@@ -226,9 +228,12 @@ class FieldManager:
     def deposit_charge(self, charge_density: np.ndarray):
         """Deposits charge from particles to the grid."""
         if charge_density.shape != (self.nx, self.ny, self.nz):
-            raise ValueError(f"Invalid shape for charge_density: expected {(self.nx, self.ny, self.nz)}, got {charge_density.shape}")
-        # self.rho += charge_density # No longer storing rho in FieldManager
-        pass # No longer storing rho in FieldManager
+            raise ValueError(
+                f"Invalid shape for charge_density: expected {(self.nx, self.ny, self.nz)}, got {charge_density.shape}"
+            )
+        if not hasattr(self, 'rho'):
+            self.rho = np.zeros((self.nx, self.ny, self.nz))
+        self.rho += charge_density
 
     def deposit_current(self, current_density: np.ndarray):
         """Deposits current from particles to the grid."""
@@ -251,7 +256,7 @@ class FieldManager:
                 'E': self.E.tolist(),
                 'B': self.B.tolist(),
                 'J': self.J.tolist(),
-                # 'rho': self.rho.tolist() # No longer checkpointing rho
+                'rho': self.rho.tolist()
             }
             return checkpoint_data
         except Exception as e:
@@ -264,7 +269,9 @@ class FieldManager:
             self.E = np.array(data.get('E', self.E))
             self.B = np.array(data.get('B', self.B))
             self.J = np.array(data.get('J', self.J))
-            # self.rho = np.array(data.get('rho', self.rho)) # No longer restarting rho
+            if not hasattr(self, 'rho'):
+                self.rho = np.zeros((self.nx, self.ny, self.nz))
+            self.rho = np.array(data.get('rho', self.rho))
         except Exception as e:
             logger.error(f"Error during restart: {e}")
 

--- a/tests/test_field_manager_charge.py
+++ b/tests/test_field_manager_charge.py
@@ -1,0 +1,13 @@
+import numpy as np
+from Simulation.utils import FieldManager
+
+def test_deposit_charge_updates_rho():
+    grid_shape = (4, 4, 4)
+    fm = FieldManager(grid_shape, 1.0, 1.0, 1.0, (0, 0, 0), {})
+    initial_rho = np.copy(fm.rho)
+    assert np.all(initial_rho == 0)
+    charge = np.ones(grid_shape)
+    fm.deposit_charge(charge)
+    assert np.allclose(fm.rho, charge)
+    fm.deposit_charge(charge)
+    assert np.allclose(fm.rho, 2 * charge)


### PR DESCRIPTION
## Summary
- Track charge density `rho` in `FieldManager` and update via `deposit_charge`
- Include `rho` in checkpoint/restart data
- Add unit test ensuring deposited charge accumulates in `rho`

## Testing
- `pytest tests/test_field_manager_charge.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aa423b91cc832a9030846759e41646