### PR TITLE
Add mixture EOS handling and tests

### DIFF
--- a/Simulation/eos.py
+++ b/Simulation/eos.py
@@ -1,11 +1,77 @@
-import numpy as np
-import h5py
 import logging
 from pathlib import Path
 from typing import Dict, Optional, Union
+
+import h5py
+import numpy as np
 from scipy.interpolate import RegularGridInterpolator
 
 logger = logging.getLogger(__name__)
+
+
+def parse_mixture_fractions(
+    mixture_fractions: Union[str, Dict[str, float], None]
+) -> Dict[str, float]:
+    """Parse mixture fraction definitions into a normalised dictionary.
+
+    Parameters
+    ----------
+    mixture_fractions:
+        Either a mapping of species to fractions or a comma separated string of
+        ``"species:fraction"`` pairs. Fractions must be non-negative and sum to
+        one. ``None`` returns an empty dictionary.
+    """
+
+    if mixture_fractions is None:
+        return {}
+
+    parsed: Dict[str, float] = {}
+
+    if isinstance(mixture_fractions, str):
+        for part in mixture_fractions.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            try:
+                species, frac = part.split(":")
+            except ValueError as exc:
+                raise ValueError(
+                    "Mixture fractions must be in 'species:fraction' format"
+                ) from exc
+            species = species.strip()
+            if not species:
+                raise ValueError(
+                    "Species name in mixture fractions cannot be empty"
+                )
+            try:
+                parsed[species] = float(frac)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Invalid fraction value for species '{species}': {frac}"
+                ) from exc
+    elif isinstance(mixture_fractions, dict):
+        for species, frac in mixture_fractions.items():
+            species = str(species)
+            try:
+                parsed[species] = float(frac)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Invalid fraction value for species '{species}': {frac}"
+                ) from exc
+    else:
+        raise TypeError("mixture_fractions must be a dict or a string")
+
+    if not parsed:
+        raise ValueError("No valid mixture fractions provided")
+
+    if any(frac < 0.0 for frac in parsed.values()):
+        raise ValueError("Mixture fractions must be non-negative")
+
+    total = sum(parsed.values())
+    if abs(total - 1.0) > 1e-6:
+        raise ValueError("Mixture fractions must sum to 1")
+
+    return parsed
 
 class TabulatedEOS:
     """
@@ -18,15 +84,20 @@ class TabulatedEOS:
     weighted EOS.
     """
 
-    def __init__(self, filename: Union[str, Path, Dict[str, Union[str, Path]]], mixture_fractions: Optional[Dict[str, float]] = None):
+    def __init__(
+        self,
+        filename: Union[str, Path, Dict[str, Union[str, Path]]],
+        mixture_fractions: Optional[Union[str, Dict[str, float]]] = None,
+    ) -> None:
         """Initializes the TabulatedEOS with data from one or more HDF5 files.
 
         Args:
             filename (Union[str, Path, Dict[str, Union[str, Path]]]): Path to the HDF5
                 file containing the EOS data for a single species or a mapping of
                 species names to file paths when ``mixture_fractions`` is supplied.
-            mixture_fractions (Optional[Dict[str, float]]): Optional mixture composition
-                where keys are species names and values are their fractions.
+            mixture_fractions (Optional[Union[str, Dict[str, float]]]): Optional
+                mixture composition. Can be provided as a dictionary or as a comma
+                separated string of ``"species:fraction"`` pairs.
         """
 
         def _load_table(path: Union[str, Path]):
@@ -50,20 +121,26 @@ class TabulatedEOS:
                     raise ValueError("EOS table has inconsistent dimensions.")
             return rho_grid, T_grid, p_table, e_table
 
+        fractions = parse_mixture_fractions(mixture_fractions)
+
         try:
-            if mixture_fractions:
+            if fractions:
                 if isinstance(filename, (str, Path)):
                     base = Path(filename)
-                    species_files = {sp: base / f"{sp}.h5" for sp in mixture_fractions}
+                    species_files = {sp: base / f"{sp}.h5" for sp in fractions}
                 elif isinstance(filename, dict):
                     species_files = {sp: Path(path) for sp, path in filename.items()}
                 else:
-                    raise TypeError("filename must be a path or mapping when mixture_fractions are provided")
+                    raise TypeError(
+                        "filename must be a path or mapping when mixture_fractions are provided"
+                    )
 
                 first = True
                 for species, path in species_files.items():
