### PR TITLE
Expose configurable PML boundary parameters

### DIFF
--- a/boundary_conditions.py
+++ b/boundary_conditions.py
@@ -105,6 +105,23 @@ class BoundaryConditions(ConfigSectionBase):
         metadata={"units": "cells"},
     )
 
+    # Perfectly matched layer (PML) configuration
+    pml_thickness: Optional[int] = Field(
+        2,
+        ge=0,
+        alias="pmlThickness",
+        metadata={"units": "cells"},
+    )
+    pml_sigma: Optional[float] = Field(
+        2.0,
+        ge=0.0,
+        alias="pmlSigma",
+    )
+    pml_profile: Optional[Literal["exponential", "linear"]] = Field(
+        "exponential",
+        alias="pmlProfile",
+    )
+
     ghost_zone_extrapolation: Optional[Literal[
         "constant",
         "linear",
@@ -137,6 +154,9 @@ class BoundaryConditions(ConfigSectionBase):
             z_high=BoundaryTypeEnum.REFLECTING,
             absorbing_layer_thickness_cells=4,
             ghost_zone_extrapolation="constant",
+            pml_thickness=2,
+            pml_sigma=2.0,
+            pml_profile="exponential",
         )
 
     def resolve_defaults(self) -> "BoundaryConditions":
@@ -151,6 +171,9 @@ class BoundaryConditions(ConfigSectionBase):
         ]:
             data.setdefault(f, BoundaryTypeEnum.REFLECTING)
         data.setdefault("absorbing_layer_thickness_cells", 4)
+        data.setdefault("pml_thickness", 2)
+        data.setdefault("pml_sigma", 2.0)
+        data.setdefault("pml_profile", "exponential")
         return self.model_validate(data, context=getattr(self, "_context", {}))
 
     def required_fields(self) -> List[str]:
@@ -169,6 +192,7 @@ class BoundaryConditions(ConfigSectionBase):
             f"Y boundaries: {self.y_low.value} | {self.y_high.value}",
             f"Z boundaries: {self.z_low.value} | {self.z_high.value}",
             f"Absorbing layer: {self.absorbing_layer_thickness_cells} cells, Extrapolation: {self.ghost_zone_extrapolation}",
+            f"PML: thickness={self.pml_thickness}, sigma={self.pml_sigma}, profile={self.pml_profile}",
         ]
         if self.boundary_field_overrides:
             lines = []

--- a/src/dpf2/simulation/utils.py
+++ b/src/dpf2/simulation/utils.py
@@ -220,31 +220,47 @@ class FieldManager:
                     field[:, :, :g] = field[:, :, g:2 * g]
                     field[:, :, -g:] = field[:, :, -2 * g:-g]
             elif bc == 'pml':
-                # Simple PML implemented via exponential damping in ghost cells
+                # Simple PML implemented via damping in ghost cells
                 thickness = int(self.boundary_conditions.get('pml_thickness', g))
                 thickness = min(thickness, g)
                 sigma = float(self.boundary_conditions.get('pml_sigma', 2.0))
                 profile = self.boundary_conditions.get('pml_profile', 'exponential')
                 factors = _pml_factors(thickness, sigma, profile)
 
+                def _apply(axis_slc, interior):
+                    facs = factors[::-1] if side == 'lo' else factors
+                    if axis == 0:
+                        facs = facs[:, None, None]
+                    elif axis == 1:
+                        facs = facs[None, :, None]
+                    else:
+                        facs = facs[None, None, :]
+                    field[axis_slc] = interior * facs
+
                 if axis == 0:
                     interior_idx = thickness if side == 'lo' else -thickness - 1
-                    interior = np.copy(field[interior_idx, :, :])
-                    for j, fac in enumerate(factors):
-                        idx = thickness - 1 - j if side == 'lo' else -thickness + j
-                        field[idx, :, :] = interior * fac
+                    interior = np.copy(field[interior_idx, :, :])[None, :, :]
+                    sl = slice(0, thickness) if side == 'lo' else slice(-thickness, None)
+                    _apply((sl, slice(None), slice(None)), interior)
+                    if thickness < g:
+                        zero_sl = slice(thickness, g) if side == 'lo' else slice(-g, -thickness)
+                        field[zero_sl, :, :] = 0.0
                 elif axis == 1:
                     interior_idx = thickness if side == 'lo' else -thickness - 1
-                    interior = np.copy(field[:, interior_idx, :])
-                    for j, fac in enumerate(factors):
-                        idx = thickness - 1 - j if side == 'lo' else -thickness + j
-                        field[:, idx, :] = interior * fac
+                    interior = np.copy(field[:, interior_idx, :])[:, None, :]
+                    sl = slice(0, thickness) if side == 'lo' else slice(-thickness, None)
+                    _apply((slice(None), sl, slice(None)), interior)
+                    if thickness < g:
+                        zero_sl = slice(thickness, g) if side == 'lo' else slice(-g, -thickness)
+                        field[:, zero_sl, :] = 0.0
                 elif axis == 2:
                     interior_idx = thickness if side == 'lo' else -thickness - 1
-                    interior = np.copy(field[:, :, interior_idx])
-                    for j, fac in enumerate(factors):
-                        idx = thickness - 1 - j if side == 'lo' else -thickness + j
-                        field[:, :, idx] = interior * fac
+                    interior = np.copy(field[:, :, interior_idx])[:, :, None]
+                    sl = slice(0, thickness) if side == 'lo' else slice(-thickness, None)
+                    _apply((slice(None), slice(None), sl), interior)
+                    if thickness < g:
+                        zero_sl = slice(thickness, g) if side == 'lo' else slice(-g, -thickness)
+                        field[:, :, zero_sl] = 0.0
             else:
                 logger.warning(f"Unknown boundary condition: {bc} - defaulting to periodic.")
                 field = np.roll(field, shift=g, axis=axis)

--- a/tests/test_boundary_conditions.py
+++ b/tests/test_boundary_conditions.py
@@ -1,4 +1,6 @@
 import json
+import json
+
 import pytest
 
 from boundary_conditions import BoundaryConditions, BoundaryTypeEnum
@@ -38,6 +40,15 @@ def test_conflict_resolution_policy_respected():
     data["conflictResolutionPolicy"] = "prefer_geometry"
     cfg = BoundaryConditions.model_validate(data, context={"geometry": "2D_RZ"})
     assert cfg.y_low is BoundaryTypeEnum.REFLECTING
+
+
+def test_pml_params_customizable():
+    data = BoundaryConditions.with_defaults().model_dump(by_alias=True)
+    data.update({"pmlThickness": 3, "pmlSigma": 1.5, "pmlProfile": "linear"})
+    cfg = BoundaryConditions.model_validate(data)
+    assert cfg.pml_thickness == 3
+    assert cfg.pml_sigma == 1.5
+    assert cfg.pml_profile == "linear"
 
 
 def test_round_trip_yaml():


### PR DESCRIPTION
## Summary
- add vectorized `pml` boundary branch to damp ghost cell fields
- expose PML parameters (thickness, sigma, profile) in boundary configuration
- test that PML configuration parses and damping behaves as expected

## Testing
- `pytest tests/test_pml_boundary.py tests/test_boundary_conditions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa685b0a3c832aa00f0a68bb41a68a