### PR TITLE
Support mixed-species tabulated EOS

### DIFF
--- a/Simulation/eos.py
+++ b/Simulation/eos.py
@@ -1,7 +1,8 @@
 import numpy as np
 import h5py
 import logging
-from typing import Dict, Optional
+from pathlib import Path
+from typing import Dict, Optional, Union
 from scipy.interpolate import RegularGridInterpolator
 
 logger = logging.getLogger(__name__)
@@ -10,47 +11,83 @@ class TabulatedEOS:
     """
     Tabulated Equation of State (EOS) for plasma simulations.
 
-    This class loads EOS data from an HDF5 file and provides methods for
+    This class loads EOS data from HDF5 files and provides methods for
     interpolating thermodynamic quantities such as pressure and energy
-    as functions of density and temperature.
+    as functions of density and temperature. When ``mixture_fractions``
+    are supplied, tables for multiple species are combined into a single
+    weighted EOS.
     """
 
-    def __init__(self, filename, mixture_fractions: Optional[Dict[str, float]] = None):
-        """Initializes the TabulatedEOS with data from an HDF5 file.
+    def __init__(self, filename: Union[str, Path, Dict[str, Union[str, Path]]], mixture_fractions: Optional[Dict[str, float]] = None):
+        """Initializes the TabulatedEOS with data from one or more HDF5 files.
 
         Args:
-            filename (str): Path to the HDF5 file containing the EOS data.
-            mixture_fractions (Optional[Dict[str, float]]): Optional mixture
-                composition. Mixtures are not currently supported and will
-                result in a :class:`NotImplementedError` if provided.
+            filename (Union[str, Path, Dict[str, Union[str, Path]]]): Path to the HDF5
+                file containing the EOS data for a single species or a mapping of
+                species names to file paths when ``mixture_fractions`` is supplied.
+            mixture_fractions (Optional[Dict[str, float]]): Optional mixture composition
+                where keys are species names and values are their fractions.
         """
-        if mixture_fractions:
-            raise NotImplementedError(
-                "Mixture EOS is not implemented for TabulatedEOS"
-            )
 
-        try:
-            with h5py.File(filename, 'r') as f:
+        def _load_table(path: Union[str, Path]):
+            with h5py.File(path, 'r') as f:
                 if not all(key in f for key in ['rho', 'T', 'p', 'e']):
                     raise ValueError("EOS table is missing required datasets.")
-                self.rho_grid = f['rho'][:]
-                self.T_grid = f['T'][:]
-                self.p_table = f['p'][:]
-                self.e_table = f['e'][:]
+                rho_grid = f['rho'][:]
+                T_grid = f['T'][:]
+                p_table = f['p'][:]
+                e_table = f['e'][:]
                 if not (
-                    self.rho_grid.ndim == 1
-                    and self.T_grid.ndim == 1
-                    and self.p_table.ndim == 2
-                    and self.e_table.ndim == 2
+                    rho_grid.ndim == 1
+                    and T_grid.ndim == 1
+                    and p_table.ndim == 2
+                    and e_table.ndim == 2
                 ):
                     raise ValueError("EOS table has incorrect dimensions.")
-                if self.p_table.shape != (len(self.rho_grid), len(self.T_grid)) or self.e_table.shape != (
-                    len(self.rho_grid), len(self.T_grid)
+                if p_table.shape != (len(rho_grid), len(T_grid)) or e_table.shape != (
+                    len(rho_grid), len(T_grid)
                 ):
                     raise ValueError("EOS table has inconsistent dimensions.")
+            return rho_grid, T_grid, p_table, e_table
+
+        try:
+            if mixture_fractions:
+                if isinstance(filename, (str, Path)):
+                    base = Path(filename)
+                    species_files = {sp: base / f"{sp}.h5" for sp in mixture_fractions}
+                elif isinstance(filename, dict):
+                    species_files = {sp: Path(path) for sp, path in filename.items()}
+                else:
+                    raise TypeError("filename must be a path or mapping when mixture_fractions are provided")
+
+                first = True
+                for species, path in species_files.items():
+                    rho, T, p_tab, e_tab = _load_table(path)
+                    weight = mixture_fractions.get(species, 0.0)
+                    if first:
+                        self.rho_grid = rho
+                        self.T_grid = T
+                        self.p_table = weight * p_tab
+                        self.e_table = weight * e_tab
+                        first = False
+                    else:
+                        if not (
+                            np.array_equal(self.rho_grid, rho)
+                            and np.array_equal(self.T_grid, T)
+                        ):
+                            raise ValueError("EOS grids for different species do not match.")
+                        self.p_table += weight * p_tab
+                        self.e_table += weight * e_tab
+                logger.info("Mixture EOS tables loaded for species: %s", ", ".join(species_files.keys()))
+            else:
+                rho, T, p_tab, e_tab = _load_table(filename)
+                self.rho_grid = rho
+                self.T_grid = T
+                self.p_table = p_tab
+                self.e_table = e_tab
+                logger.info(f"EOS table loaded from {filename}")
             self.p_interp = RegularGridInterpolator((self.rho_grid, self.T_grid), self.p_table)
             self.e_interp = RegularGridInterpolator((self.rho_grid, self.T_grid), self.e_table)
-            logger.info(f"EOS table loaded from {filename}")
         except Exception as e:
             logger.error(f"Error loading EOS table: {e}")
             raise

--- a/Simulation/eos_selector.py
+++ b/Simulation/eos_selector.py
@@ -3,6 +3,7 @@
 Selects and initializes the appropriate Equation of State (EOS) model.
 """
 import logging
