### PR TITLE
Centralize circuit solver module

### DIFF
--- a/rlc_solver.py
+++ b/rlc_solver.py
@@ -1,85 +1,10 @@
-import numpy as np
-from scipy.integrate import solve_ivp
-from typing import Tuple
+"""Compatibility wrapper for the circuit solver.
 
-from circuit_config import CircuitConfig
+This module re-exports :func:`dpf2.circuit_solver.run_circuit_simulation`
+for legacy code that imported ``run_circuit_simulation`` from the top-level
+``rlc_solver`` module.
+"""
 
+from dpf2.circuit_solver import run_circuit_simulation
 
-def _profile_to_interp(profile, t_scale: float, y_scale: float):
-    """Return interpolation functions for profile value and derivative."""
-    if profile is None:
-        return (lambda t: 0.0, lambda t: 0.0)
-    arr = np.asarray(profile, dtype=float)
-    t = arr[:, 0] * t_scale
-    y = arr[:, 1] * y_scale
-    dy_dt = np.gradient(y, t, edge_order=2)
-    def val(tt):
-        return np.interp(tt, t, y, left=y[0], right=y[-1])
-    def deriv(tt):
-        return np.interp(tt, t, dy_dt, left=dy_dt[0], right=dy_dt[-1])
-    return val, deriv
-
-
-def run_circuit_simulation(cfg: CircuitConfig, t_end: float, num_points: int = 1000) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    """Run RLC discharge with optional plasma and mutual inductance.
-
-    Parameters
-    ----------
-    cfg : CircuitConfig
-        Circuit configuration including optional coupling profiles.
-    t_end : float
-        End time in microseconds.
-    num_points : int, optional
-        Number of output points, by default 1000.
-
-    Returns
-    -------
-    tuple of ndarray
-        time [s], current [A], capacitor voltage [V], mutual current [A],
-        mutual-induced voltage [V].
-    """
-    L_ext = cfg.L_ext * 1e-6
-    R = cfg.R_ext * 1e-3
-    C = cfg.C_ext * 1e-6
-    V0 = cfg.V0 * 1e3
-    delay = cfg.switch_delay * 1e-9
-
-    lp_func, dlpdt_func = _profile_to_interp(cfg.plasma_inductance_profile, 1e-6, 1e-6)
-    m_func, _ = _profile_to_interp(cfg.mutual_inductance_profile, 1e-6, 1e-6)
-    im_func, dim_dt_func = _profile_to_interp(cfg.mutual_current_profile, 1e-6, 1e3)
-
-    def circuit_ode(t, y):
-        I, Q = y
-        Lp = lp_func(t)
-        dLpdt = dlpdt_func(t)
-        M = m_func(t)
-        dI_mutual_dt = dim_dt_func(t)
-        Ltot = L_ext + Lp
-        V_mutual = -M * dI_mutual_dt
-        dIdt = (V0 + V_mutual - R * I - Q / C - dLpdt * I) / Ltot
-        dQdt = I
-        return [dIdt, dQdt]
-
-    t_total = np.linspace(0.0, t_end * 1e-6, num_points)
-
-    if t_end * 1e-6 <= delay:
-        current = np.zeros_like(t_total)
-        voltage = np.full_like(t_total, V0)
-        i_mutual = im_func(t_total)
-        v_mutual = -m_func(t_total) * dim_dt_func(t_total)
-        return t_total, current, voltage, i_mutual, v_mutual
-
-    mask_before = t_total < delay
-    current = np.zeros_like(t_total)
-    voltage = np.full_like(t_total, V0)
-    i_mutual = im_func(t_total)
-    v_mutual = -m_func(t_total) * dim_dt_func(t_total)
-
-    t_eval = t_total[~mask_before]
-    q0 = C * V0
-    sol = solve_ivp(circuit_ode, (delay, t_total[-1]), [0.0, q0], t_eval=t_eval, method="BDF")
-
-    current[~mask_before] = sol.y[0]
-    voltage[~mask_before] = sol.y[1] / C
-
-    return t_total, current, voltage, i_mutual, v_mutual
+__all__ = ["run_circuit_simulation"]

--- a/src/dpf2/circuit_solver.py
+++ b/src/dpf2/circuit_solver.py
@@ -17,7 +17,9 @@ from typing import Tuple
 import numpy as np
 from scipy.integrate import solve_ivp
 