+                    if not path.is_file():
+                        raise ValueError(f"Missing EOS data for species '{species}'")
                     rho, T, p_tab, e_tab = _load_table(path)
-                    weight = mixture_fractions.get(species, 0.0)
+                    weight = fractions.get(species, 0.0)
                     if first:
                         self.rho_grid = rho
                         self.T_grid = T
@@ -75,10 +152,15 @@ class TabulatedEOS:
                             np.array_equal(self.rho_grid, rho)
                             and np.array_equal(self.T_grid, T)
                         ):
-                            raise ValueError("EOS grids for different species do not match.")
+                            raise ValueError(
+                                "EOS grids for different species do not match."
+                            )
                         self.p_table += weight * p_tab
                         self.e_table += weight * e_tab
-                logger.info("Mixture EOS tables loaded for species: %s", ", ".join(species_files.keys()))
+                logger.info(
+                    "Mixture EOS tables loaded for species: %s",
+                    ", ".join(species_files.keys()),
+                )
             else:
                 rho, T, p_tab, e_tab = _load_table(filename)
                 self.rho_grid = rho

--- a/Simulation/eos_selector.py
+++ b/Simulation/eos_selector.py
@@ -3,86 +3,15 @@
 Selects and initializes the appropriate Equation of State (EOS) model.
 """
 import logging
-from pathlib import Path
-from typing import Optional, Dict, Any, Union
-from eos import TabulatedEOS  # Assuming TabulatedEOS is the primary implementation
+from typing import Any, Optional, Union
+from eos import TabulatedEOS, parse_mixture_fractions  # type: ignore
 
 logger = logging.getLogger(__name__)
-
-# Define an EOS base class if strict typing/interface is desired, otherwise rely on duck typing
-# from models import PhysicsModule # Example if EOS should conform to PhysicsModule
-
-def _parse_mixture_fractions(mixture_fractions: Union[str, Dict[str, float]]) -> Dict[str, float]:
-    """Parse mixture fraction input into a validated dictionary.
-
-    Args:
-        mixture_fractions (Union[str, Dict[str, float]]): Definition of mixture fractions
-            either as a dictionary or as a comma separated string of
-            ``species:fraction`` pairs.
-
-    Returns:
-        Dict[str, float]: Normalized mixture fraction dictionary.
-
-    Raises:
-        ValueError: If the provided definition is invalid or fractions do not
-            sum to one.
-        TypeError: If ``mixture_fractions`` is not a string or dictionary.
-    """
-
-    if mixture_fractions is None:
-        return {}
-
-    parsed: Dict[str, float] = {}
-
-    if isinstance(mixture_fractions, str):
-        for part in mixture_fractions.split(','):
-            part = part.strip()
-            if not part:
-                continue
-            try:
-                species, frac = part.split(':')
-            except ValueError as exc:  # not enough values to unpack
-                raise ValueError(
-                    "Mixture fractions must be in 'species:fraction' format"
-                ) from exc
-            species = species.strip()
-            if not species:
-                raise ValueError("Species name in mixture fractions cannot be empty")
-            try:
-                parsed[species] = float(frac)
-            except (TypeError, ValueError) as exc:
-                raise ValueError(
-                    f"Invalid fraction value for species '{species}': {frac}"
-                ) from exc
-    elif isinstance(mixture_fractions, dict):
-        for species, frac in mixture_fractions.items():
-            species = str(species)
-            try:
-                parsed[species] = float(frac)
-            except (TypeError, ValueError) as exc:
-                raise ValueError(
-                    f"Invalid fraction value for species '{species}': {frac}"
-                ) from exc
-    else:
-        raise TypeError("mixture_fractions must be a dict or a string")
-
-    if not parsed:
-        raise ValueError("No valid mixture fractions provided")
-
-    if any(frac < 0.0 for frac in parsed.values()):
-        raise ValueError("Mixture fractions must be non-negative")
-
-    total = sum(parsed.values())
-    if abs(total - 1.0) > 1e-6:
-        raise ValueError("Mixture fractions must sum to 1")
-
-    return parsed
-
 
 def select_eos(
     backend: str,
     table_file: Optional[str] = None,
-    mixture_fractions: Optional[Union[str, Dict[str, float]]] = None,
+    mixture_fractions: Optional[Union[str, dict[str, float]]] = None,
     **kwargs: Any,
 ) -> Any:
     """
