### PR TITLE
Implement restart restoration in collision model and add regression test

### DIFF
--- a/Simulation/collision_model.py
+++ b/Simulation/collision_model.py
@@ -402,19 +402,17 @@ class CollisionModel(CollisionOperator):
         ion_data = data.get('ionization_cross_section')
         if isinstance(ion_data, dict):
             self.ionization_cross_section = CrossSectionData.from_dict(ion_data)
-        elif ion_data is not None:
+        else:
             self.ionization_cross_section = ion_data
 
         dd_data = data.get('dd_fusion_cross_section')
         if isinstance(dd_data, dict):
             self.dd_fusion_cross_section = CrossSectionData.from_dict(dd_data)
-        elif dd_data is not None:
+        else:
             self.dd_fusion_cross_section = dd_data
 
-        if 'crn_state' in data:
-            self.crn = data['crn_state']
+        self.crn = data.get('crn_state')
+        self.accumulators = dict(data.get('accumulators', {}))
+        self.caches = dict(data.get('caches', {}))
 
-        self.accumulators = data.get('accumulators', {})
-        self.caches = data.get('caches', {})
-
-        self.checkpoint_data = data
+        self.checkpoint_data = dict(data)

--- a/tests/test_collision_model_restart.py
+++ b/tests/test_collision_model_restart.py
@@ -54,3 +54,20 @@ def test_checkpoint_restart_roundtrip():
     assert list(cm2.dd_fusion_cross_section.cross_section) == [7, 8]
     assert cm2.accumulators == cm1.accumulators
     assert cm2.caches == cm1.caches
+
+
+def test_checkpoint_restart_idempotent():
+    cm1 = CollisionModel({})
+    ion_cs = CrossSectionData.from_dict({'energy': [1], 'cross_section': [2]})
+    dd_cs = CrossSectionData.from_dict({'energy': [3], 'cross_section': [4]})
+    cm1.ionization_cross_section = ion_cs
+    cm1.dd_fusion_cross_section = dd_cs
+    cm1.accumulators['steps'] = 5
+    cm1.caches['nu_ei'] = [0.3]
+
+    data = cm1.checkpoint()
+
+    cm2 = CollisionModel({})
+    cm2.restart(data)
+
+    assert cm2.checkpoint() == data


### PR DESCRIPTION
## Summary
- Restore all collision model state from checkpoint data, including cross sections and caches
- Add regression tests ensuring checkpoint followed by restart reproduces the stored data

## Testing
- `pytest tests/test_collision_model_restart.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa5a7ffbdc832abf5de9f6708bc9c0