### PR TITLE
Add optional dependency extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - run: pip install -e .
+      - run: "pip install -e .[server,warpx]"
       - run: pip install pytest pytest-cov
       - run: pytest --cov=. --cov-report=xml
       - uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ external circuit and pinch dynamics.
 pip install -e .
 ```
 
+Optional extras can be installed to enable additional features:
+
+```bash
+# Install with Flask-based server support
+pip install -e .[server]
+
+# Install with WarpX accelerator support
+pip install -e .[warpx]
+
+# Install all optional features
+pip install -e .[server,warpx]
+```
+
 ## Quickstart
 
 Run a simulation using the default configuration:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,25 @@ version = "0.1.0"
 description = "Minimal Dense Plasma Focus simulator"
 requires-python = ">=3.10"
 dependencies = [
-    "numpy",
-    "scipy",
-    "pydantic",
+    "flask",
+    "h5py",
     "matplotlib",
+    "numba",
+    "numpy",
+    "pydantic",
+    "scipy",
+    "sympy",
+    "werkzeug"
+]
+
+[project.optional-dependencies]
+server = [
+    "flask",
+    "flask_sock"
+]
+warpx = [
+    "pywarpx",
+    "amrex_solver"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,8 @@ numpy
 scipy
 pydantic
 matplotlib
+flask
+h5py
+numba
+sympy
+werkzeug


### PR DESCRIPTION
## Summary
- include new core dependencies and optional extras for server and WarpX features
- document optional installation extras
- ensure CI installs base package with extras

## Testing
- `pip install -e .[server,warpx]` *(fails: Could not find a version that satisfies the requirement setuptools>=61)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68aa5f5452ec832ab782cdd9b4a0c5d8