### PR TITLE
Add optional OpenCensus tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ dpf2 simulate config.json -o results.json
 Configuration files use the `DPFConfig` schema defined in this repository.
 See `examples/quickstart.ipynb` for a walk-through in a Jupyter notebook.
 
+## Tracing
+
+The standalone `dpf_simulation` entry point can emit OpenCensus trace spans
+around major simulation stages. Enable this optional feature with the
+`--enable-tracing` flag (requires the `opencensus` package):
+
+```bash
+dpf_simulation --config-file config.json --enable-tracing
+```
+
+When tracing is disabled, the simulation runs without importing the
+tracing library.
+
 ## Repository Layout
 
 - `dpf2/` – simulator package (CLI, circuit solver, plasma model, engine)

--- a/Simulation/dpf_simulation.py
+++ b/Simulation/dpf_simulation.py
@@ -12,7 +12,6 @@ import logging
 import argparse
 import numpy as np
 import random
-import opencensus.trace as trace
 from datetime import datetime
 
 from config_schema import SimulationConfig, FieldManagerConfig  # Import FieldManagerConfig
@@ -173,6 +172,11 @@ def parse_arguments():
                         help="Global logging level")
     parser.add_argument("--seed", type=int, default=None,
                         help="Random seed for reproducibility")
+    parser.add_argument(
+        "--enable-tracing",
+        action="store_true",
+        help="Enable OpenCensus tracing for simulation stages",
+    )
     args = parser.parse_args()
     return args
 
@@ -210,11 +214,31 @@ def main():
         logger.error(e)
         sys.exit(1)
 
+    tracer = None
+    if args.enable_tracing:
+        try:
+            from opencensus.trace.tracer import Tracer
+
+            tracer = Tracer()
+        except ModuleNotFoundError:
+            logger.error(
+                "OpenCensus is required for tracing but is not installed."
+            )
+            sys.exit(1)
+
     # Instantiate and run the simulation
     try:
-        sim = DPFSimulation(config)
-        sim.run()
-        sim.finalize()
+        if tracer:
+            with tracer.span(name="initialize"):
+                sim = DPFSimulation(config)
+            with tracer.span(name="run"):
+                sim.run()
+            with tracer.span(name="finalize"):
+                sim.finalize()
+        else:
+            sim = DPFSimulation(config)
+            sim.run()
+            sim.finalize()
     except InitializationError as e:
         logger.error(f"Initialization failed: {e}")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- add optional tracing flag to `dpf_simulation` and wrap initialization, run, and finalize stages in OpenCensus spans
- document tracing feature in README and guard import so tracing library is only required when enabled

## Testing
- `pytest` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'ndarray' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4ff5409c832a89c37f95aeced062