### PR TITLE
Refine error handling and expose custom exceptions

### DIFF
--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -1,8 +1,13 @@
 """Command line interface for DPF2."""
+import logging
+
 import click
 
 from ..core.config import DPFConfig
 from ..core.simulation import DPFSimulation
+from ..exceptions import ConfigurationError, SimulationError
+
+logger = logging.getLogger(__name__)
 
 
 @click.group()
@@ -15,9 +20,19 @@ def main() -> None:
 @click.option("--output", type=click.Path(), default="output", help="Output directory")
 def simulate(config: str | None, output: str) -> None:
     """Run a DPF simulation."""
-    cfg = DPFConfig() if config is None else DPFConfig()
-    sim = DPFSimulation(cfg)
-    sim.run(output_dir=output)
+    try:
+        cfg = DPFConfig.from_file(config) if config else DPFConfig()
+        sim = DPFSimulation(cfg)
+        sim.run(output_dir=output)
+    except ConfigurationError as e:
+        logger.error("Configuration error: %s", e)
+        raise click.ClickException(f"Configuration error: {e}")
+    except SimulationError as e:
+        logger.error("Simulation error: %s", e)
+        raise click.ClickException(f"Simulation error: {e}")
+    except Exception as e:
+        logger.exception("Unexpected error running simulation")
+        raise click.ClickException(f"Unexpected error: {e}")
 
 
 if __name__ == "__main__":

--- a/src/dpf2/exceptions.py
+++ b/src/dpf2/exceptions.py
@@ -1,0 +1,17 @@
+"""Custom exception hierarchy for the DPF2 project."""
+from __future__ import annotations
+
+class DPFError(Exception):
+    """Base class for all custom exceptions raised by DPF2."""
+
+class ConfigurationError(DPFError):
+    """Raised when a simulation or server configuration is invalid."""
+
+class SimulationError(DPFError):
+    """Raised for errors occurring during simulation execution."""
+
+class ServerError(DPFError):
+    """Base class for server-related errors."""
+
+class ExportError(ServerError):
+    """Raised when exporting results from the server fails."""

--- a/src/dpf2/simulation/dpf_simulator_server.py
+++ b/src/dpf2/simulation/dpf_simulator_server.py
@@ -16,29 +16,49 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from werkzeug.utils import secure_filename
 
 from dpf_simulation import DPFSimulation, ConfigurationError as SimConfigurationError
-from config_schema import ServerConfig, FieldManagerConfig # Import FieldManagerConfig
-from utils import FieldManager # Import FieldManager
+from config_schema import ServerConfig, FieldManagerConfig  # Import FieldManagerConfig
+from utils import FieldManager  # Import FieldManager
+
+# Import custom exception hierarchy
+try:  # pragma: no cover - handles execution as a module
+    from ..exceptions import (
+        ConfigurationError,
+        ExportError,
+        ServerError,
+        SimulationError,
+    )
+except Exception:  # pragma: no cover - fallback for direct execution
+    import os
+    import sys
+
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    from exceptions import (  # type: ignore
+        ConfigurationError,
+        ExportError,
+        ServerError,
+        SimulationError,
+    )
 
 # Configure logging
-logging.basicConfig(level=logging.INFO,
-                    format="%(asctime)s [%(levelname)s] %(message)s")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
 logger = logging.getLogger("DPFSimulatorServer")
 
 app = Flask(__name__)
 sock = Sock(app)
 
-# Custom Exceptions
-class ServerError(Exception):
-    pass
 
-class ConfigurationError(ServerError):
-    pass
+@app.errorhandler(ConfigurationError)
+def _handle_config_error(err: ConfigurationError):
+    """Return a JSON response for configuration errors."""
+    logger.error("Configuration error: %s", err)
+    return jsonify({"error": str(err)}), 400
 
-class SimulationError(ServerError):
-    pass
 
-class ExportError(ServerError):
-    pass
+@app.errorhandler(SimulationError)
+def _handle_sim_error(err: SimulationError):
+    """Return a JSON response for simulation errors."""
+    logger.error("Simulation error: %s", err)
+    return jsonify({"error": str(err)}), 500
 
 # ——— Simulation Interface ———
 class SimulationInterface:
@@ -79,8 +99,8 @@ class SimulationInterface:
             if hasattr(self._sim, "finalize"):
                 try:
                     self._sim.finalize()
-                except Exception:  # pragma: no cover - defensive
-                    logger.exception("Simulation finalization failed")
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.exception("Simulation finalization failed: %s", e)
 
     # ------------------------------------------------------------------
     def stop(self) -> None:
@@ -94,8 +114,8 @@ class SimulationInterface:
             if hasattr(self._sim, "config") and hasattr(self._sim, "current_time"):
                 try:
                     self._sim.config.sim_time = self._sim.current_time
-                except Exception:  # pragma: no cover - defensive
-                    logger.debug("Unable to adjust sim_time during stop")
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.debug("Unable to adjust sim_time during stop: %s", e)
 
     # ------------------------------------------------------------------
     def get_diagnostics(self):


### PR DESCRIPTION
## Summary
- Introduce centralized exception hierarchy (DPFError, SimulationError, ConfigurationError, etc.)
- Update CLI to surface actionable error messages and log context
- Integrate server with new exceptions and JSON error handlers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68aa8c975af0832abfd41a1e76a1c836