### PR TITLE
test: consolidate config round-trip tests

### DIFF
--- a/core_schema.py
+++ b/core_schema.py
@@ -519,47 +519,6 @@ except Exception as exc:
     raise RuntimeError("DPFConfig model rebuild failed") from exc
 
 # ---------------------------------------------------------------------------
-# Example test stubs
-
-def test_round_trip(tmp_path: Path) -> None:
-    """Ensure configuration can be written to disk and loaded again."""
-
-    cfg = DPFConfig.with_defaults()
-    path = tmp_path / "cfg.json"
-    cfg.to_file(path)
-    reloaded = DPFConfig.from_file(path)
-    assert reloaded.model_dump() == cfg.model_dump()
-
-def test_invalid_geometry():
-    import pytest
-    with pytest.raises(ValueError):
-        DPFConfig(
-            simulation={"geometry": GeometryType.RZ_2D.value},
-            grid={"ny": 2},
-            initial={},
-            physics={},
-            circuit={},
-            amrex={},
-            warpx={},
-            diagnostics={},
-            variability={},
-            benchmark={},
-            boundary={},
-            parallel={},
-            metadata={},
-            advanced={},
-            units={},
-            run_uuid="r1",
-            schema_version="1.0",
-            created_at=datetime.utcnow(),
-            on_validation_error=ValidationPolicy.STRICT,
-        )
-
-def test_required_fields():
-    cfg = DPFConfig.with_defaults()
-    assert "created_at" in cfg.required_fields()
-
-# ---------------------------------------------------------------------------
 # Example usage
 
 if __name__ == "__main__":

--- a/tests/test_core_schema_config.py
+++ b/tests/test_core_schema_config.py
@@ -40,3 +40,24 @@ def test_pic_mode_requires_neutrals():
     data["simulation"]["mode"] = ModeType.PIC
     with pytest.raises(ValueError):
         DPFConfig.model_validate(data)
+
+
+def test_config_round_trip(tmp_path):
+    cfg = DPFConfig.with_defaults()
+    path = tmp_path / "cfg.json"
+    cfg.to_file(path)
+    reloaded = DPFConfig.from_file(path)
+    assert reloaded.model_dump() == cfg.model_dump()
+
+
+def test_invalid_geometry():
+    cfg = DPFConfig.with_defaults()
+    data = cfg.model_dump()
+    data["grid"]["ny"] = 2
+    with pytest.raises(ValueError):
+        DPFConfig.model_validate(data)
+
+
+def test_required_fields():
+    cfg = DPFConfig.with_defaults()
+    assert "created_at" in cfg.required_fields()


### PR DESCRIPTION
## Summary
- remove placeholder test stubs from core_schema
- add config round-trip and validation tests to test_core_schema_config

## Testing
- `pip install pydantic` (fails: Could not connect to proxy)
- `pytest` (fails: 54 errors during collection)
- `pytest tests/test_core_schema_config.py` (fails: ModuleNotFoundError: No module named 'pydantic')

------
https://chatgpt.com/codex/tasks/task_e_68aa5a892ecc832aace57f2dbf4e3b18