### PR TITLE
Integrate WarpX collision API and add collision tests

### DIFF
--- a/Simulation/warp_piclibrary.py
+++ b/Simulation/warp_piclibrary.py
@@ -91,13 +91,25 @@ class PICCollisionHandler:
         v1 = np.asarray(species1.get_velocities())
         v2 = np.asarray(species2.get_velocities())
 
+        # Optional: retrieve particle weights if WarpX exposes them
+        w1 = (
+            np.asarray(species1.get_weights())
+            if hasattr(species1, "get_weights")
+            else None
+        )
+        w2 = (
+            np.asarray(species2.get_weights())
+            if hasattr(species2, "get_weights")
+            else None
+        )
+
         if v1.size == 0 or v2.size == 0:
             logger.debug("One of the species has no particles; skipping collisions")
             return
 
         # --- Estimate plasma parameters ---------------------------------------------------
-        n1 = v1.shape[0]
-        n2 = v2.shape[0]
+        n1 = float(np.sum(w1)) if w1 is not None else float(v1.shape[0])
+        n2 = float(np.sum(w2)) if w2 is not None else float(v2.shape[0])
 
         volume = None
         if hasattr(warp_instance, "get_volume"):
@@ -120,8 +132,11 @@ class PICCollisionHandler:
         Te = m1 * np.mean(speeds1**2) / (3.0 * k_B)
 
         # Collision frequency and probability
-        freq = self.collision_freq_func(ne, Te, **self.kwargs)
-        prob = 1.0 - np.exp(-freq * dt)
+        freq = float(self.collision_freq_func(ne, Te, **self.kwargs))
+        prob = np.clip(1.0 - np.exp(-freq * dt), 0.0, 1.0)
+        if prob <= 0.0:
+            logger.debug("Zero collision probability; skipping")
+            return
 
         # --- Determine colliding pairs ----------------------------------------------------
         num_pairs = min(n1, n2)
@@ -171,7 +186,7 @@ class PICCollisionHandler:
             try:
                 if hasattr(warp_instance, "add_collision_operator"):
                     warp_instance.add_collision_operator(
-                        sp1, sp2, self.collision_freq_func, self.kwargs
+                        sp1, sp2, self.collision_freq_func, **self.kwargs
                     )
                 else:
                     import picmi  # type: ignore

--- a/tests/test_pic_collisions.py
+++ b/tests/test_pic_collisions.py
@@ -49,6 +49,21 @@ def test_apply_collisions_scatter_velocities():
     assert not np.allclose(v_i_before, v_i_after)
 
 
+def test_no_collisions_when_zero_probability():
+    """Collisions should leave velocities unchanged when the rate is zero."""
+    np.random.seed(1)
+    warp = SimpleWarpX()
+    handler = PICCollisionHandler(lambda ne, Te, Z=1.0: 0.0)
+
+    v_e_before = warp.get_particle_container("e").get_velocities()
+    v_i_before = warp.get_particle_container("i").get_velocities()
+
+    handler.apply_collisions("e", "i", warp, dt=0.1)
+
+    assert np.allclose(v_e_before, warp.get_particle_container("e").get_velocities())
+    assert np.allclose(v_i_before, warp.get_particle_container("i").get_velocities())
+
+
 def test_apply_collisions_unknown_species():
     warp = SimpleWarpX()
     handler = PICCollisionHandler(lambda ne, Te: 1.0)


### PR DESCRIPTION
## Summary
- retrieve particle velocities and optional weights from WarpX containers
- compute collision probabilities via `collision_freq_func` and handle zero probability
- register collision operators with `warp_instance`
- test collision scattering and no-collision behavior with mocked WarpX objects

## Testing
- `python -m pytest tests/test_pic_collisions.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68aa462933ec832aa1926ee81964f5fe