@@ -91,7 +20,7 @@ def select_eos(
     Args:
         backend (str): The type of EOS backend to use (e.g., 'tabulated').
         table_file (Optional[str]): Path to the HDF5 file for tabulated EOS.
-        mixture_fractions (Optional[Union[str, Dict[str, float]]]): Fractions for
+        mixture_fractions (Optional[Union[str, dict[str, float]]]): Fractions for
             mixture EOS. Can be provided as a dictionary or as a comma separated
             string in the form ``"species1:frac1,species2:frac2"``.
         **kwargs: Additional arguments specific to the EOS backend.
@@ -110,18 +39,11 @@ def select_eos(
             logger.error("Tabulated EOS backend selected, but 'table_file' not provided.")
             raise ValueError("Missing 'table_file' for tabulated EOS backend.")
         try:
-            parsed_mixture = _parse_mixture_fractions(mixture_fractions) if mixture_fractions is not None else {}
-            if parsed_mixture:
-                base = Path(table_file)
-                species_files: Dict[str, str] = {}
-                for species in parsed_mixture:
-                    species_path = base / f"{species}.h5"
-                    if not species_path.is_file():
-                        raise ValueError(f"Missing EOS data for species '{species}'")
-                    species_files[species] = str(species_path)
-                eos_instance = TabulatedEOS(filename=species_files, mixture_fractions=parsed_mixture)
-            else:
-                eos_instance = TabulatedEOS(filename=table_file)
+            fractions = parse_mixture_fractions(mixture_fractions)
+            eos_instance = TabulatedEOS(
+                filename=table_file,
+                mixture_fractions=fractions or None,
+            )
             logger.info(f"Instantiated TabulatedEOS from file: {table_file}")
             return eos_instance
         except FileNotFoundError:

--- a/tests/test_plasma_eos.py
+++ b/tests/test_plasma_eos.py
@@ -1,12 +1,25 @@
 import sys
 from pathlib import Path
 
-import pytest
 import h5py
+import numpy as np
+import pytest
 
 # Ensure Simulation modules are importable
 sys.path.append(str(Path(__file__).resolve().parents[1] / "Simulation"))
 from eos import TabulatedEOS  # type: ignore
+
+
+def _create_species_eos_file(
+    tmp_path: Path, species: str, p_val: float = 1.0, e_val: float = 1.0
+) -> Path:
+    file_path = tmp_path / f"{species}.h5"
+    with h5py.File(file_path, "w") as f:
+        f.create_dataset("rho", data=np.array([1.0, 2.0]))
+        f.create_dataset("T", data=np.array([3.0, 4.0]))
+        f.create_dataset("p", data=np.full((2, 2), p_val))
+        f.create_dataset("e", data=np.full((2, 2), e_val))
+    return file_path
 
 
 def test_tabulated_eos_missing_dataset(tmp_path):
@@ -29,3 +42,18 @@ def test_tabulated_eos_inconsistent_dimensions(tmp_path):
         f.create_dataset("e", data=[[7.0, 8.0], [9.0, 10.0]])
     with pytest.raises(ValueError, match="inconsistent dimensions"):
         TabulatedEOS(str(file_path))
+
+
+def test_tabulated_eos_mixture_combination(tmp_path):
+    _create_species_eos_file(tmp_path, "A", p_val=1.0, e_val=10.0)
+    _create_species_eos_file(tmp_path, "B", p_val=2.0, e_val=20.0)
+    mix = TabulatedEOS(str(tmp_path), mixture_fractions="A:0.25,B:0.75")
+    assert np.allclose(mix.p_table, 0.25 * 1.0 + 0.75 * 2.0)
+    assert np.allclose(mix.e_table, 0.25 * 10.0 + 0.75 * 20.0)
+
+
+def test_tabulated_eos_invalid_mixture(tmp_path):
+    _create_species_eos_file(tmp_path, "A")
+    _create_species_eos_file(tmp_path, "B")
+    with pytest.raises(ValueError):
+        TabulatedEOS(str(tmp_path), mixture_fractions="A:0.6,B:0.5")


### PR DESCRIPTION
## Summary
- add `parse_mixture_fractions` utility and weighted table combination to `TabulatedEOS`
- reuse mixture parser in `select_eos` and delegate species file handling to `TabulatedEOS`
- cover valid and invalid mixture inputs with new tests

## Testing
- `pytest tests/test_plasma_eos.py tests/test_eos_selector.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa5a82ead0832aa8210fa2ad9edc22