### PR TITLE
Implement mixture EOS handling and validation

### DIFF
--- a/src/dpf2/simulation/eos.py
+++ b/src/dpf2/simulation/eos.py
@@ -141,18 +141,20 @@ class TabulatedEOS:
                         "filename must be a path or mapping when mixture_fractions are provided"
                     )
 
-                first = True
-                for species, path in species_files.items():
-                    if not path.is_file():
-                        raise ValueError(f"Missing EOS data for species '{species}'")
+                missing_files = [sp for sp, path in species_files.items() if not path.is_file()]
+                if missing_files:
+                    raise ValueError(
+                        "Missing EOS data for species: " + ", ".join(sorted(missing_files))
+                    )
+
+                for idx, (species, path) in enumerate(species_files.items()):
                     rho, T, p_tab, e_tab = _load_table(path)
                     weight = fractions.get(species, 0.0)
-                    if first:
+                    if idx == 0:
                         self.rho_grid = rho
                         self.T_grid = T
                         self.p_table = weight * p_tab
                         self.e_table = weight * e_tab
-                        first = False
                     else:
                         if not (
                             np.array_equal(self.rho_grid, rho)

--- a/src/dpf2/simulation/eos_selector.py
+++ b/src/dpf2/simulation/eos_selector.py
@@ -4,7 +4,8 @@ Selects and initializes the appropriate Equation of State (EOS) model.
 """
 import logging
 from typing import Any, Optional, Union
-from eos import TabulatedEOS, parse_mixture_fractions  # type: ignore
+
+from .eos import TabulatedEOS, parse_mixture_fractions
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_eos_selector.py
+++ b/tests/test_eos_selector.py
@@ -40,3 +40,14 @@ def test_select_eos_mixture_missing_data(tmp_path):
             table_file=str(tmp_path),
             mixture_fractions="A:0.5,B:0.5",
         )
+
+
+def test_select_eos_invalid_fractions(tmp_path):
+    _create_species_eos_file(tmp_path, "A")
+    _create_species_eos_file(tmp_path, "B")
+    with pytest.raises(ValueError):
+        select_eos(
+            "tabulated",
+            table_file=str(tmp_path),
+            mixture_fractions="A:0.3,B:0.3",
+        )

--- a/tests/test_tabulated_mixture_eos.py
+++ b/tests/test_tabulated_mixture_eos.py
@@ -1,5 +1,6 @@
 import h5py
 import numpy as np
+import pytest
 from pathlib import Path
 
 from dpf2.eos import TabulatedEOS
@@ -42,4 +43,24 @@ def test_mixed_eos_weighted_combination(tmp_path):
 
     np.testing.assert_allclose(mix_eos.pressure(rho, T_val), expected_p)
     np.testing.assert_allclose(mix_eos.energy(rho, T_val), expected_e)
+
+
+def test_mixed_eos_invalid_fraction_sum(tmp_path):
+    path_a = _create_species_file(tmp_path, "A", p_val=1.0, e_val=100.0)
+    path_b = _create_species_file(tmp_path, "B", p_val=2.0, e_val=200.0)
+    fractions = {"A": 0.2, "B": 0.2}
+
+    with pytest.raises(ValueError):
+        TabulatedEOS(
+            filename={"A": str(path_a), "B": str(path_b)},
+            mixture_fractions=fractions,
+        )
+
+
+def test_mixed_eos_missing_species_data(tmp_path):
+    path_a = _create_species_file(tmp_path, "A", p_val=1.0, e_val=100.0)
+    fractions = {"A": 0.5, "B": 0.5}
+
+    with pytest.raises(ValueError):
+        TabulatedEOS(filename=str(tmp_path), mixture_fractions=fractions)
 


### PR DESCRIPTION
## Summary
- validate and parse mixture fractions for TabulatedEOS
- combine species EOS tables weighted by fractions and check for missing data
- ensure eos selector forwards validated mixture fractions
- add tests for mixture EOS success and failure cases

## Testing
- `pytest tests/test_tabulated_mixture_eos.py -q` *(fails: No module named 'h5py')*
- `pytest tests/test_eos_selector.py -q` *(fails: No module named 'h5py')*


------
https://chatgpt.com/codex/tasks/task_e_68aa72ce1a54832aa9ec7350ff695208