### PR TITLE
Ensure PhysicsModule import and Simulation alias for module registry

### DIFF
--- a/src/Simulation/__init__.py
+++ b/src/Simulation/__init__.py
@@ -1,0 +1,6 @@
+"""Compatibility package exposing the legacy Simulation namespace."""
+
+import importlib
+import sys
+
+sys.modules[__name__] = importlib.import_module("simulation")

--- a/src/dpf2/simulation/module_registry.py
+++ b/src/dpf2/simulation/module_registry.py
@@ -1,12 +1,13 @@
 # module_registry.py
+from Simulation.models import PhysicsModule  # Ensure plugin base class is available
+
 import importlib
 import inspect
 import logging
 import os
 from typing import Dict, Type, Any, List, Optional
-from pydantic import BaseModel, ValidationError
 
-from Simulation.models import PhysicsModule  # Ensure plugin base class is available
+from pydantic import BaseModel, ValidationError
 from utils import FieldManager
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- Move `PhysicsModule` import to the top of `module_registry` for correct initialization.
- Add legacy `Simulation` namespace alias so `python -m Simulation.module_registry` works.

## Testing
- `PYTHONPATH=src:src/dpf2 ./venv/bin/python -m Simulation.module_registry`
- `PYTHONPATH=src:src/dpf2 ./venv/bin/python - <<'PY'
from Simulation.module_registry import ModuleRegistry
class NotPhysics: pass
reg = ModuleRegistry()
try:
    reg.register(NotPhysics)
except TypeError as e:
    print('TypeError raised:', e)
PY`
- `PYTHONPATH=src:src/dpf2 ./venv/bin/pytest tests/test_module_registry.py -q` *(fails: DPFConfig model rebuild failed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9297716c832aa78cb8aee1ce1aeb