### PR TITLE
Improve exception handling and dt validation

### DIFF
--- a/src/dpf2/simulation/collision_model.py
+++ b/src/dpf2/simulation/collision_model.py
@@ -159,7 +159,8 @@ class CrossSectionData:
         obj.cross_section = np.array(data.get('cross_section', []))
         try:
             obj.interp = interp1d(obj.energy, obj.cross_section, bounds_error=False, fill_value=0.0)
-        except Exception:
+        except Exception as e:
+            logger.warning(f"Failed to construct cross-section interpolation: {e}")
             obj.interp = lambda E: 0.0
         return obj
 
@@ -420,7 +421,8 @@ class CollisionModel(CollisionOperator):
         if rng_state is not None:
             try:
                 np.random.set_state(rng_state)
-            except Exception:
+            except Exception as e:
+                logger.warning(f"Failed to restore RNG state: {e}")
                 np.random.seed()
         else:
             np.random.seed()

--- a/src/dpf2/simulation/dpf_simulator_amrex_backend.py
+++ b/src/dpf2/simulation/dpf_simulator_amrex_backend.py
@@ -7,8 +7,9 @@ import argparse
 import json
 try:  # pragma: no cover - optional MPI
     from mpi4py import MPI  # type: ignore
-except Exception:  # pragma: no cover
+except Exception as e:  # pragma: no cover
     MPI = None
+    logging.getLogger(__name__).warning("mpi4py not available: %s", e)
 from catalyst import CatalystPipeline
 from dpf_simulator_full_backend import DPFSimulatorBackend
 from fluid_solver_high_order import FluidSolver3DAMReX

--- a/src/dpf2/simulation/dpf_simulator_full_backend.py
+++ b/src/dpf2/simulation/dpf_simulator_full_backend.py
@@ -68,6 +68,10 @@ def _estimate_total_steps(sim_time, dt):
     Returns:
         int: Estimated number of steps.
     """
+    if dt is None or dt <= 0:
+        msg = f"Invalid dt={dt}: unable to estimate total steps"
+        logger.warning(msg)
+        raise SimulationRuntimeError(msg)
     try:
         total_steps = int(np.ceil(sim_time / float(dt)))
         logger.info("Estimated total steps: %d", total_steps)

--- a/src/dpf2/simulation/hybrid_controller.py
+++ b/src/dpf2/simulation/hybrid_controller.py
@@ -28,7 +28,8 @@ import queue
 from typing import Dict, Any, Optional, List
 try:
     import caliper  # Ribbon profiling
-except Exception:  # pragma: no cover - fallback for test environment
+except Exception as e:  # pragma: no cover - fallback for test environment
+    logging.getLogger(__name__).warning("Caliper not available: %s", e)
     from contextlib import contextmanager
 
     @contextmanager

--- a/src/dpf2/simulation/load_balance_metrics.py
+++ b/src/dpf2/simulation/load_balance_metrics.py
@@ -1,8 +1,13 @@
+import logging
 import numpy as np
+
+logger = logging.getLogger(__name__)
+
 try:
     from mpi4py import MPI  # type: ignore
-except Exception:  # pragma: no cover - mpi4py optional
+except Exception as e:  # pragma: no cover - mpi4py optional
     MPI = None
+    logger.warning(f"mpi4py not available: {e}")
 
 
 class LoadBalanceMetrics:

--- a/tests/test_total_steps_warning.py
+++ b/tests/test_total_steps_warning.py
@@ -78,4 +78,4 @@ def test_warning_on_invalid_dt(monkeypatch, caplog):
         with pytest.raises(sim_mod.SimulationRuntimeError):
             sim_mod._estimate_total_steps(1.0, 0.0)
 
-    assert "Failed to estimate total steps" in caplog.text
+    assert "Invalid dt=0.0: unable to estimate total steps" in caplog.text


### PR DESCRIPTION
## Summary
- add explicit `dt` validation in `_estimate_total_steps`
- log failures when cross-section interpolation or RNG restoration fails
- warn when optional dependencies like `mpi4py` or `caliper` are missing
- update test to assert warning for invalid `dt`

## Testing
- `pytest tests/test_total_steps_warning.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa87c32d64832abe6caa895fd5fd64