### PR TITLE
Implement HDF5-based Tabulated EOS with interpolation

### DIFF
--- a/dpf2/eos/__init__.py
+++ b/dpf2/eos/__init__.py
@@ -12,7 +12,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
+import h5py
 import numpy as np
+from scipy.interpolate import RegularGridInterpolator
 
 from ..core_schema import EOSModel
 
@@ -53,30 +55,53 @@ class IdealGasEOS:
 RealGasEOS = IdealGasEOS
 
 
-@dataclass
 class TabulatedEOS:
-    """Very small placeholder for a tabulated SESAME-style EOS.
+    """Equation of state based on a tabulated 2-D data set.
 
-    The constructor reads a CSV file with three columns ``rho,T,P`` and
-    determines a single proportionality constant assuming
-    ``P = const * rho * T``.  Real implementations would perform bilinear
-    interpolation of the tabulated data; this lightweight approach keeps
-    dependencies minimal while exercising the code paths.
+    The table is expected to be stored in an HDF5 file with datasets
+    ``rho`` and ``e`` defining the grid axes and ``p`` and ``T`` providing
+    the pressure and temperature values on that grid.  Bilinear
+    interpolation is performed using :class:`scipy.interpolate.RegularGridInterpolator`.
     """
 
-    table_path: Path
-    cv: float = 1.0
+    def __init__(self, filename: str | Path, mixture_fractions: dict[str, float] | None = None):
+        if mixture_fractions:
+            raise NotImplementedError("Mixture EOS is not implemented for TabulatedEOS")
 
-    def __post_init__(self) -> None:
-        data = np.loadtxt(self.table_path, delimiter=",", skiprows=1)
-        self._const = float(np.mean(data[:, 2] / (data[:, 0] * data[:, 1])))
+        with h5py.File(filename, "r") as f:
+            if not all(key in f for key in ("rho", "e", "p", "T")):
+                raise ValueError("EOS table is missing required datasets.")
+            self.rho_grid = f["rho"][:]
+            self.e_grid = f["e"][:]
+            self.p_table = f["p"][:]
+            self.T_table = f["T"][:]
+
+        if not (
+            self.rho_grid.ndim == 1
+            and self.e_grid.ndim == 1
+            and self.p_table.ndim == 2
+            and self.T_table.ndim == 2
+        ):
+            raise ValueError("EOS table has incorrect dimensions.")
+
+        expected_shape = (len(self.rho_grid), len(self.e_grid))
+        if self.p_table.shape != expected_shape or self.T_table.shape != expected_shape:
+            raise ValueError("EOS table has inconsistent dimensions.")
+
+        self.p_interp = RegularGridInterpolator((self.rho_grid, self.e_grid), self.p_table)
+        self.T_interp = RegularGridInterpolator((self.rho_grid, self.e_grid), self.T_table)
 
     def pressure(self, rho: np.ndarray, e: np.ndarray) -> np.ndarray:
-        T = self.temperature(rho, e)
-        return self._const * rho * T
+        """Interpolate pressure for density ``rho`` and specific energy ``e``."""
 
-    def temperature(self, rho: np.ndarray, e: np.ndarray) -> np.ndarray:  # noqa: ARG002
-        return e / self.cv
+        points = np.stack([rho, e], axis=-1)
+        return self.p_interp(points)
+
+    def temperature(self, rho: np.ndarray, e: np.ndarray) -> np.ndarray:
+        """Interpolate temperature for density ``rho`` and specific energy ``e``."""
+
+        points = np.stack([rho, e], axis=-1)
+        return self.T_interp(points)
 
 
 def create_eos(model: EOSModel, *, table_path: Path | None = None, gamma: float = 5.0 / 3.0) -> EOSBase:

--- a/tests/test_new_physics_packages.py
+++ b/tests/test_new_physics_packages.py
@@ -1,4 +1,5 @@
 import numpy as np
+import h5py
 
 from dpf2.eos import TabulatedEOS, create_eos
 from dpf2.chemistry import FlychkTable
@@ -7,12 +8,28 @@ from dpf2.hall_mhd_solver import HallMHDSolver, MHDState
 from core_schema import EOSModel
 
 
-def test_tabulated_eos_pressure():
-    eos = TabulatedEOS("tests/data/sesame_dummy.csv")
+def _make_test_table(path):
+    rho = np.array([1.0, 2.0])
+    e = np.array([100.0, 200.0])
+    p = rho[:, None] * e[None, :]
+    T = e[None, :] / rho[:, None]
+    with h5py.File(path, "w") as f:
+        f.create_dataset("rho", data=rho)
+        f.create_dataset("e", data=e)
+        f.create_dataset("p", data=p)
+        f.create_dataset("T", data=T)
+
+
+def test_tabulated_eos_pressure(tmp_path):
+    file_path = tmp_path / "eos.h5"
+    _make_test_table(file_path)
+    eos = TabulatedEOS(file_path)
     rho = np.array([1.5])
-    e = np.array([450.0])
+    e = np.array([150.0])
     p = eos.pressure(rho, e)
-    assert np.allclose(p, rho * 450.0)
+    T = eos.temperature(rho, e)
+    assert np.allclose(p, rho * e)
+    assert np.allclose(T, e / rho)
 
 
 def test_flychk_interpolation():
@@ -31,8 +48,10 @@ def test_monte_carlo_radiation_loss():
     assert loss.min() >= 0
 
 
-def test_hall_mhd_solver_with_models():
-    eos = create_eos(EOSModel.TABULATED, table_path="tests/data/sesame_dummy.csv")
+def test_hall_mhd_solver_with_models(tmp_path):
+    file_path = tmp_path / "eos.h5"
+    _make_test_table(file_path)
+    eos = create_eos(EOSModel.TABULATED, table_path=file_path)
     chem = FlychkTable("tests/data/flychk_dummy.csv")
     rad = MonteCarloRadiation(BremsstrahlungModel(coeff=1e-6), rng_seed=0)
     solver = HallMHDSolver(eos=eos, chemistry=chem, radiation=rad)

--- a/tests/test_tabulated_eos_table.py
+++ b/tests/test_tabulated_eos_table.py
@@ -1,0 +1,26 @@
+import numpy as np
+import h5py
+
+from dpf2.eos import TabulatedEOS
+
+
+def make_table(path):
+    rho = np.array([1.0, 2.0])
+    e = np.array([10.0, 20.0])
+    p = rho[:, None] * e[None, :]
+    T = e[None, :] / rho[:, None]
+    with h5py.File(path, "w") as f:
+        f.create_dataset("rho", data=rho)
+        f.create_dataset("e", data=e)
+        f.create_dataset("p", data=p)
+        f.create_dataset("T", data=T)
+
+
+def test_interpolation(tmp_path):
+    path = tmp_path / "table.h5"
+    make_table(path)
+    eos = TabulatedEOS(path)
+    rho = np.array([1.5])
+    e = np.array([15.0])
+    assert np.allclose(eos.pressure(rho, e), rho * e)
+    assert np.allclose(eos.temperature(rho, e), e / rho)


### PR DESCRIPTION
## Summary
- Replace placeholder TabulatedEOS with HDF5-backed 2‑D table and bilinear interpolation for pressure and temperature
- Add synthetic EOS table builder in tests and update physics package tests to use HDF5 data
- Introduce dedicated TabulatedEOS interpolation test for known outputs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `pip install numpy h5py scipy pydantic werkzeug` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4633ae20832ab2ebd7e2fe974377