### PR TITLE
test: assert config serialization round trip

### DIFF
--- a/tests/test_core_schema_config.py
+++ b/tests/test_core_schema_config.py
@@ -49,7 +49,10 @@ def test_config_round_trip():
     data = json.loads(json_str)
     assert "simulation" in data
     reloaded = DPFConfig.model_validate(data)
+    # Reloaded configuration should match the original instance
     assert reloaded.model_dump() == cfg.model_dump()
+    # Serializing again should reproduce the original JSON representation
+    assert json.loads(reloaded.model_dump_json(by_alias=True)) == data
 
 
 def test_invalid_geometry():


### PR DESCRIPTION
## Summary
- strengthen config round-trip test by asserting reserialization matches original data

## Testing
- ❌ `pytest tests/test_core_schema_config.py::test_config_round_trip -q` (ModuleNotFoundError: No module named 'pydantic')

------
https://chatgpt.com/codex/tasks/task_e_68aa87c7fc48832a8559888290552ad3