### PR TITLE
Add opacity parameter validation and tests

### DIFF
--- a/Simulation/radiation_model.py
+++ b/Simulation/radiation_model.py
@@ -282,20 +282,33 @@ class RadiationModel(PhysicsModule):
     def _compute_opacity(self, Te, ne, Z):
         """Computes the opacity based on the selected model."""
         if self.opacity_model == "constant":
-            return np.array(self.opacity_params.get("constant_opacity", 1.0))
+            if "constant_opacity" not in self.opacity_params:
+                raise ValueError("'constant_opacity' parameter required for constant opacity model")
+            return np.array(self.opacity_params["constant_opacity"])
         elif self.opacity_model == "temperature_dependent":
-            base = self.opacity_params.get("base", 0.0)
-            alpha = self.opacity_params.get("alpha", 1.0)
-            beta = self.opacity_params.get("beta", 1.0)
+            try:
+                base = self.opacity_params["base"]
+                alpha = self.opacity_params["alpha"]
+                beta = self.opacity_params["beta"]
+            except KeyError as exc:
+                raise ValueError(f"Missing opacity parameter for temperature_dependent model: {exc.args[0]}") from exc
             return np.array(base + alpha * np.power(Te, beta))
         elif self.opacity_model == "density_dependent":
-            base = self.opacity_params.get("base", 0.0)
-            alpha = self.opacity_params.get("alpha", 1.0)
+            try:
+                base = self.opacity_params["base"]
+                alpha = self.opacity_params["alpha"]
+            except KeyError as exc:
+                raise ValueError(f"Missing opacity parameter for density_dependent model: {exc.args[0]}") from exc
+
             if self.opacity_params.get("use_Z", False):
-                exponent = self.opacity_params.get("Z_exponent", 1.0)
+                if "Z_exponent" not in self.opacity_params:
+                    raise ValueError("'Z_exponent' parameter required when use_Z is True")
+                exponent = self.opacity_params["Z_exponent"]
                 quantity = Z
             else:
-                exponent = self.opacity_params.get("ne_exponent", 1.0)
+                if "ne_exponent" not in self.opacity_params:
+                    raise ValueError("'ne_exponent' parameter required when use_Z is False")
+                exponent = self.opacity_params["ne_exponent"]
                 quantity = ne
             return np.array(base + alpha * np.power(quantity, exponent))
         else:

--- a/tests/test_radiation_opacity.py
+++ b/tests/test_radiation_opacity.py
@@ -1,9 +1,30 @@
 import sys
 import types
-import numpy as np
+import pytest
+
+# Provide a minimal numpy stub for the methods used in these tests
+np_stub = types.SimpleNamespace(
+    array=lambda x: x,
+    power=lambda a, b: a ** b,
+    allclose=lambda a, b, rtol=1e-5, atol=1e-8: abs(a - b) <= (atol + rtol * abs(b)),
+    pi=3.141592653589793,
+    ndarray=object,
+)
+sys.modules.setdefault("numpy", np_stub)
+np = np_stub
 
 # Stub out dependencies not needed for opacity calculations
 sys.modules.setdefault("amrex", types.ModuleType("amrex"))
+sys.modules.setdefault("h5py", types.ModuleType("h5py"))
+sys.modules.setdefault("adios2", types.ModuleType("adios2"))
+numba_stub = types.ModuleType("numba")
+numba_stub.njit = lambda *a, **k: (lambda f: f)
+numba_stub.prange = range
+sys.modules.setdefault("numba", numba_stub)
+scipy_interp = types.ModuleType("scipy.interpolate")
+scipy_interp.RegularGridInterpolator = lambda *a, **k: None
+sys.modules.setdefault("scipy", types.ModuleType("scipy"))
+sys.modules.setdefault("scipy.interpolate", scipy_interp)
 models_stub = types.ModuleType("models")
 models_stub.PhysicsModule = object
 models_stub.SimulationState = object
@@ -45,8 +66,26 @@ def test_density_dependent_opacity_ne():
 
 
 def test_density_dependent_opacity_Z():
-    rm = _make_model("density_dependent", {"alpha": 0.3, "Z_exponent": 2.0, "use_Z": True})
+    rm = _make_model("density_dependent", {"base": 0.0, "alpha": 0.3, "Z_exponent": 2.0, "use_Z": True})
     Z = 5.0
-    expected = 0.3 * Z ** 2.0
+    expected = 0.0 + 0.3 * Z ** 2.0
     out = rm._compute_opacity(Te=0.0, ne=0.0, Z=Z)
     assert np.allclose(out, expected)
+
+
+def test_missing_constant_param():
+    rm = _make_model("constant", {})
+    with pytest.raises(ValueError):
+        rm._compute_opacity(Te=0.0, ne=0.0, Z=0.0)
+
+
+def test_missing_temperature_param():
+    rm = _make_model("temperature_dependent", {"base": 1.0, "alpha": 0.5})
+    with pytest.raises(ValueError):
+        rm._compute_opacity(Te=1.0, ne=0.0, Z=0.0)
+
+
+def test_missing_density_param():
+    rm = _make_model("density_dependent", {"base": 0.1, "alpha": 0.2})
+    with pytest.raises(ValueError):
+        rm._compute_opacity(Te=0.0, ne=1.0, Z=0.0)


### PR DESCRIPTION
## Summary
- validate opacity model parameters and raise clear errors when missing
- add unit tests exercising constant, temperature-dependent, and density-dependent opacity models including missing parameter cases
- provide lightweight numpy and dependency stubs for isolated opacity testing

## Testing
- `pytest tests/test_radiation_opacity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa4a85b9b4832a91aa503533e1b78f