### PR TITLE
Improve dt estimation error handling

### DIFF
--- a/src/dpf2/simulation/dpf_simulator_full_backend.py
+++ b/src/dpf2/simulation/dpf_simulator_full_backend.py
@@ -77,8 +77,7 @@ def _estimate_total_steps(sim_time, dt):
         logger.info("Estimated total steps: %d", total_steps)
         return total_steps
     except Exception as e:  # pragma: no cover - defensive, tested separately
-        msg = f"Failed to estimate total steps: {e}"
-        logger.warning(msg)
+        logger.exception("Failed to estimate total steps: %s", e)
         raise SimulationRuntimeError(
             f"Invalid dt={dt}: unable to estimate total steps"
         ) from e

--- a/tests/test_total_steps_warning.py
+++ b/tests/test_total_steps_warning.py
@@ -8,8 +8,8 @@ import logging
 import pytest
 
 
-def test_warning_on_invalid_dt(monkeypatch, caplog):
-    """Ensure a warning is logged and an error raised for invalid dt."""
+def _load_sim_module(monkeypatch):
+    """Import ``dpf_simulator_full_backend`` with minimal stubs."""
 
     # Stub external dependencies
     np_stub = types.ModuleType("numpy")
@@ -73,9 +73,33 @@ def test_warning_on_invalid_dt(monkeypatch, caplog):
     spec = importlib.util.spec_from_file_location("sim_mod", module_path)
     sim_mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(sim_mod)
+    return sim_mod
 
+
+def test_warning_on_invalid_dt(monkeypatch, caplog):
+    """Ensure a warning is logged and an error raised for invalid dt."""
+
+    sim_mod = _load_sim_module(monkeypatch)
     with caplog.at_level(logging.WARNING):
         with pytest.raises(sim_mod.SimulationRuntimeError):
             sim_mod._estimate_total_steps(1.0, 0.0)
 
     assert "Invalid dt=0.0: unable to estimate total steps" in caplog.text
+
+
+def test_failure_logging_on_non_numeric_dt(monkeypatch, caplog):
+    """Ensure failures during estimation are logged and raise an error."""
+
+    sim_mod = _load_sim_module(monkeypatch)
+
+    class BadNumber:
+        def __float__(self):
+            raise TypeError("no float conversion")
+        def __le__(self, other):
+            return False
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(sim_mod.SimulationRuntimeError):
+            sim_mod._estimate_total_steps(1.0, BadNumber())
+
+    assert "Failed to estimate total steps" in caplog.text


### PR DESCRIPTION
## Summary
- log failures estimating total steps with exception details
- raise SimulationRuntimeError with invalid dt and log
- add regression tests for invalid and non-numeric dt

## Testing
- `pytest tests/test_total_steps_warning.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa929c9074832a80a56a2c6410c7c1