### PR TITLE
test: ensure config round trips

### DIFF
--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -38,7 +38,7 @@ def test_yaml_round_trip_and_summary_output(tmp_path):
     yaml.safe_dump({"deviceProfiles": cfg.model_dump(by_alias=True)}, open(yaml_path, "w"))
     loaded = yaml.safe_load(open(yaml_path))
     cfg2 = DeviceProfiles.model_validate(loaded["deviceProfiles"])
-    assert cfg2.devices["PF1000"].anode_radius_cm == cfg.devices["PF1000"].anode_radius_cm
+    assert cfg2.model_dump(by_alias=True) == cfg.model_dump(by_alias=True)
     summary = cfg.summarize()
     assert "Devices:" in summary and "PF1000" in summary
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -48,7 +48,6 @@ def test_yaml_round_trip_and_summary(tmp_path):
     yaml.safe_dump({"metadata": cfg.model_dump(by_alias=True)}, open(yaml_path, "w"))
     loaded = yaml.safe_load(open(yaml_path))
     cfg2 = Metadata.model_validate(loaded["metadata"])
-    assert cfg2.run_uuid == cfg.run_uuid
-    assert cfg2.summary_id == cfg.summary_id
+    assert cfg2.model_dump(by_alias=True) == cfg.model_dump(by_alias=True)
     summary = cfg.summarize()
     assert "Schema:" in summary and "Surrogate:" in summary


### PR DESCRIPTION
## Summary
- verify device profile config round trips via YAML serialization
- ensure metadata config round trips via YAML serialization

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest tests/test_device_profiles.py tests/test_metadata.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68aa658dc140832a9950381ac714e01e