### PR TITLE
refactor: centralize solver base classes

### DIFF
--- a/dpf2/__init__.py
+++ b/dpf2/__init__.py
@@ -3,7 +3,7 @@
 from .circuit_solver import RLCCircuit, CircuitSolver
 from .pinch_models import AnalyticPinchModel, SemiAnalyticPinchModel
 from .simulation_engine import SimulationEngine
-from .core.bases import PlasmaSolverBase, CircuitSolverBase, DiagnosticsBase
+from .core import PlasmaSolverBase, CircuitSolverBase, DiagnosticsBase
 from .ai import SurrogateModel, TorchSurrogateModel, ONNXSurrogateModel
 from .hall_mhd_solver import HallMHDSolver, MHDState
 

--- a/dpf2/hall_mhd_solver.py
+++ b/dpf2/hall_mhd_solver.py
@@ -15,7 +15,7 @@ from typing import Any, Callable
 import numpy as np
 from scipy.constants import mu_0
 
-from dpf2.core.bases import PlasmaSolverBase
+from dpf2.core import PlasmaSolverBase
 from .eos import EOSBase, IdealGasEOS
 from .chemistry import ChemistryModel, SahaEquilibrium
 from .radiation import RadiationBase

--- a/dpf2/solvers/axisymmetric_hlld.py
+++ b/dpf2/solvers/axisymmetric_hlld.py
@@ -15,7 +15,7 @@ The solver operates on state dictionaries containing 2-D ``numpy.ndarray``
 objects.  The expected fields are ``rho`` (density), the three momentum
 components ``mom_r``, ``mom_phi`` and ``mom_z``, magnetic field components
 ``B_r``, ``B_phi`` and ``B_z`` and the total ``energy``.  The public
-:class:`AxisymmetricHLLD` class conforms to :class:`~dpf2.core.bases.PlasmaSolverBase`
+:class:`AxisymmetricHLLD` class conforms to :class:`~dpf2.core.PlasmaSolverBase`
 by providing a :meth:`step` method advancing the state by ``dt`` seconds.
 
 The goal of the tests is not to provide a production ready plasma solver, but
@@ -29,7 +29,7 @@ from typing import Dict
 
 import numpy as np
 
-from dpf2.core.bases import PlasmaSolverBase
+from dpf2.core import PlasmaSolverBase
 
 State = Dict[str, np.ndarray]
 

--- a/src/dpf2/__init__.py
+++ b/src/dpf2/__init__.py
@@ -1,8 +1,12 @@
 """DPF2 high-fidelity simulation toolkit."""
 
-from .core.config import DPFConfig
-from .core.simulation import DPFSimulation
-from dpf2.core.bases import PlasmaSolverBase, CircuitSolverBase, DiagnosticsBase
+from .core import (
+    DPFConfig,
+    DPFSimulation,
+    PlasmaSolverBase,
+    CircuitSolverBase,
+    DiagnosticsBase,
+)
 from .ai import SurrogateModel, TorchSurrogateModel, ONNXSurrogateModel
 
 __all__ = [

--- a/src/dpf2/core/__init__.py
+++ b/src/dpf2/core/__init__.py
@@ -2,7 +2,7 @@
 
 from .config import DPFConfig
 from .simulation import DPFSimulation
-from dpf2.core.bases import PlasmaSolverBase, CircuitSolverBase, DiagnosticsBase
+from .bases import PlasmaSolverBase, CircuitSolverBase, DiagnosticsBase
 
 __all__ = [
     "DPFConfig",

--- a/src/dpf2/core/bases.py
+++ b/src/dpf2/core/bases.py
@@ -1,0 +1,44 @@
+"""Abstract base classes for solver components.
+
+This file provides canonical interfaces for plasma, circuit and
+diagnostics modules.  Other copies in the repository should import
+from here to avoid duplication."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class PlasmaSolverBase(ABC):
+    """Interface for plasma solvers."""
+
+    @abstractmethod
+    def step(self, state: Any, dt: float) -> Any:
+        """Advance the plasma state by ``dt`` seconds."""
+        raise NotImplementedError
+
+
+class CircuitSolverBase(ABC):
+    """Interface for external circuit solvers."""
+
+    @abstractmethod
+    def step(self, current: float, voltage: float, dt: float) -> tuple[float, float]:
+        """Return updated (current, voltage) after ``dt`` seconds."""
+        raise NotImplementedError
+
+
+class DiagnosticsBase(ABC):
+    """Interface for simulation diagnostics."""
+
+    @abstractmethod
+    def record(self, state: Any, time: float) -> None:
+        """Record the simulation ``state`` at ``time``."""
+        raise NotImplementedError
+
+
+__all__ = [
+    "PlasmaSolverBase",
+    "CircuitSolverBase",
+    "DiagnosticsBase",
+]


### PR DESCRIPTION
## Summary
- add canonical solver base classes in `src/dpf2/core/bases.py`
- import base classes through `dpf2.core` for consistency
- update solver modules to rely on unified base interfaces

## Testing
- `pytest -q` *(fails: No module named 'pydantic'; No module named 'numpy'; No module named 'werkzeug'; AttributeError: 'types.SimpleNamespace' object has no attribute 'ndarray')*


------
https://chatgpt.com/codex/tasks/task_e_68aa5a84d310832ab8c2fbebd702bc43