### PR TITLE
Ensure ModuleRegistry only accepts PhysicsModule subclasses

### DIFF
--- a/Simulation/module_registry.py
+++ b/Simulation/module_registry.py
@@ -3,8 +3,6 @@ import importlib
 import inspect
 import logging
 import os
-import sys
-from abc import ABC
 from typing import Dict, Type, Any, List, Optional
 from pydantic import BaseModel, ValidationError
 
@@ -46,9 +44,9 @@ class ModuleRegistry:
         if not inspect.isclass(module_class):
             raise TypeError("module_class must be a class.")
 
-        # Check if module_class is a subclass of ABC
-        if not issubclass(module_class, ABC):
-            raise TypeError("module_class must be a subclass of ABC (Abstract Base Class).")
+        # Check if module_class is a subclass of PhysicsModule
+        if not issubclass(module_class, PhysicsModule):
+            raise TypeError("module_class must be a subclass of PhysicsModule.")
 
         self.modules[module_class] = {
             'config_schema': config_schema,

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -1,0 +1,13 @@
+import pytest
+
+from Simulation.module_registry import ModuleRegistry
+
+
+class NotPhysics:
+    pass
+
+
+def test_register_non_physicsmodule_raises_type_error():
+    registry = ModuleRegistry()
+    with pytest.raises(TypeError, match="subclass of PhysicsModule"):
+        registry.register(NotPhysics)


### PR DESCRIPTION
## Summary
- Validate registered modules against `PhysicsModule` instead of `ABC`
- Adjust error messaging for improper module registration
- Add regression test for rejecting non-`PhysicsModule` classes

## Testing
- `pytest tests/test_module_registry.py -q` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68aa4ff009dc832a8a64feb88094c96b