### PR TITLE
Refine tests by removing pass placeholders

### DIFF
--- a/tests/test_circuit_model.py
+++ b/tests/test_circuit_model.py
@@ -45,7 +45,7 @@ def test_anode_radius_must_be_smaller():
 
 def test_collision_model_requires_spitzer():
     class BadCollision:
-        pass
+        """Collision model lacking the required spitzer_resistivity."""
 
     with pytest.raises(ValueError, match="spitzer_resistivity"):
         CircuitModel(

--- a/tests/test_dpf_simulation_run.py
+++ b/tests/test_dpf_simulation_run.py
@@ -14,7 +14,7 @@ class DummySolver:
         return 0.6
 
 class DummyEOS:
-    pass
+    """Dummy EOS used by the selector."""
 
 class DummyCircuit:
     def __init__(self, collision_model=None, field_manager=None, **kwargs):
@@ -63,7 +63,7 @@ def test_run_calls_modules(monkeypatch):
     module_registry_mod = ModuleType("module_registry")
     class ModuleRegistry:
         def register(self, *args, **kwargs):
-            pass
+            """Registry stub does nothing for tests."""
         def create(self, cls, config=None, field_manager=None, created_modules=None):
             config = config or {}
             return cls(field_manager=field_manager, **config)
@@ -72,14 +72,14 @@ def test_run_calls_modules(monkeypatch):
 
     collision_mod = ModuleType("collision_model")
     class CollisionModel(DummyCollision):
-        pass
+        """Simple collision model inheriting base behavior."""
     collision_mod.CollisionModel = CollisionModel
     monkeypatch.setitem(sys.modules, "collision_model", collision_mod)
 
     radiation_mod = ModuleType("radiation_model")
     class RadiationModel:
         def apply(self, state, dt):
-            pass
+            """No-op radiation step."""
         def checkpoint(self):
             return {}
     radiation_mod.RadiationModel = RadiationModel
@@ -88,7 +88,7 @@ def test_run_calls_modules(monkeypatch):
     hybrid_mod = ModuleType("hybrid_controller")
     class HybridController:
         def apply(self, state, dt):
-            pass
+            """No-op hybrid step."""
     hybrid_mod.HybridController = HybridController
     monkeypatch.setitem(sys.modules, "hybrid_controller", hybrid_mod)
 
@@ -102,35 +102,35 @@ def test_run_calls_modules(monkeypatch):
 
     circuit_mod = ModuleType("circuit")
     class CircuitModel(DummyCircuit):
-        pass
+        """Circuit model using DummyCircuit implementation."""
     circuit_mod.CircuitModel = CircuitModel
     monkeypatch.setitem(sys.modules, "circuit", circuit_mod)
 
     utils_mod = ModuleType("utils")
     class FieldManager:
         def __init__(self, *a, **k):
-            pass
+            """Placeholder field manager."""
         def get_J(self):
             return 0
     class SimulationState:
         def __init__(self, *a, **k):
-            pass
+            """Placeholder simulation state."""
     utils_mod.FieldManager = FieldManager
     utils_mod.SimulationState = SimulationState
     monkeypatch.setitem(sys.modules, "utils", utils_mod)
 
     diagnostics_mod = ModuleType("diagnostics")
     class Diagnostics(DummyDiagnostics):
-        pass
+        """Diagnostics stub capturing records."""
     diagnostics_mod.Diagnostics = Diagnostics
     monkeypatch.setitem(sys.modules, "diagnostics", diagnostics_mod)
 
     pic_solver_mod = ModuleType("pic_solver")
     class PICSolver:
         def __init__(self, *a, **k):
-            pass
+            """Initialize PIC solver stub."""
         def step(self):
-            pass
+            """No-op PIC step."""
     pic_solver_mod.PICSolver = PICSolver
     monkeypatch.setitem(sys.modules, "pic_solver", pic_solver_mod)
 

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -4,7 +4,7 @@ from dpf2.simulation.module_registry import ModuleRegistry
 
 
 class NotPhysics:
-    pass
+    """Simple class that does not inherit from PhysicsModule."""
 
 
 def test_register_non_physicsmodule_raises_type_error():

--- a/tests/test_pic_collisions.py
+++ b/tests/test_pic_collisions.py
@@ -73,7 +73,7 @@ def test_apply_collisions_unknown_species():
 
 def test_apply_collisions_missing_hook():
     class BrokenWarp:
-        pass
+        """WarpX-like object missing required collision interface."""
 
     warp = BrokenWarp()
     handler = PICCollisionHandler(lambda ne, Te: 1.0)

--- a/tests/test_resource_limits.py
+++ b/tests/test_resource_limits.py
@@ -21,7 +21,8 @@ def test_resource_limit_violation_triggers_simulation_error():
 
         class DummySock:
             def __init__(self, *a, **k):
-                pass
+                self.args = a
+                self.kwargs = k
             def route(self, *a, **k):
                 def decorator(f):
                     return f
@@ -42,14 +43,15 @@ def test_resource_limit_violation_triggers_simulation_error():
         sys.modules['config_schema'] = types.SimpleNamespace(ServerConfig=object, FieldManagerConfig=object)
         class DummyFieldManager:
             def __init__(self, *a, **k):
-                pass
+                self.config = {}
         sys.modules['utils'] = types.SimpleNamespace(FieldManager=DummyFieldManager)
         from dpf2.simulation import dpf_simulator_server as server
         from werkzeug.security import generate_password_hash
 
         class DummySimulation:
             def __init__(self, config, field_manager=None):
-                pass
+                self.config = config
+                self.field_manager = field_manager
             def run(self):
                 bytearray(300 * 1024 * 1024)
 

--- a/tests/test_sheath_dynamics.py
+++ b/tests/test_sheath_dynamics.py
@@ -18,7 +18,7 @@ class _SheathConfig:
         self.__dict__.update(kwargs)
 
 class _HybridConfig:
-    pass
+    """Placeholder for HybridConfig used in tests."""
 
 sys.modules.setdefault("config_schema", types.SimpleNamespace(SheathConfig=_SheathConfig, HybridConfig=_HybridConfig))
 

--- a/tests/test_total_steps_warning.py
+++ b/tests/test_total_steps_warning.py
@@ -47,7 +47,7 @@ def test_warning_on_invalid_dt(monkeypatch, caplog):
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
     class SheathConfig:
-        pass
+        """Minimal sheath configuration for test."""
     config_mod.SimulationConfig = SimulationConfig
     config_mod.SheathConfig = SheathConfig
     monkeypatch.setitem(sys.modules, "config_schema", config_mod)


### PR DESCRIPTION
## Summary
- replace placeholder `pass` blocks in test stubs with minimal logic or documentation
- ensure tests for simulation run, circuit model, resource limits, and others use explicit behavior instead of empty bodies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68aa68609f74832a944cf106a471977d