### PR TITLE
Implement Bohm sheath field updates and add tests

### DIFF
--- a/src/dpf2/simulation/sheath_model.py
+++ b/src/dpf2/simulation/sheath_model.py
@@ -130,13 +130,20 @@ class BohmSheath:
         boundary to update.
         """
 
-        E = fm.get_E()
-        if self.axis == 0:
-            E[0, -1, :, :] = sheath_field
-        elif self.axis == 1:
-            E[1, :, -1, :] = sheath_field
-        else:  # default z
-            E[2, :, :, -1] = sheath_field
+        # Take a defensive copy so callers holding a reference to the
+        # ``FieldManager``'s electric field do not see it mutate until the
+        # update is committed.  This mirrors the behaviour of the public
+        # :meth:`update_E` API which expects a full array to be supplied.
+        E = fm.get_E().copy()
+
+        # Build an index tuple selecting the component normal to the sheath
+        # (``self.axis``) and the high-side boundary cell along the same
+        # spatial direction.  All transverse indices are left as ``slice(None)``
+        # so that the entire boundary plane is modified in one operation.
+        idx = [self.axis, slice(None), slice(None), slice(None)]
+        idx[self.axis + 1] = -1
+        E[tuple(idx)] = sheath_field
+
         fm.update_E(E)
 
     # ------------------------------------------------------------------

--- a/tests/test_bohm_sheath.py
+++ b/tests/test_bohm_sheath.py
@@ -85,6 +85,18 @@ def test_apply_direct_field_manager():
     assert np.allclose(fm.get_E()[2, :, :, -1], expected_field)
 
 
+def test_direct_field_manager_interior_unchanged():
+    """Applying to a FieldManager leaves interior cells untouched."""
+    _, fm = make_state()
+    sheath = BohmSheath(electron_temperature=4.0, ion_mass=1.67e-27)
+    sheath.apply(fm)
+    E = fm.get_E()
+    # Boundary updated
+    assert np.any(E[2, :, :, -1] != 0.0)
+    # Interior slice remains zero
+    assert np.all(E[2, :, :, -2] == 0.0)
+
+
 def test_apply_updates_momentum_array():
     density = np.ones((4, 4, 4))
     momentum = np.zeros((3, 4, 4, 4))


### PR DESCRIPTION
## Summary
- Use generic indexing and a defensive copy when applying Bohm sheath fields to a FieldManager
- Add regression test to ensure FieldManager interior cells remain unchanged after Bohm sheath application

## Testing
- `pytest tests/test_bohm_sheath.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa72d0a130832a88cda68418406a40