-__all__ = ["CircuitSolver", "RLCCircuit"]
+from circuit_config import CircuitConfig
+
+__all__ = ["CircuitSolver", "RLCCircuit", "run_circuit_simulation"]
 
 
 @dataclass
@@ -100,3 +102,89 @@ class CircuitSolver:
         else:
             raise ValueError("method must be 'analytical' or 'ode'")
         return t, I
+
+
+def _profile_to_interp(profile, t_scale: float, y_scale: float):
+    """Return interpolation functions for profile value and derivative."""
+    if profile is None:
+        return (lambda t: 0.0, lambda t: 0.0)
+    arr = np.asarray(profile, dtype=float)
+    t = arr[:, 0] * t_scale
+    y = arr[:, 1] * y_scale
+    dy_dt = np.gradient(y, t, edge_order=2)
+
+    def val(tt):
+        return np.interp(tt, t, y, left=y[0], right=y[-1])
+
+    def deriv(tt):
+        return np.interp(tt, t, dy_dt, left=dy_dt[0], right=dy_dt[-1])
+
+    return val, deriv
+
+
+def run_circuit_simulation(
+    cfg: CircuitConfig, t_end: float, num_points: int = 1000
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Run RLC discharge with optional plasma and mutual inductance.
+
+    Parameters
+    ----------
+    cfg:
+        Circuit configuration including optional coupling profiles.
+    t_end:
+        End time in microseconds.
+    num_points:
+        Number of output points, by default ``1000``.
+
+    Returns
+    -------
+    tuple of ndarray
+        time [s], current [A], capacitor voltage [V], mutual current [A],
+        mutual-induced voltage [V].
+    """
+
+    L_ext = cfg.L_ext * 1e-6
+    R = cfg.R_ext * 1e-3
+    C = cfg.C_ext * 1e-6
+    V0 = cfg.V0 * 1e3
+    delay = cfg.switch_delay * 1e-9
+
+    lp_func, dlpdt_func = _profile_to_interp(cfg.plasma_inductance_profile, 1e-6, 1e-6)
+    m_func, _ = _profile_to_interp(cfg.mutual_inductance_profile, 1e-6, 1e-6)
+    im_func, dim_dt_func = _profile_to_interp(cfg.mutual_current_profile, 1e-6, 1e3)
+
+    def circuit_ode(t, y):
+        I, Q = y
+        Lp = lp_func(t)
+        dLpdt = dlpdt_func(t)
+        M = m_func(t)
+        dI_mutual_dt = dim_dt_func(t)
+        Ltot = L_ext + Lp
+        V_mutual = -M * dI_mutual_dt
+        dIdt = (V0 + V_mutual - R * I - Q / C - dLpdt * I) / Ltot
+        dQdt = I
+        return [dIdt, dQdt]
+
+    t_total = np.linspace(0.0, t_end * 1e-6, num_points)
+
+    if t_end * 1e-6 <= delay:
+        current = np.zeros_like(t_total)
+        voltage = np.full_like(t_total, V0)
+        i_mutual = im_func(t_total)
+        v_mutual = -m_func(t_total) * dim_dt_func(t_total)
+        return t_total, current, voltage, i_mutual, v_mutual
+
+    mask_before = t_total < delay
+    current = np.zeros_like(t_total)
+    voltage = np.full_like(t_total, V0)
+    i_mutual = im_func(t_total)
+    v_mutual = -m_func(t_total) * dim_dt_func(t_total)
+
+    t_eval = t_total[~mask_before]
+    q0 = C * V0
+    sol = solve_ivp(circuit_ode, (delay, t_total[-1]), [0.0, q0], t_eval=t_eval, method="BDF")
+
+    current[~mask_before] = sol.y[0]
+    voltage[~mask_before] = sol.y[1] / C
+
+    return t_total, current, voltage, i_mutual, v_mutual

--- a/tests/test_rlc_solver.py
+++ b/tests/test_rlc_solver.py
@@ -1,6 +1,6 @@
 import numpy as np
 from circuit_config import CircuitConfig
-from rlc_solver import run_circuit_simulation
+from dpf2.circuit_solver import run_circuit_simulation
 
 
 def test_rlc_solver_runs():


### PR DESCRIPTION
## Summary
- move RLC circuit simulation routine into `dpf2.circuit_solver`
- keep top-level `rlc_solver` as thin compatibility wrapper
- update tests to import `run_circuit_simulation` from the canonical module

## Testing
- `pytest tests/test_rlc_solver.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68aa87c4d424832a9e54a5ed50b2f056