### PR TITLE
Implement Bohm sheath velocity and field boundary updates

### DIFF
--- a/src/dpf2/simulation/sheath_model.py
+++ b/src/dpf2/simulation/sheath_model.py
@@ -179,29 +179,29 @@ class BohmSheath:
             if fm is not None:
                 self._apply_to_field_manager(fm, sheath_field)
 
-                # Update velocity field if present or create one
-                vel = getattr(target, 'velocity', None)
-                if vel is None:
-                    vel = np.zeros((3,) + target.grid_shape)
-                    target.velocity = vel
-                if self.axis == 0:
-                    vel[0, -1, :, :] = v_bohm
-                elif self.axis == 1:
-                    vel[1, :, -1, :] = v_bohm
-                else:
-                    vel[2, :, :, -1] = v_bohm
+            # Update velocity field if present or create one
+            vel = getattr(target, 'velocity', None)
+            if vel is None:
+                vel = np.zeros((3,) + target.grid_shape)
+                target.velocity = vel
+            if self.axis == 0:
+                vel[0, -1, :, :] = v_bohm
+            elif self.axis == 1:
+                vel[1, :, -1, :] = v_bohm
+            else:
+                vel[2, :, :, -1] = v_bohm
 
-                # Update electrostatic potential field
-                phi = getattr(target, 'potential', None)
-                if phi is None:
-                    phi = np.zeros(target.grid_shape)
-                    target.potential = phi
-                if self.axis == 0:
-                    phi[-1, :, :] = phi_s
-                elif self.axis == 1:
-                    phi[:, -1, :] = phi_s
-                else:
-                    phi[:, :, -1] = phi_s
+            # Update electrostatic potential field
+            phi = getattr(target, 'potential', None)
+            if phi is None:
+                phi = np.zeros(target.grid_shape)
+                target.potential = phi
+            if self.axis == 0:
+                phi[-1, :, :] = phi_s
+            elif self.axis == 1:
+                phi[:, -1, :] = phi_s
+            else:
+                phi[:, :, -1] = phi_s
             return
 
         # Case 2: target is itself a FieldManager

--- a/tests/test_bohm_sheath.py
+++ b/tests/test_bohm_sheath.py
@@ -42,6 +42,15 @@ def test_apply_updates_field_manager():
     assert np.allclose(fm.get_E()[2, :, :, -1], expected_field)
 
 
+def test_field_manager_interior_unchanged():
+    state, fm = make_state()
+    sheath = BohmSheath(electron_temperature=5.0, ion_mass=1.67e-27)
+    sheath.apply(state)
+    E = fm.get_E()
+    # Interior slice should remain zero while boundary is updated
+    assert np.all(E[2, :, :, -2] == 0.0)
+
+
 def test_apply_updates_state_velocity_and_potential():
     state, _ = make_state()
     sheath = BohmSheath(electron_temperature=5.0, ion_mass=1.67e-27)


### PR DESCRIPTION
## Summary
- ensure `BohmSheath.apply` always sets boundary velocities and potentials via Bohm criterion, even when no FieldManager is present
- add unit test confirming only boundary-adjacent electric field cells are modified by the sheath

## Testing
- `pytest tests/test_bohm_sheath.py::test_field_manager_interior_unchanged -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aa658d0cc0832a86882ff52ef09688