### PR TITLE
Ensure hybrid step triggers circuit and radiation side effects

### DIFF
--- a/Simulation/hybrid_controller.py
+++ b/Simulation/hybrid_controller.py
@@ -252,6 +252,17 @@ class HybridController(PhysicsModule):
                 fluid_data = self._extract_fluid_data(state, reg)
                 fb[reg] = self._run_pic_subcycles(fluid_data, reg, dt)
 
+            # 3. Apply feedback from PIC to fluid state
+            self._apply_feedback(state, fb, regions)
+
+            # 4. Circuit update
+            self.circuit.step(state, dt)
+
+            # 5. Radiation effects
+            self.radiation.apply(state, dt)
+
+            # 6. Energy correction to maintain conservation
+            self._energy_correction(E_pre)
 
         except Exception as e:
             logger.error(f"Error during hybrid step: {e}")

--- a/tests/test_circuit_model.py
+++ b/tests/test_circuit_model.py
@@ -15,7 +15,9 @@ class DummyCollision:
 
 
 class DummyFieldManager:
-    pass
+    def get_J(self):
+        """Return a zero current density for testing."""
+        return 0.0
 
 
 def test_negative_parameters_raise():

--- a/tests/test_hybrid_integration.py
+++ b/tests/test_hybrid_integration.py
@@ -60,6 +60,7 @@ def test_hybrid_step_combines_fluid_and_pic():
         def __init__(self):
             self.state = {'density': density}
             self.step_called = False
+            self.energy_increments = []
 
         def get_total_energy(self):
             return 0.0
@@ -68,7 +69,7 @@ def test_hybrid_step_combines_fluid_and_pic():
             self.step_called = True
 
         def increment_internal_energy(self, corr):
-            pass
+            self.energy_increments.append(corr)
 
     class DummyPIC:
         def __init__(self):
@@ -86,16 +87,27 @@ def test_hybrid_step_combines_fluid_and_pic():
             }
 
     class DummyCircuit:
+        def __init__(self):
+            self.step_calls = 0
+
         def step(self, state, dt):
-            pass
+            self.step_calls += 1
+            state.circuit_steps = getattr(state, 'circuit_steps', 0) + 1
 
     class DummyRadiation:
+        def __init__(self):
+            self.apply_calls = 0
+
         def apply(self, state, dt):
-            pass
+            self.apply_calls += 1
+            state.radiation_calls = getattr(state, 'radiation_calls', 0) + 1
 
     class DummySheath:
+        def __init__(self):
+            self.apply_calls = 0
+
         def apply(self, state, phi):
-            pass
+            self.apply_calls += 1
 
     cfg = type('cfg', (), {})()
     cfg.criteria = type('criteria', (), {
@@ -116,12 +128,19 @@ def test_hybrid_step_combines_fluid_and_pic():
 
     fluid = DummyFluid()
     pic = DummyPIC()
-    controller = HybridController(cfg, fluid, pic, DummyCircuit(), DummyRadiation(), None, DummySheath(), fm)
+    circuit = DummyCircuit()
+    radiation = DummyRadiation()
+    sheath = DummySheath()
+    controller = HybridController(cfg, fluid, pic, circuit, radiation, None, sheath, fm)
 
     region = (slice(0, 2), slice(0, 2), slice(0, 2))
     controller.hybrid_step(state, [region], dt=1.0)
 
     assert fluid.step_called
     assert pic.step_calls > 0
+    assert circuit.step_calls == 1
+    assert radiation.apply_calls == 1
+    assert getattr(state, 'circuit_steps', 0) == 1
+    assert getattr(state, 'radiation_calls', 0) == 1
     assert np.allclose(state.velocity, 0.1)
     assert np.allclose(state.pressure, 0.2)


### PR DESCRIPTION
## Summary
- verify `HybridController.hybrid_step` applies PIC feedback and updates circuit and radiation models
- replace `pass`-stubs in integration tests with lightweight mocks and assert side effects
- add minimal field manager mock for circuit tests

## Testing
- `pytest tests/test_hybrid_integration.py tests/test_circuit_model.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aa4ff64d54832a8e905526163f5851