### PR TITLE
Implement opacity model formulas with validation and tests

### DIFF
--- a/src/dpf2/simulation/radiation_model.py
+++ b/src/dpf2/simulation/radiation_model.py
@@ -312,6 +312,9 @@ class RadiationModel(PhysicsModule):
 
             elif model == "temperature_dependent":
                 # κ = base + α * Te^β
+                for key in ("base", "alpha", "beta"):
+                    if key not in params:
+                        raise KeyError(key)
                 base = params["base"]
                 alpha = params["alpha"]
                 beta = params["beta"]
@@ -319,15 +322,20 @@ class RadiationModel(PhysicsModule):
 
             elif model == "density_dependent":
                 # κ = base + α * quantity^exp where quantity is ne or Z
+                for key in ("base", "alpha"):
+                    if key not in params:
+                        raise KeyError(key)
                 base = params["base"]
                 alpha = params["alpha"]
-                if params.get("use_Z", False):
-                    exponent = params["Z_exponent"]
-                    quantity = Z
-                else:
-                    exponent = params["ne_exponent"]
-                    quantity = ne
+
+                use_Z = params.get("use_Z", False)
+                exponent_key = "Z_exponent" if use_Z else "ne_exponent"
+                if exponent_key not in params:
+                    raise KeyError(exponent_key)
+                quantity = Z if use_Z else ne
+                exponent = params[exponent_key]
                 return np.array(base + alpha * quantity ** exponent, dtype=float)
+
         except KeyError as exc:
             # Provide a clear error message if any required parameter is missing
             raise ValueError(f"Missing opacity parameter: {exc.args[0]}") from exc

--- a/tests/test_radiation_opacity.py
+++ b/tests/test_radiation_opacity.py
@@ -113,34 +113,39 @@ def test_density_dependent_opacity_Z():
 
 def test_missing_constant_param():
     rm = _make_model("constant", {})
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         rm._compute_opacity(Te=0.0, ne=0.0, Z=0.0)
+    assert "constant_opacity" in str(exc.value)
 
 
 def test_missing_temperature_param():
     rm = _make_model("temperature_dependent", {"base": 1.0, "alpha": 0.5})
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         rm._compute_opacity(Te=1.0, ne=0.0, Z=0.0)
+    assert "beta" in str(exc.value)
 
 
 def test_missing_density_param():
     rm = _make_model("density_dependent", {"base": 0.1, "alpha": 0.2})
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         rm._compute_opacity(Te=0.0, ne=1.0, Z=0.0)
+    assert "ne_exponent" in str(exc.value)
 
 
 def test_missing_density_Z_exponent():
     rm = _make_model(
         "density_dependent", {"base": 0.1, "alpha": 0.2, "use_Z": True}
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         rm._compute_opacity(Te=0.0, ne=0.0, Z=1.0)
+    assert "Z_exponent" in str(exc.value)
 
 
 def test_missing_params_object():
     rm = _make_model("constant", None)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         rm._compute_opacity(Te=0.0, ne=0.0, Z=0.0)
+    assert "dictionary" in str(exc.value)
 
 
 def test_unknown_model():


### PR DESCRIPTION
## Summary
- compute opacity from temperature or density using parameters
- validate opacity parameters and raise clear errors
- add tests for all opacity models and missing parameter cases

## Testing
- `pytest tests/test_radiation_opacity.py`

------
https://chatgpt.com/codex/tasks/task_e_68aa9299c834832ab00e5b0288bba3e9