### PR TITLE
refactor: validate wall function type and improve tests

### DIFF
--- a/src/dpf2/simulation/turbulence_model.py
+++ b/src/dpf2/simulation/turbulence_model.py
@@ -2,7 +2,7 @@
 import numpy as np
 import logging
 from numba import njit, prange
-from models import PhysicsModule, SimulationState
+from .models import PhysicsModule, SimulationState
 from typing import Dict, Any, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - only for type checking
@@ -207,6 +207,13 @@ class TurbulenceModel(PhysicsModule):
         nx = state.velocity.shape[0]
         y = 0.5 * state.dx
 
+        valid_types = {"log_law", "power_law"}
+        if self.wall_function_type not in valid_types:
+            raise ValueError(
+                f"Unsupported wall function type '{self.wall_function_type}'. "
+                f"Supported options are 'log_law' and 'power_law'."
+            )
+
         if self.wall_function_type == "log_law":
             # Logarithmic law of the wall.  We apply the same relation to both
             # x-normal boundaries to keep the routine symmetric.  Only the
@@ -236,14 +243,6 @@ class TurbulenceModel(PhysicsModule):
             boundary_pairs = ((g, g + 1), (nx - g - 1, nx - g - 2))
             for idx, interior in boundary_pairs:
                 state.velocity[idx, :, :, 0] = state.velocity[interior, :, :, 0] * factor
-
-        else:
-            # A defensive check in case an unsupported option slips through
-            # configuration validation.
-            raise ValueError(
-                f"Unsupported wall function type '{self.wall_function_type}'. "
-                "Supported options are 'log_law' and 'power_law'."
-            )
 
     def initialize(self):
         """

--- a/tests/test_turbulence_model.py
+++ b/tests/test_turbulence_model.py
@@ -138,8 +138,7 @@ def test_wall_function_requires_initialized_turbulence_fields():
 def test_unrecognized_wall_function_type_raises():
     """Ensure an error is raised for unsupported wall function options."""
     cfg = TurbulenceConfig(wall_function_type="invalid_option")
-
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unknown wall function type"):
         TurbulenceModel(cfg)
 
 
@@ -154,7 +153,6 @@ def test_apply_wall_functions_rejects_unknown_option():
     model.epsilon = np.ones_like(state.density) * 0.01
 
     model.wall_function_type = "invalid"
-
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unsupported wall function type"):
         model._apply_wall_functions(state)
 


### PR DESCRIPTION
## Summary
- ensure turbulence model uses relative imports
- validate wall function type before applying profiles
- assert descriptive error messages in turbulence model tests

## Testing
- `pytest tests/test_turbulence_model.py::test_log_law_wall_function_adjusts_velocity_and_fields -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aa87be98b8832a8c29a93c729f6c0d