### PR TITLE
Implement wall function profiles and add tests

### DIFF
--- a/src/dpf2/simulation/turbulence_model.py
+++ b/src/dpf2/simulation/turbulence_model.py
@@ -228,20 +228,22 @@ class TurbulenceModel(PhysicsModule):
         elif self.wall_function_type == "power_law":
             # Simple power-law relation (1/7th power law).  The wall velocity
             # is extrapolated from the nearest interior cell using the power
-            # law profile.
+            # law profile.  We treat the left and right boundaries symmetrically
+            # by applying the same factor derived from the 1/7th power law.
             n = 7.0
             factor = (y / state.dx) ** (1.0 / n)
 
-            # Left boundary uses velocity from the next interior cell
-            state.velocity[g, :, :, 0] = state.velocity[g + 1, :, :, 0] * factor
-
-            # Right boundary uses velocity from the previous interior cell
-            state.velocity[nx - g - 1, :, :, 0] = state.velocity[nx - g - 2, :, :, 0] * factor
+            boundary_pairs = ((g, g + 1), (nx - g - 1, nx - g - 2))
+            for idx, interior in boundary_pairs:
+                state.velocity[idx, :, :, 0] = state.velocity[interior, :, :, 0] * factor
 
         else:
             # A defensive check in case an unsupported option slips through
             # configuration validation.
-            raise ValueError(f"Unknown wall function type: {self.wall_function_type}")
+            raise ValueError(
+                f"Unsupported wall function type '{self.wall_function_type}'. "
+                "Supported options are 'log_law' and 'power_law'."
+            )
 
     def initialize(self):
         """

--- a/tests/test_turbulence_model.py
+++ b/tests/test_turbulence_model.py
@@ -142,3 +142,19 @@ def test_unrecognized_wall_function_type_raises():
     with pytest.raises(ValueError):
         TurbulenceModel(cfg)
 
+
+def test_apply_wall_functions_rejects_unknown_option():
+    """Even after initialization with a valid option, setting an unsupported
+    wall function should trigger a descriptive error."""
+
+    cfg = TurbulenceConfig(wall_function_type="none")
+    model = TurbulenceModel(cfg)
+    state = _basic_state()
+    model.k = np.ones_like(state.density) * 0.1
+    model.epsilon = np.ones_like(state.density) * 0.01
+
+    model.wall_function_type = "invalid"
+
+    with pytest.raises(ValueError):
+        model._apply_wall_functions(state)
+


### PR DESCRIPTION
## Summary
- Extend `_apply_wall_functions` to symmetrically apply power-law boundary conditions and provide clear errors for unsupported options
- Add unit test exercising error handling when an invalid wall function is specified

## Testing
- ⚠️ `pytest tests/test_turbulence_model.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aa72c8df9c832aa4d68216ccb16978