### PR TITLE
Rename custom runtime errors

### DIFF
--- a/Simulation/dpf_simulation.py
+++ b/Simulation/dpf_simulation.py
@@ -36,7 +36,8 @@ class ConfigurationError(Exception):
 class InitializationError(Exception):
     pass
 
-class RuntimeError(Exception):
+class SimulationRuntimeError(Exception):
+    """Raised for runtime errors occurring during simulation execution."""
     pass
 
 class DPFSimulation:
@@ -159,7 +160,9 @@ class DPFSimulation:
                 logger.info(f"Step {self.step_count}: time={self.current_time:.3e}")
 
         except Exception as e:
-            raise RuntimeError(f"Simulation failed at step {self.step_count}: {e}")
+            raise SimulationRuntimeError(
+                f"Simulation failed at step {self.step_count}: {e}"
+            )
 
     def finalize(self):
         """Finalizes the simulation."""
@@ -218,7 +221,7 @@ def main():
     except InitializationError as e:
         logger.error(f"Initialization failed: {e}")
         sys.exit(1)
-    except RuntimeError as e:
+    except SimulationRuntimeError as e:
         logger.error(f"Simulation failed: {e}")
         sys.exit(1)
     except Exception as e:

--- a/Simulation/dpf_simulator_full_backend.py
+++ b/Simulation/dpf_simulator_full_backend.py
@@ -25,7 +25,8 @@ class ConfigurationError(Exception):
 class InitializationError(Exception):
     pass
 
-class RuntimeError(Exception):
+class SimulationRuntimeError(Exception):
+    """Raised when the simulation cannot proceed due to runtime conditions."""
     pass
 
 def _generate_boundary_conditions(domain_lo, domain_hi, bc_config=None):
@@ -275,7 +276,9 @@ class DPFSimulatorBackend:
                 logger.warning(f"Exception occurred at t={self.current_time:.3e}: {e}. Reducing dt and retrying.")
                 self.dt *= 0.5
                 if self.dt < self.dt_min:
-                    raise RuntimeError(f"Simulation aborted at t={self.current_time:.6e}: {e}")
+                    raise SimulationRuntimeError(
+                        f"Simulation aborted at t={self.current_time:.6e}: {e}"
+                    )
                 continue
 
         # Finalize WarpX / PIC


### PR DESCRIPTION
## Summary
- avoid masking Python's `RuntimeError` by renaming custom class to `SimulationRuntimeError`
- use `SimulationRuntimeError` in simulation modules' raises and handlers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68aa4ff257dc832aa09c5416fda946fd