### PR TITLE
Unify base class imports

### DIFF
--- a/dpf2/__init__.py
+++ b/dpf2/__init__.py
@@ -3,7 +3,7 @@
 from .circuit_solver import RLCCircuit, CircuitSolver
 from .pinch_models import AnalyticPinchModel, SemiAnalyticPinchModel
 from .simulation_engine import SimulationEngine
-from .core import PlasmaSolverBase, CircuitSolverBase, DiagnosticsBase
+from .core.bases import PlasmaSolverBase, CircuitSolverBase, DiagnosticsBase
 from .ai import SurrogateModel, TorchSurrogateModel, ONNXSurrogateModel
 from .hall_mhd_solver import HallMHDSolver, MHDState
 

--- a/dpf2/hall_mhd_solver.py
+++ b/dpf2/hall_mhd_solver.py
@@ -15,7 +15,7 @@ from typing import Any, Callable
 import numpy as np
 from scipy.constants import mu_0
 
-from .core import PlasmaSolverBase
+from dpf2.core.bases import PlasmaSolverBase
 from .eos import EOSBase, IdealGasEOS
 from .chemistry import ChemistryModel, SahaEquilibrium
 from .radiation import RadiationBase

--- a/dpf2/solvers/axisymmetric_hlld.py
+++ b/dpf2/solvers/axisymmetric_hlld.py
@@ -29,7 +29,7 @@ from typing import Dict
 
 import numpy as np
 
-from ..core.bases import PlasmaSolverBase
+from dpf2.core.bases import PlasmaSolverBase
 
 State = Dict[str, np.ndarray]
 


### PR DESCRIPTION
## Summary
- centralize PlasmaSolverBase, CircuitSolverBase, and DiagnosticsBase imports to `dpf2.core.bases`
- adjust solver modules to reference the canonical base classes

## Testing
- `pytest` *(fails: No module named 'pydantic'; No module named 'numpy'; No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_68aa4a8cca40832ab09c43ecb2dd44ac