### PR TITLE
Handle invalid dt when estimating total steps

### DIFF
--- a/Simulation/dpf_simulator_full_backend.py
+++ b/Simulation/dpf_simulator_full_backend.py
@@ -54,6 +54,31 @@ def _generate_boundary_conditions(domain_lo, domain_hi, bc_config=None):
 
     return default_bc
 
+
+def _estimate_total_steps(sim_time, dt):
+    """Estimate how many steps the simulation will take.
+
+    Logs a warning and raises :class:`SimulationRuntimeError` if the
+    estimation fails (for example due to an invalid ``dt``).
+
+    Args:
+        sim_time (float): Total simulation time.
+        dt (float): Time step size.
+
+    Returns:
+        int: Estimated number of steps.
+    """
+    try:
+        total_steps = int(np.ceil(sim_time / float(dt)))
+        logger.info("Estimated total steps: %d", total_steps)
+        return total_steps
+    except Exception as e:  # pragma: no cover - defensive, tested separately
+        msg = f"Failed to estimate total steps: {e}"
+        logger.warning(msg)
+        raise SimulationRuntimeError(
+            f"Invalid dt={dt}: unable to estimate total steps"
+        ) from e
+
 class DPFSimulatorBackend:
     """
     Unified Dense Plasma Focus simulation orchestrator.
@@ -290,15 +315,7 @@ class DPFSimulatorBackend:
             self.diagnostics.to_hdf5()
 
         # Print estimated total steps
-        try:
-            total_steps = int(np.ceil(self.sim_time / float(self.dt)))
-            logger.info("Estimated total steps: %d", total_steps)
-        except Exception as e:
-            msg = f"Failed to estimate total steps: {e}"
-            logger.warning(msg)
-            raise ValueError(
-                f"Invalid dt={self.dt}: unable to estimate total steps"
-            ) from e
+        _estimate_total_steps(self.sim_time, self.dt)
 
     def compute_global_dt(self):
         """Compute global dt satisfying CFL condition."""

--- a/tests/test_total_steps_warning.py
+++ b/tests/test_total_steps_warning.py
@@ -55,14 +55,8 @@ def test_warning_on_invalid_dt(monkeypatch, caplog):
     # Import module under test
     sim_mod = importlib.import_module("Simulation.dpf_simulator_full_backend")
 
-    dummy = types.SimpleNamespace(sim_time=1.0, dt=0.0)
     with caplog.at_level(logging.WARNING):
-        with pytest.raises(ValueError):
-            try:
-                int(sim_mod.np.ceil(dummy.sim_time / float(dummy.dt)))
-            except Exception as e:
-                msg = f"Failed to estimate total steps: {e}"
-                sim_mod.logger.warning(msg)
-                raise ValueError("Invalid dt: unable to estimate total steps") from e
+        with pytest.raises(sim_mod.SimulationRuntimeError):
+            sim_mod._estimate_total_steps(1.0, 0.0)
 
     assert "Failed to estimate total steps" in caplog.text


### PR DESCRIPTION
## Summary
- add helper `_estimate_total_steps` that logs a warning and raises `SimulationRuntimeError` when `dt` is invalid
- call helper from backend run method to catch and surface issues with `dt`
- extend tests to verify warning/error when `dt` is zero

## Testing
- `pytest tests/test_total_steps_warning.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa5a816b24832a9c540214c6704f9d