### PR TITLE
Restore collision model state on restart and test deterministic evolution

### DIFF
--- a/src/dpf2/simulation/collision_model.py
+++ b/src/dpf2/simulation/collision_model.py
@@ -441,19 +441,15 @@ class CollisionModel(CollisionOperator):
         if rng_state is not None:
             try:
                 np.random.set_state(rng_state)
-
             except Exception as e:
                 logger.warning(f"Failed to restore RNG state: {e}")
-
-            except Exception:
-                # If state is corrupt fall back to a deterministic seed so that
-                # behaviour after restart is still reproducible.
-
-                np.random.seed()
+                # Fall back to a deterministic seed so behaviour after restart
+                # remains reproducible even if the state object is corrupt.
+                np.random.seed(0)
         else:
-            # No RNG state stored – reseed to avoid using an uncontrolled
-            # previous state.
-            np.random.seed()
+            # No RNG state stored – reset to a deterministic seed rather than
+            # continuing from an uncontrolled global state.
+            np.random.seed(0)
 
         # Keep a copy of the checkpoint for idempotency checks
         self.checkpoint_data = dict(data)

--- a/tests/test_collision_model_restart.py
+++ b/tests/test_collision_model_restart.py
@@ -152,3 +152,34 @@ def test_checkpoint_restart_reproduces_behavior(collision_model_classes):
     assert list(cm.ionization_cross_section.energy) == energy_before
     assert list(cm.ionization_cross_section.cross_section) == xs_before
 
+
+def test_checkpoint_restart_identical_evolution(collision_model_classes):
+    """After restarting from a checkpoint the model should evolve identically."""
+    CollisionModel, _ = collision_model_classes
+    cm_module = sys.modules[CollisionModel.__module__]
+    np = cm_module.np
+
+    cm1 = CollisionModel({})
+
+    # Capture a checkpoint of the initial state
+    import copy
+    data = copy.deepcopy(cm1.checkpoint())
+
+    # "Evolve" the model once: update an accumulator and draw a random number
+    cm1.accumulators['steps'] = cm1.accumulators.get('steps', 0) + 1
+    rand1 = np.random.rand()
+    cm1.caches['rand'] = rand1
+    evolved1 = cm1.checkpoint()
+
+    # Restart from the original checkpoint and perform the same evolution
+    cm2 = CollisionModel({})
+    cm2.restart(data)
+    cm2.accumulators['steps'] = cm2.accumulators.get('steps', 0) + 1
+    rand2 = np.random.rand()
+    cm2.caches['rand'] = rand2
+    evolved2 = cm2.checkpoint()
+
+    # The random draw and the resulting state after evolution must match
+    assert rand1 == rand2
+    assert evolved1 == evolved2
+


### PR DESCRIPTION
## Summary
- Ensure collision model `restart` rebuilds cross-section tables, restores internal state, and resets RNG deterministically
- Add regression test confirming evolution remains identical after `checkpoint`/`restart`

## Testing
- `pytest tests/test_collision_model_restart.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa929aaa88832a895f561211dce5aa