### PR TITLE
feat: add WarpX collision handling

### DIFF
--- a/src/dpf2/simulation/warp_piclibrary.py
+++ b/src/dpf2/simulation/warp_piclibrary.py
@@ -8,7 +8,7 @@ and simulation loop.
 """
 
 import logging
-from typing import Callable, Optional, Dict, Any
+from typing import Callable, Any
 import numpy as np
 
 # Assuming WarpX particle data might be accessible through objects passed here,
@@ -108,8 +108,8 @@ class PICCollisionHandler:
             return
 
         # --- Estimate plasma parameters ---------------------------------------------------
-        n1 = float(np.sum(w1)) if w1 is not None else float(v1.shape[0])
-        n2 = float(np.sum(w2)) if w2 is not None else float(v2.shape[0])
+        n1 = int(np.sum(w1)) if w1 is not None else int(v1.shape[0])
+        n2 = int(np.sum(w2)) if w2 is not None else int(v2.shape[0])
 
         volume = None
         if hasattr(warp_instance, "get_volume"):
@@ -139,7 +139,7 @@ class PICCollisionHandler:
             return
 
         # --- Determine colliding pairs ----------------------------------------------------
-        num_pairs = min(n1, n2)
+        num_pairs = int(min(n1, n2))
         if num_pairs == 0:
             return
         rand = np.random.random(num_pairs)
@@ -185,9 +185,14 @@ class PICCollisionHandler:
         for sp1, sp2 in species_pairs:
             try:
                 if hasattr(warp_instance, "add_collision_operator"):
-                    warp_instance.add_collision_operator(
-                        sp1, sp2, self.collision_freq_func, **self.kwargs
-                    )
+                    try:
+                        warp_instance.add_collision_operator(
+                            sp1, sp2, self.collision_freq_func, self.kwargs
+                        )
+                    except TypeError:
+                        warp_instance.add_collision_operator(
+                            sp1, sp2, self.collision_freq_func, **self.kwargs
+                        )
                 else:
                     import picmi  # type: ignore
 
@@ -199,7 +204,6 @@ class PICCollisionHandler:
                     if hasattr(warp_instance, "add_collision"):
                         warp_instance.add_collision(coll)
                     else:
-                        # Fallback: store collision operator list on instance
                         warp_instance.collisions = getattr(warp_instance, "collisions", [])
                         warp_instance.collisions.append(coll)
             except Exception as e:  # pragma: no cover - logging path

--- a/tests/test_pic_collisions.py
+++ b/tests/test_pic_collisions.py
@@ -29,7 +29,7 @@ class SimpleWarpX:
         return self._species[name]
 
     def add_collision_operator(self, s1, s2, freq_func, kwargs):
-        self.registered_ops.append((s1, s2))
+        self.registered_ops.append((s1, s2, freq_func, kwargs))
 
 
 def test_apply_collisions_scatter_velocities():
@@ -83,6 +83,9 @@ def test_apply_collisions_missing_hook():
 
 def test_setup_warpx_collisions_registers_ops():
     warp = SimpleWarpX()
-    handler = PICCollisionHandler(lambda ne, Te, Z=1.0: 1.0)
+    freq = lambda ne, Te, Z=1.0: 1.0
+    handler = PICCollisionHandler(freq)
     handler.setup_warpx_collisions(warp, [("e", "i")])
-    assert ("e", "i") in warp.registered_ops
+    assert warp.registered_ops[0][0:2] == ("e", "i")
+    assert warp.registered_ops[0][2] is freq
+    assert warp.registered_ops[0][3] == {}


### PR DESCRIPTION
## Summary
- implement Monte Carlo style collision scattering between WarpX species
- register collision operators with the WarpX object using provided frequency function
- add unit tests with mocked WarpX containers verifying collisions modify particle velocities

## Testing
- `pytest tests/test_pic_collisions.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aa685bdd18832a833b07c3d3df0585