### PR TITLE
Add per-process resource limits for simulations

### DIFF
--- a/Simulation/config_schema.py
+++ b/Simulation/config_schema.py
@@ -176,6 +176,8 @@ class ServerConfig(BaseModel):
     max_simultaneous_simulations: int = Field(5, gt=0, description="Maximum number of simultaneous simulations")
     telemetry_interval: float = Field(0.1, gt=0, description="Interval for sending telemetry data [s]")
     data_directory: str = Field("data", description="Directory to store simulation data")
+    cpu_time_limit: int = Field(60, gt=0, description="CPU time limit per simulation in seconds")
+    memory_limit: int = Field(1024**3, gt=0, description="Address space limit per simulation in bytes")
     # Add other parameters as needed
 
 class SheathConfig(BaseModel):

--- a/Simulation/dpf_simulator_server.py
+++ b/Simulation/dpf_simulator_server.py
@@ -69,8 +69,12 @@ class SimulationInterface:
         """
         try:
             self._sim.run()
+        except MemoryError as exc:
+            logger.exception("Simulation exceeded memory limit")
+            raise SimulationError("Simulation exceeded memory limit") from exc
         except Exception as exc:  # pragma: no cover - defensive
             logger.exception("Simulation run failed: %s", exc)
+            raise SimulationError(f"Simulation run failed: {exc}") from exc
         finally:
             if hasattr(self._sim, "finalize"):
                 try:
@@ -127,6 +131,7 @@ class SimulationManager:
     def __init__(self):
         self.simulations: Dict[str, SimulationInterface] = {}
         self.sim_threads: Dict[str, threading.Thread] = {}
+        self.sim_errors: Dict[str, Exception] = {}
 
     def create_simulation(self, config: Dict[str, Any]) -> str:
         sim_id = str(uuid.uuid4())
@@ -152,7 +157,17 @@ class SimulationManager:
         sim = self.simulations.get(sim_id)
         if not sim:
             raise SimulationError(f"Simulation {sim_id} not found")
-        thread = threading.Thread(target=sim.run, daemon=True)
+
+        def _run_with_limits():
+            cpu_limit = app.config.get('CPU_TIME_LIMIT')
+            mem_limit = app.config.get('MEMORY_LIMIT')
+            apply_resource_limits(cpu_limit, mem_limit)
+            try:
+                sim.run()
+            except SimulationError as exc:
+                self.sim_errors[sim_id] = exc
+
+        thread = threading.Thread(target=_run_with_limits, daemon=True)
         self.sim_threads[sim_id] = thread
         thread.start()
 
@@ -214,6 +229,13 @@ def requires_auth(f):
     return decorated
 
 # ——— Resource Management ———
+def apply_resource_limits(cpu_seconds: int | None, memory_bytes: int | None) -> None:
+    """Apply CPU time and address space limits for the current process."""
+    if cpu_seconds is not None:
+        resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds))
+    if memory_bytes is not None:
+        resource.setrlimit(resource.RLIMIT_AS, (memory_bytes, memory_bytes))
+
 def limit_simulations(f):
     @wraps(f)
     def decorated(*args, **kwargs):

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -1,0 +1,96 @@
+import subprocess
+import sys
+import textwrap
+
+
+def test_resource_limit_violation_triggers_simulation_error():
+    script = textwrap.dedent(
+        """
+        import types
+        import sys
+        sys.modules['sympy'] = types.SimpleNamespace(symbols=lambda *args, **kwargs: (None, None))
+        class DummyFlask:
+            def __init__(self, *a, **k):
+                self.config = {}
+            def route(self, *a, **k):
+                def decorator(f):
+                    return f
+                return decorator
+            def test_client(self):
+                return None
+
+        class DummySock:
+            def __init__(self, *a, **k):
+                pass
+            def route(self, *a, **k):
+                def decorator(f):
+                    return f
+                return decorator
+
+        sys.modules['flask'] = types.SimpleNamespace(
+            Flask=DummyFlask,
+            request=None, jsonify=lambda *a, **k: None,
+            send_file=lambda *a, **k: None, abort=lambda *a, **k: None,
+        )
+        sys.modules['flask_sock'] = types.SimpleNamespace(Sock=DummySock)
+        sys.modules['werkzeug.security'] = types.SimpleNamespace(
+            generate_password_hash=lambda s: s,
+            check_password_hash=lambda h, p: True,
+        )
+        sys.modules['werkzeug.utils'] = types.SimpleNamespace(secure_filename=lambda s: s)
+        sys.modules['dpf_simulation'] = types.SimpleNamespace(DPFSimulation=object, ConfigurationError=Exception)
+        sys.modules['config_schema'] = types.SimpleNamespace(ServerConfig=object, FieldManagerConfig=object)
+        class DummyFieldManager:
+            def __init__(self, *a, **k):
+                pass
+        sys.modules['utils'] = types.SimpleNamespace(FieldManager=DummyFieldManager)
+        from Simulation import dpf_simulator_server as server
+        from werkzeug.security import generate_password_hash
+
+        class DummySimulation:
+            def __init__(self, config, field_manager=None):
+                pass
+            def run(self):
+                bytearray(300 * 1024 * 1024)
+
+        server.DPFSimulation = DummySimulation
+
+        app = server.app
+        app.config['ADMIN_USERNAME'] = 'admin'
+        app.config['ADMIN_PASSWORD_HASH'] = generate_password_hash('secret')
+        app.config['MAX_SIMULTANEOUS_SIMULATIONS'] = 1
+        app.config['TELEMETRY_INTERVAL'] = 0.01
+        app.config['CPU_TIME_LIMIT'] = 1
+        app.config['MEMORY_LIMIT'] = 150 * 1024 * 1024
+
+        config = {
+            'dx': 1.0,
+            'dy': 1.0,
+            'dz': 1.0,
+            'sim_time': 0.05,
+            'dt_init': 0.01,
+            'grid_shape': [1, 1, 1],
+            'domain_lo': [0.0, 0.0, 0.0],
+            'circuit': {
+                'C': 1.0,
+                'V0': 1.0,
+                'L0': 1.0,
+                'R0': 0.1,
+                'anode_radius': 0.01,
+                'cathode_radius': 0.02,
+            },
+        }
+
+        sim_id = server.simulation_manager.create_simulation(config)
+        server.simulation_manager.run_simulation(sim_id)
+        thread = server.simulation_manager.get_simulation_thread(sim_id)
+        thread.join()
+
+        if sim_id not in server.simulation_manager.sim_errors:
+            raise RuntimeError('Simulation should have failed')
+        raise server.SimulationError('limit exceeded')
+        """
+    )
+    proc = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True)
+    assert proc.returncode != 0
+    assert 'SimulationError' in proc.stderr


### PR DESCRIPTION
## Summary
- add ServerConfig fields for CPU time and memory limits
- enforce limits in simulator server via resource.setrlimit
- test subprocess limit violation raises SimulationError

## Testing
- `pytest tests/test_resource_limits.py -q`
- `pytest tests/test_api_endpoints.py::test_start_stop_and_retrieve_state -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*


------
https://chatgpt.com/codex/tasks/task_e_68aa4ff3c75c832a92100efd0265f086