### PR TITLE
Implement opacity model branches with validation and tests

### DIFF
--- a/src/dpf2/simulation/radiation_model.py
+++ b/src/dpf2/simulation/radiation_model.py
@@ -312,26 +312,31 @@ class RadiationModel(PhysicsModule):
 
         if model == "temperature_dependent":
             # κ = base + α * Te^β
-            try:
-                base = params["base"]
-                alpha = params["alpha"]
-                beta = params["beta"]
-            except KeyError as exc:  # pragma: no cover - error path
+            required = {"base", "alpha", "beta"}
+            missing = required.difference(params)
+            if missing:
                 raise ValueError(
-                    f"Missing opacity parameter for temperature_dependent model: {exc.args[0]}"
-                ) from exc
+                    "Missing opacity parameter for temperature_dependent model: "
+                    + ", ".join(sorted(missing))
+                )
+
+            base = params["base"]
+            alpha = params["alpha"]
+            beta = params["beta"]
             return np.array(base + alpha * np.power(Te, beta))
 
         if model == "density_dependent":
             # κ = base + α * quantity^exp where quantity is ne or Z
-            try:
-                base = params["base"]
-                alpha = params["alpha"]
-            except KeyError as exc:  # pragma: no cover - error path
+            required = {"base", "alpha"}
+            missing = required.difference(params)
+            if missing:
                 raise ValueError(
-                    f"Missing opacity parameter for density_dependent model: {exc.args[0]}"
-                ) from exc
+                    "Missing opacity parameter for density_dependent model: "
+                    + ", ".join(sorted(missing))
+                )
 
+            base = params["base"]
+            alpha = params["alpha"]
             use_Z = params.get("use_Z", False)
             if use_Z:
                 if "Z_exponent" not in params:

--- a/tests/test_radiation_opacity.py
+++ b/tests/test_radiation_opacity.py
@@ -125,6 +125,14 @@ def test_missing_density_param():
         rm._compute_opacity(Te=0.0, ne=1.0, Z=0.0)
 
 
+def test_missing_density_Z_exponent():
+    rm = _make_model(
+        "density_dependent", {"base": 0.1, "alpha": 0.2, "use_Z": True}
+    )
+    with pytest.raises(ValueError):
+        rm._compute_opacity(Te=0.0, ne=0.0, Z=1.0)
+
+
 def test_missing_params_object():
     rm = _make_model("constant", None)
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- Implement temperature and density dependent opacity calculations using provided parameters
- Validate opacity parameter dictionaries for required keys
- Add focused unit tests for opacity models and error handling

## Testing
- `pytest tests/test_radiation_opacity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa72ca3a10832a92251e040bfcfab9