### PR TITLE
Improve DPF simulation run loop and add regression test

### DIFF
--- a/Simulation/dpf_simulation.py
+++ b/Simulation/dpf_simulation.py
@@ -151,10 +151,63 @@ class DPFSimulation:
     def run(self):
         """Runs the simulation."""
         try:
-            # Main loop
             while self.current_time < self.config.sim_time:
+                # --- determine timestep ---
+                if hasattr(self.solver, "compute_optimal_dt"):
+                    self.dt = self.solver.compute_optimal_dt()
+                elif hasattr(self.solver, "compute_dt"):
+                    self.dt = self.solver.compute_dt()
+                if self.dt is None or self.dt <= 0.0:
+                    raise RuntimeError("Invalid time step")
+                # clip to remaining simulation time
+                if self.current_time + self.dt > self.config.sim_time:
+                    self.dt = self.config.sim_time - self.current_time
+
+                # --- advance primary solver or hybrid controller ---
+                if "hybrid" in self.modules:
+                    try:
+                        self.modules["hybrid"].apply(self.state, self.dt)
+                    except Exception as exc:
+                        logger.error(f"Hybrid controller error: {exc}")
+                else:
+                    self.solver.step(self.dt)
+                    if self.pic_solver:
+                        self.pic_solver.step()
+
+                # --- collision and radiation modules ---
+                for name in ("collision", "radiation"):
+                    module = self.modules.get(name)
+                    if module:
+                        try:
+                            module.apply(self.state, self.dt)
+                        except Exception as exc:
+                            logger.error(f"{name.capitalize()} module error: {exc}")
+
+                # --- circuit update ---
+                try:
+                    self.circuit.step(self.state, self.dt)
+                except Exception as exc:
+                    logger.error(f"Circuit step failed: {exc}")
+
+                # --- diagnostics and checkpointing ---
+                checkpoint_data = {}
+                for name, module in self.modules.items():
+                    if hasattr(module, "checkpoint"):
+                        try:
+                            checkpoint_data[name] = module.checkpoint()
+                        except Exception as exc:
+                            logger.error(f"Checkpoint failed for {name}: {exc}")
+                diagnostics = self.modules.get("diagnostics")
+                if diagnostics:
+                    try:
+                        diagnostics.record(self.current_time, self.circuit, self.solver, self.pic_solver, self.modules.get("radiation"), checkpoint_id=self.step_count)
+                        if hasattr(diagnostics, "checkpoints"):
+                            diagnostics.checkpoints.append(checkpoint_data)
+                    except Exception as exc:
+                        logger.error(f"Diagnostics error: {exc}")
+
+                # --- advance time ---
                 self.step_count += 1
-                self.solver.step(self.dt)
                 self.current_time += self.dt
                 logger.info(f"Step {self.step_count}: time={self.current_time:.3e}")
 

