### PR TITLE
Add user manual and MkDocs API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ A minimal Dense Plasma Focus (DPF) simulator implemented in Python.  This
 project provides a command line interface and simple models for the
 external circuit and pinch dynamics.
 
+## Documentation
+
+User guides and API references are available in the [docs/](docs/user_manual.md)
+directory.  The manual covers installation, configuration files, CLI usage,
+and extension points, while the [API reference](docs/api.md) is generated from
+the package source code.
+
 ## Installation
 
 ```bash
@@ -16,6 +23,16 @@ Run a simulation using the default configuration:
 
 ```bash
 dpf2 simulate config.json -o results.json
+```
+
+Or run a simulation programmatically:
+
+```python
+from dpf2 import DPFConfig, DPFSimulation
+
+config = DPFConfig()
+simulation = DPFSimulation(config)
+result = simulation.run()
 ```
 
 Configuration files use the `DPFConfig` schema defined in this repository.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,3 @@
+# API Reference
+
+::: dpf2

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1,0 +1,37 @@
+# DPF2 User Manual
+
+## Installation
+
+Install the simulator and its dependencies using pip:
+
+```bash
+pip install -e .
+```
+
+This will install the `dpf2` command line interface and Python package in editable mode so local changes are immediately available.
+
+## Configuration Schema
+
+Simulations are configured with the `DPFConfig` data class.  It defines the geometry, initial conditions, and numerical parameters for a run.  Configuration files are written in JSON and validated against this schema.  Refer to `dpf_config.py` and related `*config.py` modules for field descriptions and default values.
+
+## CLI Usage
+
+The package installs a `dpf2` entry point that exposes common operations.  Run a simulation with:
+
+```bash
+dpf2 simulate config.json -o results.json
+```
+
+Use `dpf2 --help` or `dpf2 <command> --help` to see available commands and options.
+
+## Module Extension Points
+
+`dpf2` is designed for extensibility.  New physics models, circuit solvers, or diagnostics can be integrated by subclassing the following base classes:
+
+- `PlasmaSolverBase` – implement alternative plasma evolution models.
+- `CircuitSolverBase` – plug in custom external circuit solvers.
+- `DiagnosticsBase` – add new diagnostics or analysis routines.
+- `SurrogateModel` – wrap AI models that replace expensive physics modules.
+
+Subclass the appropriate base class, register it in your configuration, and the simulation engine will use your implementation.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: DPF2 Documentation
+nav:
+  - User Manual: user_manual.md
+  - API Reference: api.md
+plugins:
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]


### PR DESCRIPTION
## Summary
- add a user manual with installation, configuration, CLI usage, and extension points
- create MkDocs configuration and API reference stub for the `dpf2` package
- update README with documentation links and a quickstart snippet

## Testing
- `pip install mkdocs mkdocstrings[python]` *(fails: Could not find a version that satisfies the requirement mkdocs)*
- `mkdocs build` *(fails: command not found: mkdocs)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68aa5f56bd88832a9fcee1e88451dcfc