### PR TITLE
Validate mixture species files for TabulatedEOS and add parsing tests

### DIFF
--- a/src/dpf2/simulation/eos.py
+++ b/src/dpf2/simulation/eos.py
@@ -129,7 +129,13 @@ class TabulatedEOS:
                     base = Path(filename)
                     species_files = {sp: base / f"{sp}.h5" for sp in fractions}
                 elif isinstance(filename, dict):
-                    species_files = {sp: Path(path) for sp, path in filename.items()}
+                    missing = set(fractions) - set(filename)
+                    if missing:
+                        raise ValueError(
+                            "Missing EOS data for species: "
+                            + ", ".join(sorted(missing))
+                        )
+                    species_files = {sp: Path(filename[sp]) for sp in fractions}
                 else:
                     raise TypeError(
                         "filename must be a path or mapping when mixture_fractions are provided"

--- a/tests/test_parse_mixture_fractions.py
+++ b/tests/test_parse_mixture_fractions.py
@@ -1,0 +1,36 @@
+import importlib.util
+import pathlib
+import sys
+import types
+
+# Provide minimal stubs for heavy dependencies so the module can be imported
+sys.modules.setdefault('h5py', types.ModuleType('h5py'))
+sys.modules.setdefault('numpy', types.ModuleType('numpy'))
+sys.modules.setdefault('scipy', types.ModuleType('scipy'))
+sys.modules.setdefault('scipy.interpolate', types.ModuleType('scipy.interpolate'))
+sys.modules['scipy.interpolate'].RegularGridInterpolator = object
+
+spec = importlib.util.spec_from_file_location(
+    'eos', pathlib.Path(__file__).resolve().parent.parent / 'src' / 'dpf2' / 'simulation' / 'eos.py'
+)
+eos = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(eos)
+parse_mixture_fractions = eos.parse_mixture_fractions
+
+
+import pytest
+
+
+def test_parse_mixture_fractions_string():
+    fractions = parse_mixture_fractions('A:0.5,B:0.5')
+    assert fractions == {'A': 0.5, 'B': 0.5}
+
+
+def test_parse_mixture_fractions_invalid_sum():
+    with pytest.raises(ValueError):
+        parse_mixture_fractions('A:0.4,B:0.4')
+
+
+def test_parse_mixture_fractions_negative():
+    with pytest.raises(ValueError):
+        parse_mixture_fractions('A:-0.1,B:1.1')

--- a/tests/test_plasma_eos.py
+++ b/tests/test_plasma_eos.py
@@ -55,3 +55,9 @@ def test_tabulated_eos_invalid_mixture(tmp_path):
     _create_species_eos_file(tmp_path, "B")
     with pytest.raises(ValueError):
         TabulatedEOS(str(tmp_path), mixture_fractions="A:0.6,B:0.5")
+
+
+def test_tabulated_eos_missing_species_file(tmp_path):
+    path_a = _create_species_eos_file(tmp_path, "A")
+    with pytest.raises(ValueError, match="Missing EOS data for species"):
+        TabulatedEOS({"A": str(path_a)}, mixture_fractions={"A": 0.5, "B": 0.5})


### PR DESCRIPTION
## Summary
- ensure mixture EOS loading errors when species files are missing
- add unit tests for mixture parsing and missing species in plasma EOS

## Testing
- `pytest tests/test_parse_mixture_fractions.py -q`
- `pytest tests/test_plasma_eos.py::test_tabulated_eos_mixture_combination -q` *(fails: ModuleNotFoundError: No module named 'h5py')*


------
https://chatgpt.com/codex/tasks/task_e_68aa658b53d4832a94d6a43c35321a8f