--- a/tests/test_dpf_simulation_run.py
+++ b/tests/test_dpf_simulation_run.py
@@ -1,0 +1,184 @@
+import pytest
+from types import SimpleNamespace, ModuleType
+from abc import ABC
+
+class DummySolver:
+    gamma = 1.4
+    def __init__(self):
+        self.dt_calls = 0
+        self.steps = []
+    def step(self, dt):
+        self.steps.append(dt)
+    def compute_optimal_dt(self):
+        self.dt_calls += 1
+        return 0.6
+
+class DummyEOS:
+    pass
+
+class DummyCircuit:
+    def __init__(self, collision_model=None, field_manager=None, **kwargs):
+        self.current = 0.0
+        self.voltage = kwargs.get("V0", 0.0)
+    def step(self, state, dt):
+        self.current += dt
+    def get_current(self):
+        return self.current
+    def get_voltage(self):
+        return self.voltage
+
+class DummyCollision(ABC):
+    def __init__(self, field_manager=None, **kwargs):
+        self.apply_calls = 0
+        self.checkpoint_calls = 0
+    def apply(self, state, dt):
+        self.apply_calls += 1
+    def checkpoint(self):
+        self.checkpoint_calls += 1
+        return {"calls": self.apply_calls}
+
+class DummyDiagnostics:
+    def __init__(self, *args, **kwargs):
+        self.records = []
+        self.checkpoints = []
+    def record(self, t, *args, **kwargs):
+        self.records.append(t)
+
+
+def test_run_calls_modules(monkeypatch):
+    import sys, types
+
+    solver = DummySolver()
+
+    # Stub external dependencies before importing simulation module
+    dummy_trace = types.SimpleNamespace()
+    monkeypatch.setitem(sys.modules, "opencensus", types.SimpleNamespace(trace=dummy_trace))
+    monkeypatch.setitem(sys.modules, "opencensus.trace", dummy_trace)
+
+    config_schema_mod = ModuleType("config_schema")
+    config_schema_mod.SimulationConfig = type("SimulationConfig", (), {})
+    config_schema_mod.FieldManagerConfig = type("FieldManagerConfig", (), {})
+    monkeypatch.setitem(sys.modules, "config_schema", config_schema_mod)
+
+    module_registry_mod = ModuleType("module_registry")
+    class ModuleRegistry:
+        def register(self, *args, **kwargs):
+            pass
+        def create(self, cls, config=None, field_manager=None, created_modules=None):
+            config = config or {}
+            return cls(field_manager=field_manager, **config)
+    module_registry_mod.ModuleRegistry = ModuleRegistry
+    monkeypatch.setitem(sys.modules, "module_registry", module_registry_mod)
+
+    collision_mod = ModuleType("collision_model")
+    class CollisionModel(DummyCollision):
+        pass
+    collision_mod.CollisionModel = CollisionModel
+    monkeypatch.setitem(sys.modules, "collision_model", collision_mod)
+
+    radiation_mod = ModuleType("radiation_model")
+    class RadiationModel:
+        def apply(self, state, dt):
+            pass
+        def checkpoint(self):
+            return {}
+    radiation_mod.RadiationModel = RadiationModel
+    monkeypatch.setitem(sys.modules, "radiation_model", radiation_mod)
+
+    hybrid_mod = ModuleType("hybrid_controller")
+    class HybridController:
+        def apply(self, state, dt):
+            pass
+    hybrid_mod.HybridController = HybridController
+    monkeypatch.setitem(sys.modules, "hybrid_controller", hybrid_mod)
+
+    eos_selector_mod = ModuleType("eos_selector")
+    eos_selector_mod.select_eos = lambda *a, **k: DummyEOS()
+    monkeypatch.setitem(sys.modules, "eos_selector", eos_selector_mod)
+
+    solver_selector_mod = ModuleType("solver_selector")
+    solver_selector_mod.select_solver = lambda backend, config, field_manager: solver
+    monkeypatch.setitem(sys.modules, "solver_selector", solver_selector_mod)
+
+    circuit_mod = ModuleType("circuit")
+    class CircuitModel(DummyCircuit):
+        pass
+    circuit_mod.CircuitModel = CircuitModel
+    monkeypatch.setitem(sys.modules, "circuit", circuit_mod)
+
+    utils_mod = ModuleType("utils")
+    class FieldManager:
+        def __init__(self, *a, **k):
+            pass
+        def get_J(self):
+            return 0
+    class SimulationState:
+        def __init__(self, *a, **k):
+            pass
+    utils_mod.FieldManager = FieldManager
+    utils_mod.SimulationState = SimulationState
+    monkeypatch.setitem(sys.modules, "utils", utils_mod)
+
+    diagnostics_mod = ModuleType("diagnostics")
+    class Diagnostics(DummyDiagnostics):
+        pass
+    diagnostics_mod.Diagnostics = Diagnostics
+    monkeypatch.setitem(sys.modules, "diagnostics", diagnostics_mod)
+
+    pic_solver_mod = ModuleType("pic_solver")
+    class PICSolver:
+        def __init__(self, *a, **k):
+            pass
+        def step(self):
+            pass
+    pic_solver_mod.PICSolver = PICSolver
+    monkeypatch.setitem(sys.modules, "pic_solver", pic_solver_mod)
+
+    import Simulation.dpf_simulation as simmod
+
+    circuit_cfg = SimpleNamespace(C=1.0, V0=1.0, L0=1.0, R0=0.0,
+                                 anode_radius=0.1, cathode_radius=0.2,
+                                 ESR=0.0, ESL=0.0,
+                                 switch_resistance=0.0, switch_inductance=0.0,
+                                 transmission_line_impedance=50.0,
+                                 transmission_line_length=1.0)
+    circuit_cfg.dict = lambda: vars(circuit_cfg)
+
+    collision_cfg = SimpleNamespace()
+    collision_cfg.dict = lambda: {}
+
+    diag_cfg = SimpleNamespace(hdf5_filename="diag.h5")
+    field_cfg = SimpleNamespace(boundary_conditions={})
+
+    cfg = SimpleNamespace(
+        grid_shape=[2, 2, 2],
+        dx=1.0,
+        dy=1.0,
+        dz=1.0,
+        domain_lo=(0.0, 0.0, 0.0),
+        sim_time=1.0,
+        dt_init=None,
+        solver_backend="dummy",
+        eos_backend="tabulated",
+        table_file="table.h5",
+        enable_eos_mixture=False,
+        mixture_fractions=None,
+        circuit=circuit_cfg,
+        collision=collision_cfg,
+        radiation=None,
+        pic=None,
+        hybrid=None,
+        diagnostics=diag_cfg,
+        field_manager=field_cfg,
+    )
+
+    sim = simmod.DPFSimulation(cfg)
+    sim.run()
+
+    coll = sim.modules["collision"]
+    diag = sim.modules["diagnostics"]
+    assert sim.current_time == pytest.approx(1.0)
+    assert solver.dt_calls == sim.step_count
+    assert coll.apply_calls == sim.step_count
+    assert coll.checkpoint_calls == sim.step_count
+    assert len(diag.records) == sim.step_count


### PR DESCRIPTION
## Summary
- Enhance simulation loop to recompute timestep, invoke physics modules, and manage diagnostics/checkpoints
- Add regression test ensuring run loop calls collision module and diagnostics correctly

## Testing
- `venv/bin/python -m pytest tests/test_dpf_simulation_run.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa4ff14bb8832a82c15317f49b201a