### PR TITLE
Log invalid sim parameters

### DIFF
--- a/src/dpf2/simulation/dpf_simulator_server.py
+++ b/src/dpf2/simulation/dpf_simulator_server.py
@@ -265,7 +265,8 @@ def _validate_sim_parameters(params):
         ):
             raise ValueError
         return dx, sim_time, tuple(grid_shape)
-    except Exception:
+    except Exception as e:
+        logger.warning("Invalid simulation parameters: %s", e)
         abort(400, description="Invalid simulation parameters (dx, sim_time, grid_shape)")
 
 # ——— API Endpoints ———

--- a/tests/test_total_steps_warning.py
+++ b/tests/test_total_steps_warning.py
@@ -1,6 +1,8 @@
 import types
 import sys
 import importlib
+import importlib.util
+from pathlib import Path
 import logging
 
 import pytest
@@ -22,7 +24,19 @@ def test_warning_on_invalid_dt(monkeypatch, caplog):
     mpi_stub.MPI = types.SimpleNamespace(COMM_WORLD=None)
     monkeypatch.setitem(sys.modules, "mpi4py", mpi_stub)
 
+    pydantic_stub = types.ModuleType("pydantic")
+    pd_dataclasses = types.ModuleType("pydantic.dataclasses")
+    import dataclasses
+    pd_dataclasses.dataclass = dataclasses.dataclass
+    pydantic_stub.dataclasses = pd_dataclasses
+    monkeypatch.setitem(sys.modules, "pydantic", pydantic_stub)
+    monkeypatch.setitem(sys.modules, "pydantic.dataclasses", pd_dataclasses)
+
     # Stub internal modules referenced during import
+    package_stub = types.ModuleType("dpf2")
+    package_stub.__path__ = []
+    monkeypatch.setitem(sys.modules, "dpf2", package_stub)
+
     modules = {
         "module_registry": ["ModuleRegistry"],
         "fluid_solver_high_order": ["FluidSolverHighOrder"],
@@ -40,6 +54,8 @@ def test_warning_on_invalid_dt(monkeypatch, caplog):
         for attr in attrs:
             setattr(mod, attr, type(attr, (), {}))
         monkeypatch.setitem(sys.modules, name, mod)
+        monkeypatch.setitem(sys.modules, f"dpf2.{name}", mod)
+        setattr(package_stub, name, mod)
 
     # Minimal config schema stubs
     config_mod = types.ModuleType("config_schema")
@@ -52,8 +68,11 @@ def test_warning_on_invalid_dt(monkeypatch, caplog):
     config_mod.SheathConfig = SheathConfig
     monkeypatch.setitem(sys.modules, "config_schema", config_mod)
 
-    # Import module under test
-    sim_mod = importlib.import_module("dpf2.simulation.dpf_simulator_full_backend")
+    # Import module under test without package dependencies
+    module_path = Path(__file__).resolve().parent.parent / "src/dpf2/simulation/dpf_simulator_full_backend.py"
+    spec = importlib.util.spec_from_file_location("sim_mod", module_path)
+    sim_mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(sim_mod)
 
     with caplog.at_level(logging.WARNING):
         with pytest.raises(sim_mod.SimulationRuntimeError):

--- a/tests/test_validate_sim_parameters.py
+++ b/tests/test_validate_sim_parameters.py
@@ -1,0 +1,93 @@
+import importlib
+import types
+import sys
+import logging
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def test_invalid_sim_parameters_warn(monkeypatch, caplog):
+    """_validate_sim_parameters warns and aborts on bad input."""
+    # Stub external modules required for import
+    flask_stub = types.ModuleType("flask")
+    class DummyFlask:
+        def __init__(self, *args, **kwargs):
+            pass
+        def route(self, *args, **kwargs):
+            def decorator(f):
+                return f
+            return decorator
+        config = {}
+    def abort(code, description=None):
+        raise RuntimeError(description or str(code))
+    flask_stub.Flask = DummyFlask
+    flask_stub.request = None
+    flask_stub.jsonify = lambda *a, **k: {}
+    flask_stub.send_file = lambda *a, **k: None
+    flask_stub.abort = abort
+    monkeypatch.setitem(sys.modules, "flask", flask_stub)
+
+    flask_sock_stub = types.ModuleType("flask_sock")
+    class Sock:
+        def __init__(self, *args, **kwargs):
+            pass
+        def route(self, *args, **kwargs):
+            def decorator(f):
+                return f
+            return decorator
+    flask_sock_stub.Sock = Sock
+    monkeypatch.setitem(sys.modules, "flask_sock", flask_sock_stub)
+
+    dpf_sim_stub = types.ModuleType("dpf_simulation")
+    dpf_sim_stub.DPFSimulation = type("DPFSimulation", (), {})
+    class ConfigError(Exception):
+        pass
+    dpf_sim_stub.ConfigurationError = ConfigError
+    monkeypatch.setitem(sys.modules, "dpf_simulation", dpf_sim_stub)
+
+    config_schema_stub = types.ModuleType("config_schema")
+    config_schema_stub.ServerConfig = type("ServerConfig", (), {})
+    config_schema_stub.FieldManagerConfig = type("FieldManagerConfig", (), {})
+    monkeypatch.setitem(sys.modules, "config_schema", config_schema_stub)
+
+    pydantic_stub = types.ModuleType("pydantic")
+    pd_dataclasses = types.ModuleType("pydantic.dataclasses")
+    import dataclasses
+    pd_dataclasses.dataclass = dataclasses.dataclass
+    pydantic_stub.dataclasses = pd_dataclasses
+    monkeypatch.setitem(sys.modules, "pydantic", pydantic_stub)
+    monkeypatch.setitem(sys.modules, "pydantic.dataclasses", pd_dataclasses)
+
+    werk_stub = types.ModuleType("werkzeug")
+    werk_sec = types.ModuleType("werkzeug.security")
+    werk_sec.generate_password_hash = lambda x: x
+    werk_sec.check_password_hash = lambda h, p: True
+    werk_utils = types.ModuleType("werkzeug.utils")
+    werk_utils.secure_filename = lambda x: x
+    werk_stub.security = werk_sec
+    werk_stub.utils = werk_utils
+    monkeypatch.setitem(sys.modules, "werkzeug", werk_stub)
+    monkeypatch.setitem(sys.modules, "werkzeug.security", werk_sec)
+    monkeypatch.setitem(sys.modules, "werkzeug.utils", werk_utils)
+
+    sympy_stub = types.ModuleType("sympy")
+    sympy_stub.symbols = lambda *args, **kwargs: (None, None)
+    monkeypatch.setitem(sys.modules, "sympy", sympy_stub)
+
+    utils_stub = types.ModuleType("utils")
+    utils_stub.FieldManager = type("FieldManager", (), {})
+    monkeypatch.setitem(sys.modules, "utils", utils_stub)
+
+    module_path = Path(__file__).resolve().parent.parent / "src/dpf2/simulation/dpf_simulator_server.py"
+    spec = importlib.util.spec_from_file_location("server_mod", module_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    bad = {"dx": "bad", "sim_time": "1", "grid_shape": [1, 2, 3]}
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(RuntimeError):
+            mod._validate_sim_parameters(bad)
+
+    assert "Invalid simulation parameters" in caplog.text


### PR DESCRIPTION
## Summary
- warn when simulation parameter validation fails instead of silently aborting
- add coverage for invalid simulation parameters

## Testing
- `pytest tests/test_total_steps_warning.py tests/test_validate_sim_parameters.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa72cc9764832ab19578562cbfd353