### PR TITLE
Implement Bohm sheath potential and boundary updates

### DIFF
--- a/Simulation/sheath_model.py
+++ b/Simulation/sheath_model.py
@@ -95,10 +95,28 @@ class BohmSheath:
         return np.sqrt(Te_joule / self.ion_mass)
 
     # ------------------------------------------------------------------
-    def _apply_to_field_manager(self, fm: Any, v_bohm: float) -> None:
+    def _sheath_potential(self) -> float:
+        r"""Compute the sheath potential drop using the Bohm criterion.
+
+        A very simple estimate for the potential drop at a floating wall is
+        obtained by equating the ion and electron fluxes, yielding
+
+        .. math::
+
+            \phi_s = T_e \ln\sqrt{m_i/(2\pi m_e)}.
+
+        The electron temperature ``T_e`` is provided in electron-volts, so the
+        resulting potential is also in volts.
+        """
+
+        mass_ratio = self.ion_mass / (2 * np.pi * m_e)
+        return self.electron_temperature * np.log(np.sqrt(mass_ratio))
+
+    # ------------------------------------------------------------------
+    def _apply_to_field_manager(self, fm: Any, sheath_field: float) -> None:
         """Apply boundary condition directly to a FieldManager."""
         E = fm.get_E()
-        E[self.axis, :, :, -1] = v_bohm
+        E[self.axis, :, :, -1] = sheath_field
         fm.update_E(E)
 
     # ------------------------------------------------------------------
@@ -114,17 +132,40 @@ class BohmSheath:
         """
 
         v_bohm = self._bohm_velocity()
+        phi_s = self._sheath_potential()
+
+        # Determine grid spacing along the sheath-normal axis for field estimate
+        dz = 1.0
+        if hasattr(target, 'dz'):
+            dz = getattr(target, 'dz', 1.0)
+        elif hasattr(target, 'field_manager') and hasattr(target.field_manager, 'dz'):
+            dz = target.field_manager.dz
+        sheath_field = phi_s / dz
 
         # Case 1: target is a SimulationState holding a FieldManager
         if hasattr(target, "field_manager"):
             fm = getattr(target, "field_manager", None)
             if fm is not None:
-                self._apply_to_field_manager(fm, v_bohm)
+                self._apply_to_field_manager(fm, sheath_field)
+
+                # Update velocity field if present or create one
+                vel = getattr(target, 'velocity', None)
+                if vel is None:
+                    vel = np.zeros((3,) + target.grid_shape)
+                    target.velocity = vel
+                vel[self.axis, :, :, -1] = v_bohm
+
+                # Update electrostatic potential field
+                phi = getattr(target, 'potential', None)
+                if phi is None:
+                    phi = np.zeros(target.grid_shape)
+                    target.potential = phi
+                phi[:, :, -1] = phi_s
             return
 
         # Case 2: target is itself a FieldManager
         if hasattr(target, "get_E") and hasattr(target, "update_E"):
-            self._apply_to_field_manager(target, v_bohm)
+            self._apply_to_field_manager(target, sheath_field)
             return
 
         # Case 3: raw arrays -- modify the momentum to satisfy Bohm velocity

--- a/tests/test_bohm_sheath.py
+++ b/tests/test_bohm_sheath.py
@@ -6,7 +6,7 @@ import numpy as np
 sim_path = Path(__file__).resolve().parents[1] / 'Simulation'
 sys.path.append(str(sim_path))
 
-from sheath_model import BohmSheath, e_charge
+from sheath_model import BohmSheath, e_charge, m_e
 from utils import FieldManager, SimulationState
 
 
@@ -42,8 +42,21 @@ def test_apply_updates_field_manager():
     state, fm = make_state()
     sheath = BohmSheath(electron_temperature=5.0, ion_mass=1.67e-27)
     sheath.apply(state)
+    mass_ratio = 1.67e-27 / (2 * np.pi * m_e)
+    sheath_potential = 5.0 * np.log(np.sqrt(mass_ratio))
+    expected_field = sheath_potential / fm.dz
+    assert np.allclose(fm.get_E()[2, :, :, -1], expected_field)
+
+
+def test_apply_updates_state_velocity_and_potential():
+    state, _ = make_state()
+    sheath = BohmSheath(electron_temperature=5.0, ion_mass=1.67e-27)
+    sheath.apply(state)
     v_bohm = np.sqrt(e_charge * 5.0 / 1.67e-27)
-    assert np.allclose(fm.get_E()[2, :, :, -1], v_bohm)
+    mass_ratio = 1.67e-27 / (2 * np.pi * m_e)
+    sheath_potential = 5.0 * np.log(np.sqrt(mass_ratio))
+    assert np.allclose(state.velocity[2, :, :, -1], v_bohm)
+    assert np.allclose(state.potential[:, :, -1], sheath_potential)
 
 
 def test_apply_updates_momentum_array():


### PR DESCRIPTION
## Summary
- compute sheath potential from Bohm criterion and derive boundary electric field
- update BohmSheath.apply to set field, velocity, and potential near boundaries
- add tests covering field, velocity, and potential adjustments at sheath boundaries

## Testing
- `pytest tests/test_bohm_sheath.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aa423c4964832abfd340d9a4e7a7f7