+from pathlib import Path
 from typing import Optional, Dict, Any, Union
 from eos import TabulatedEOS  # Assuming TabulatedEOS is the primary implementation
 
@@ -109,8 +110,18 @@ def select_eos(
             logger.error("Tabulated EOS backend selected, but 'table_file' not provided.")
             raise ValueError("Missing 'table_file' for tabulated EOS backend.")
         try:
-            parsed_mixture = _parse_mixture_fractions(mixture_fractions) if mixture_fractions is not None else None
-            eos_instance = TabulatedEOS(filename=table_file, mixture_fractions=parsed_mixture)
+            parsed_mixture = _parse_mixture_fractions(mixture_fractions) if mixture_fractions is not None else {}
+            if parsed_mixture:
+                base = Path(table_file)
+                species_files: Dict[str, str] = {}
+                for species in parsed_mixture:
+                    species_path = base / f"{species}.h5"
+                    if not species_path.is_file():
+                        raise ValueError(f"Missing EOS data for species '{species}'")
+                    species_files[species] = str(species_path)
+                eos_instance = TabulatedEOS(filename=species_files, mixture_fractions=parsed_mixture)
+            else:
+                eos_instance = TabulatedEOS(filename=table_file)
             logger.info(f"Instantiated TabulatedEOS from file: {table_file}")
             return eos_instance
         except FileNotFoundError:

--- a/tests/test_eos_selector.py
+++ b/tests/test_eos_selector.py
@@ -8,33 +8,35 @@ import pytest
 # Ensure Simulation modules are importable
 sys.path.append(str(Path(__file__).resolve().parents[1] / "Simulation"))
 from eos_selector import select_eos  # type: ignore
+from eos import TabulatedEOS  # type: ignore
 
 
-def _create_dummy_eos_file(tmp_path: Path) -> Path:
-    file_path = tmp_path / "eos.h5"
+def _create_species_eos_file(tmp_path: Path, species: str, p_val: float = 1.0, e_val: float = 1.0) -> Path:
+    file_path = tmp_path / f"{species}.h5"
     with h5py.File(file_path, "w") as f:
         f.create_dataset("rho", data=np.array([1.0, 2.0]))
         f.create_dataset("T", data=np.array([3.0, 4.0]))
-        f.create_dataset("p", data=np.ones((2, 2)))
-        f.create_dataset("e", data=np.ones((2, 2)))
+        f.create_dataset("p", data=np.full((2, 2), p_val))
+        f.create_dataset("e", data=np.full((2, 2), e_val))
     return file_path
 
 
 def test_select_eos_valid_mixture(tmp_path):
-    file_path = _create_dummy_eos_file(tmp_path)
-    with pytest.raises(NotImplementedError):
-        select_eos(
-            "tabulated",
-            table_file=str(file_path),
-            mixture_fractions="A:0.5,B:0.5",
-        )
+    _create_species_eos_file(tmp_path, "A")
+    _create_species_eos_file(tmp_path, "B")
+    eos = select_eos(
+        "tabulated",
+        table_file=str(tmp_path),
+        mixture_fractions="A:0.5,B:0.5",
+    )
+    assert isinstance(eos, TabulatedEOS)
 
 
 def test_select_eos_mixture_missing_data(tmp_path):
-    file_path = _create_dummy_eos_file(tmp_path)
+    _create_species_eos_file(tmp_path, "A")
     with pytest.raises(ValueError):
         select_eos(
             "tabulated",
-            table_file=str(file_path),
-            mixture_fractions="A:0.5",
+            table_file=str(tmp_path),
+            mixture_fractions="A:0.5,B:0.5",
         )

--- a/tests/test_tabulated_mixture_eos.py
+++ b/tests/test_tabulated_mixture_eos.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+# Ensure Simulation modules are importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "Simulation"))
+from eos import TabulatedEOS  # type: ignore
+
+
+def _create_species_file(tmp_path: Path, species: str, p_val: float, e_val: float) -> Path:
+    path = tmp_path / f"{species}.h5"
+    with h5py.File(path, "w") as f:
+        f.create_dataset("rho", data=np.array([1.0, 2.0]))
+        f.create_dataset("T", data=np.array([3.0, 4.0]))
+        f.create_dataset("p", data=np.full((2, 2), p_val))
+        f.create_dataset("e", data=np.full((2, 2), e_val))
+    return path
+
+
+def test_mixed_eos_weighted_combination(tmp_path):
+    path_a = _create_species_file(tmp_path, "A", p_val=1.0, e_val=10.0)
+    path_b = _create_species_file(tmp_path, "B", p_val=2.0, e_val=20.0)
+    fractions = {"A": 0.25, "B": 0.75}
+
+    mix_eos = TabulatedEOS(
+        filename={"A": str(path_a), "B": str(path_b)},
+        mixture_fractions=fractions,
+    )
+    eos_a = TabulatedEOS(str(path_a))
+    eos_b = TabulatedEOS(str(path_b))
+
+    rho = np.array([1.0])
+    T = np.array([3.0])
+
+    expected_p = fractions["A"] * eos_a.ion_pressure(rho, T) + fractions["B"] * eos_b.ion_pressure(rho, T)
+    expected_e = fractions["A"] * eos_a.ion_energy(rho, T) + fractions["B"] * eos_b.ion_energy(rho, T)
+
+    np.testing.assert_allclose(mix_eos.ion_pressure(rho, T), expected_p)
+    np.testing.assert_allclose(mix_eos.ion_energy(rho, T), expected_e)


### PR DESCRIPTION
## Summary
- extend TabulatedEOS to combine multiple species tables using mixture fractions
- validate required species files and pass fractions in eos_selector
- add tests covering mixed EOS selection and weighted results

## Testing
- `pytest tests/test_plasma_eos.py tests/test_eos_selector.py tests/test_tabulated_mixture_eos.py -q` *(fails: No module named 'h5py')*


------
https://chatgpt.com/codex/tasks/task_e_68aa462dbb78832aa31af4fb61d80aa6