### PR TITLE
Warn on config file hashing failures

### DIFF
--- a/advanced_options.py
+++ b/advanced_options.py
@@ -157,7 +157,8 @@ class AdvancedOptions(ConfigSectionBase):
             try:
                 if p.exists():
                     data["injectRuntimeScript"] = p.read_bytes().decode(errors="ignore")
-            except Exception:
+            except Exception as e:
+                warnings.warn(f"Failed to read {p}: {e}", RuntimeWarning)
                 data["injectRuntimeScript"] = str(path_key)
         serialized = json.dumps(data, sort_keys=True, default=str)
         return hashlib.sha256(serialized.encode()).hexdigest()

--- a/experimental_variability.py
+++ b/experimental_variability.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional, Literal
 
@@ -35,6 +36,8 @@ if not hasattr(BaseModel, "model_copy"):
 
 # Local imports ---------------------------------------------------------------
 from core_schema import ConfigSectionBase, UnitsSystem, UNIT_SCALE_MAP, to_camel_case
+
+logger = logging.getLogger(__name__)
 
 
 class ExperimentalVariabilityModel(ConfigSectionBase):
@@ -150,7 +153,8 @@ class ExperimentalVariabilityModel(ConfigSectionBase):
                 try:
                     if p.exists():
                         data[key] = p.read_bytes().decode(errors="ignore")
-                except Exception:
+                except Exception as e:
+                    logger.warning("Failed to read %s: %s", p, e)
                     data[key] = str(path)
         serialized = json.dumps(data, sort_keys=True, default=str)
         return hashlib.sha256(serialized.encode()).hexdigest()


### PR DESCRIPTION
## Summary
- log and warn when hashing helpers cannot read referenced files
- ref: total step estimator warns and raises when `dt` is invalid

## Testing
- `pytest tests/test_total_steps_warning.py -q` *(fails: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68aa6587b070832aa8acad16dc1c4cdb