### PR TITLE
Apply BCs in place and add regression test

### DIFF
--- a/src/dpf2/simulation/utils.py
+++ b/src/dpf2/simulation/utils.py
@@ -250,12 +250,16 @@ class FieldManager:
                 field = np.roll(field, shift=g, axis=axis)
             return field
 
-        # Apply boundary conditions to each field component in-place
-        for field in (self.E, self.B, self.J):
-            for i in range(3):
-                for axis_num, axis in enumerate(['x', 'y', 'z']):
-                    for side in ['lo', 'hi']:
-                        field[i] = apply_bc(field[i], f"{axis}_{side}", axis_num)
+        # Apply boundary conditions to each field component in-place without
+        # creating temporary stacked arrays.  This ensures that ``E``, ``B`` and
+        # ``J`` maintain their original shapes and avoids the overhead of
+        # re-stacking arrays after every boundary update.
+        for i in range(3):
+            for axis_num, axis in enumerate(["x", "y", "z"]):
+                for side in ["lo", "hi"]:
+                    apply_bc(self.E[i], f"{axis}_{side}", axis_num)
+                    apply_bc(self.B[i], f"{axis}_{side}", axis_num)
+                    apply_bc(self.J[i], f"{axis}_{side}", axis_num)
 
         # Verify field shapes remain intact after boundary application
         expected_shape = (3, self.nx, self.ny, self.nz)

--- a/tests/test_field_manager_boundary_shapes.py
+++ b/tests/test_field_manager_boundary_shapes.py
@@ -1,0 +1,43 @@
+import numpy as np
+from dpf2.simulation.utils import FieldManager
+
+def test_apply_boundary_conditions_preserves_shape_and_updates_boundaries():
+    nx = ny = nz = 4
+    boundary_conditions = {
+        "x_lo": "dirichlet",
+        "x_hi": "dirichlet",
+        "y_lo": "dirichlet",
+        "y_hi": "dirichlet",
+        "z_lo": "dirichlet",
+        "z_hi": "dirichlet",
+        "ghost_cells": 1,
+    }
+    fm = FieldManager(
+        grid_shape=(nx, ny, nz),
+        dx=1.0,
+        dy=1.0,
+        dz=1.0,
+        domain_lo=(0.0, 0.0, 0.0),
+        boundary_conditions=boundary_conditions,
+    )
+    fm.E.fill(1.0)
+    fm.B.fill(1.0)
+    fm.J.fill(1.0)
+
+    fm.apply_boundary_conditions(None)
+
+    expected_shape = (3, nx, ny, nz)
+    assert fm.E.shape == expected_shape
+    assert fm.B.shape == expected_shape
+    assert fm.J.shape == expected_shape
+
+    for arr in (fm.E, fm.B, fm.J):
+        # Boundary cells should be zero due to dirichlet conditions
+        assert np.all(arr[:, 0, :, :] == 0.0)
+        assert np.all(arr[:, -1, :, :] == 0.0)
+        assert np.all(arr[:, :, 0, :] == 0.0)
+        assert np.all(arr[:, :, -1, :] == 0.0)
+        assert np.all(arr[:, :, :, 0] == 0.0)
+        assert np.all(arr[:, :, :, -1] == 0.0)
+        # Interior cells remain unchanged
+        assert np.all(arr[:, 1:-1, 1:-1, 1:-1] == 1.0)


### PR DESCRIPTION
## Summary
- apply boundary condition updates directly to each E, B, and J component without stacking
- add regression test ensuring field arrays retain shape and Dirichlet boundaries are applied

## Testing
- `python -m pytest tests/test_field_manager_boundary_shapes.py tests/test_pml_boundary.py -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68aa68593308832a81c8e79425308bc8