### PR TITLE
Add CI workflow with lint, type, and test steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,26 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
-  test:
+  ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
-      - run: "pip install -e .[server,warpx]"
-      - run: pip install pytest pytest-cov
-      - run: pytest --cov=. --cov-report=xml
-      - uses: actions/upload-artifact@v3
-        with:
-          name: coverage-report
-          path: coverage.xml
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          pip install .[server,warpx]
+          pip install ruff mypy pytest
+      - name: Lint
+        run: ruff check .
+      - name: Type check
+        run: mypy .
+      - name: Test
+        run: pytest
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for linting, type checking, and testing

## Testing
- `ruff check .` *(fails: 301 errors)*
- `mypy .` *(fails: Unexpected indent in tests/test_hybrid_integration.py:32)*
- `pytest` *(fails: 62 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8c8e0110832a9188be606e9c6500