### PR TITLE
Handle EOS mixtures with fraction validation

### DIFF
--- a/src/dpf2/simulation/eos.py
+++ b/src/dpf2/simulation/eos.py
@@ -122,6 +122,7 @@ class TabulatedEOS:
             return rho_grid, T_grid, p_table, e_table
 
         fractions = parse_mixture_fractions(mixture_fractions)
+        self.mixture_fractions = fractions
 
         try:
             if fractions:
@@ -216,36 +217,36 @@ class TabulatedEOS:
             logger.error(f"Error interpolating electron pressure: {e}")
             raise
 
-    def ion_energy(self, rho, p):
+    def ion_energy(self, rho, T):
         """
-        Returns the ion internal energy at a given density and pressure.
+        Returns the ion internal energy at a given density and temperature.
 
         Args:
             rho (np.ndarray): Mass density (kg/m^3).
-            p (np.ndarray): Pressure (Pa).
+            T (np.ndarray): Temperature (K).
 
         Returns:
             np.ndarray: Ion internal energy (J/kg).
         """
         try:
-            return self.e_interp(np.stack([rho, p], axis=-1))
+            return self.e_interp(np.stack([rho, T], axis=-1))
         except Exception as e:
             logger.error(f"Error interpolating ion energy: {e}")
             raise
 
-    def electron_energy(self, rho, p):
+    def electron_energy(self, rho, T):
         """
-        Returns the electron internal energy at a given density and pressure.
+        Returns the electron internal energy at a given density and temperature.
 
         Args:
             rho (np.ndarray): Mass density (kg/m^3).
-            p (np.ndarray): Pressure (Pa).
+            T (np.ndarray): Temperature (K).
 
         Returns:
             np.ndarray: Electron internal energy (J/kg).
         """
         try:
-            return self.e_interp(np.stack([rho, p], axis=-1))
+            return self.e_interp(np.stack([rho, T], axis=-1))
         except Exception as e:
             logger.error(f"Error interpolating electron energy: {e}")
             raise

--- a/src/dpf2/simulation/eos_selector.py
+++ b/src/dpf2/simulation/eos_selector.py
@@ -5,7 +5,7 @@ Selects and initializes the appropriate Equation of State (EOS) model.
 import logging
 from typing import Any, Optional, Union
 
-from .eos import TabulatedEOS
+from .eos import TabulatedEOS, parse_mixture_fractions
 
 logger = logging.getLogger(__name__)
 
@@ -39,10 +39,14 @@ def select_eos(
         if table_file is None:
             logger.error("Tabulated EOS backend selected, but 'table_file' not provided.")
             raise ValueError("Missing 'table_file' for tabulated EOS backend.")
+        fractions = None
+        if mixture_fractions is not None:
+            fractions = parse_mixture_fractions(mixture_fractions)
+
         try:
             eos_instance = TabulatedEOS(
                 filename=table_file,
-                mixture_fractions=mixture_fractions,
+                mixture_fractions=fractions,
             )
             logger.info(f"Instantiated TabulatedEOS from file: {table_file}")
             return eos_instance

--- a/tests/test_eos_selector.py
+++ b/tests/test_eos_selector.py
@@ -66,3 +66,25 @@ def test_select_eos_invalid_fractions(tmp_path):
             table_file=str(tmp_path),
             mixture_fractions="A:0.3,B:0.3",
         )
+
+
+def test_select_eos_invalid_format(tmp_path):
+    _create_species_eos_file(tmp_path, "A")
+    _create_species_eos_file(tmp_path, "B")
+    with pytest.raises(ValueError):
+        select_eos(
+            "tabulated",
+            table_file=str(tmp_path),
+            mixture_fractions="A:0.5,B",
+        )
+
+
+def test_select_eos_negative_fraction(tmp_path):
+    _create_species_eos_file(tmp_path, "A")
+    _create_species_eos_file(tmp_path, "B")
+    with pytest.raises(ValueError):
+        select_eos(
+            "tabulated",
+            table_file=str(tmp_path),
+            mixture_fractions="A:-0.1,B:1.1",
+        )

--- a/tests/test_tabulated_mixture_eos.py
+++ b/tests/test_tabulated_mixture_eos.py
@@ -68,3 +68,34 @@ def test_mixed_eos_missing_species_data(tmp_path):
     with pytest.raises(ValueError):
         TabulatedEOS(filename=str(tmp_path), mixture_fractions=fractions)
 
+
+def test_mixed_eos_string_fractions(tmp_path):
+    path_a = _create_species_file(tmp_path, "A", p_val=1.0, e_val=100.0)
+    path_b = _create_species_file(tmp_path, "B", p_val=2.0, e_val=200.0)
+    mix_eos = TabulatedEOS(
+        filename=str(tmp_path),
+        mixture_fractions="A:0.5,B:0.5",
+    )
+    eos_a = TabulatedEOS(str(path_a))
+    eos_b = TabulatedEOS(str(path_b))
+
+    rho = np.array([1.0])
+    T_val = np.array([10.0])
+
+    expected_p = 0.5 * eos_a.pressure(rho, T_val) + 0.5 * eos_b.pressure(rho, T_val)
+    expected_e = 0.5 * eos_a.energy(rho, T_val) + 0.5 * eos_b.energy(rho, T_val)
+
+    np.testing.assert_allclose(mix_eos.pressure(rho, T_val), expected_p)
+    np.testing.assert_allclose(mix_eos.energy(rho, T_val), expected_e)
+
+
+def test_mixed_eos_negative_fraction(tmp_path):
+    path_a = _create_species_file(tmp_path, "A", p_val=1.0, e_val=100.0)
+    path_b = _create_species_file(tmp_path, "B", p_val=2.0, e_val=200.0)
+
+    with pytest.raises(ValueError):
+        TabulatedEOS(
+            filename={"A": str(path_a), "B": str(path_b)},
+            mixture_fractions={"A": -0.1, "B": 1.1},
+        )
+


### PR DESCRIPTION
## Summary
- support combining multiple EOS species tables using mixture fractions
- validate and parse mixture fractions in `select_eos`
- test valid and invalid mixture configurations

## Testing
- `pytest tests/test_tabulated_mixture_eos.py tests/test_eos_selector.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Cannot connect to proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa929de484832abeeda18ecc93fa30