### PR TITLE
Implement axis-aware Bohm sheath boundary updates

### DIFF
--- a/Simulation/sheath_model.py
+++ b/Simulation/sheath_model.py
@@ -155,12 +155,23 @@ class BohmSheath:
         phi_s = self._sheath_potential()
 
         # Determine grid spacing along the sheath-normal axis for field estimate
-        dz = 1.0
-        if hasattr(target, 'dz'):
-            dz = getattr(target, 'dz', 1.0)
-        elif hasattr(target, 'field_manager') and hasattr(target.field_manager, 'dz'):
-            dz = target.field_manager.dz
-        sheath_field = phi_s / dz
+        spacing = 1.0
+        if self.axis == 0:
+            if hasattr(target, 'dx'):
+                spacing = getattr(target, 'dx', 1.0)
+            elif hasattr(target, 'field_manager') and hasattr(target.field_manager, 'dx'):
+                spacing = target.field_manager.dx
+        elif self.axis == 1:
+            if hasattr(target, 'dy'):
+                spacing = getattr(target, 'dy', 1.0)
+            elif hasattr(target, 'field_manager') and hasattr(target.field_manager, 'dy'):
+                spacing = target.field_manager.dy
+        else:
+            if hasattr(target, 'dz'):
+                spacing = getattr(target, 'dz', 1.0)
+            elif hasattr(target, 'field_manager') and hasattr(target.field_manager, 'dz'):
+                spacing = target.field_manager.dz
+        sheath_field = phi_s / spacing
 
         # Case 1: target is a SimulationState holding a FieldManager
         if hasattr(target, "field_manager"):

--- a/tests/test_bohm_sheath.py
+++ b/tests/test_bohm_sheath.py
@@ -90,3 +90,26 @@ def test_apply_updates_momentum_array():
     v_bohm = np.sqrt(e_charge * 2.0 / 1.67e-27)
     assert np.allclose(momentum[2, :, :, -1], v_bohm)
     assert np.all(momentum[2, :, :, -2] == 0.0)
+
+
+def test_apply_handles_all_axes():
+    """The sheath orientation can be changed via the ``axis`` parameter."""
+    mass_ratio = 1.67e-27 / (2 * np.pi * m_e)
+    phi_s = 5.0 * np.log(np.sqrt(mass_ratio))
+    v_bohm = np.sqrt(e_charge * 5.0 / 1.67e-27)
+
+    # X-directed sheath
+    state_x, fm_x = make_state()
+    sheath_x = BohmSheath(electron_temperature=5.0, ion_mass=1.67e-27, axis=0)
+    sheath_x.apply(state_x)
+    assert np.allclose(state_x.velocity[0, -1, :, :], v_bohm)
+    assert np.allclose(state_x.potential[-1, :, :], phi_s)
+    assert np.allclose(fm_x.get_E()[0, -1, :, :], phi_s / fm_x.dx)
+
+    # Y-directed sheath
+    state_y, fm_y = make_state()
+    sheath_y = BohmSheath(electron_temperature=5.0, ion_mass=1.67e-27, axis=1)
+    sheath_y.apply(state_y)
+    assert np.allclose(state_y.velocity[1, :, -1, :], v_bohm)
+    assert np.allclose(state_y.potential[:, -1, :], phi_s)
+    assert np.allclose(fm_y.get_E()[1, :, -1, :], phi_s / fm_y.dy)


### PR DESCRIPTION
## Summary
- Implement Bohm sheath boundary condition that computes field strength using grid spacing along the chosen axis
- Update velocity, potential, and electric field near boundaries according to Bohm criterion
- Extend unit tests to verify boundary behavior for sheaths aligned with x, y, and z axes

## Testing
- `pytest tests/test_bohm_sheath.py::test_apply_handles_all_axes` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68aa5a86a298832a9e4de92414192056