### PR TITLE
refactor: centralize base class imports

### DIFF
--- a/src/dpf2/__init__.py
+++ b/src/dpf2/__init__.py
@@ -1,12 +1,7 @@
 """DPF2 high-fidelity simulation toolkit."""
 
-from .core import (
-    DPFConfig,
-    DPFSimulation,
-    PlasmaSolverBase,
-    CircuitSolverBase,
-    DiagnosticsBase,
-)
+from .core import DPFConfig, DPFSimulation
+from .core.bases import PlasmaSolverBase, CircuitSolverBase, DiagnosticsBase
 from .ai import SurrogateModel, TorchSurrogateModel, ONNXSurrogateModel
 
 from .version import __version__

--- a/src/dpf2/core/__init__.py
+++ b/src/dpf2/core/__init__.py
@@ -1,13 +1,13 @@
-"""Core components for simplified DPF simulations."""
+"""Core components for simplified DPF simulations.
+
+Base classes for solver components now live in :mod:`dpf2.core.bases` and
+are no longer re-exported here.
+"""
 
 from .config import DPFConfig
 from .simulation import DPFSimulation
-from .bases import PlasmaSolverBase, CircuitSolverBase, DiagnosticsBase
 
 __all__ = [
     "DPFConfig",
     "DPFSimulation",
-    "PlasmaSolverBase",
-    "CircuitSolverBase",
-    "DiagnosticsBase",
 ]

--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -15,7 +15,7 @@ from typing import Any, Callable
 import numpy as np
 from scipy.constants import mu_0
 
-from dpf2.core import PlasmaSolverBase
+from dpf2.core.bases import PlasmaSolverBase
 from .eos import EOSBase, IdealGasEOS
 from .chemistry import ChemistryModel, SahaEquilibrium
 from .radiation import RadiationBase

--- a/src/dpf2/solvers/axisymmetric_hlld.py
+++ b/src/dpf2/solvers/axisymmetric_hlld.py
@@ -15,8 +15,9 @@ The solver operates on state dictionaries containing 2-D ``numpy.ndarray``
 objects.  The expected fields are ``rho`` (density), the three momentum
 components ``mom_r``, ``mom_phi`` and ``mom_z``, magnetic field components
 ``B_r``, ``B_phi`` and ``B_z`` and the total ``energy``.  The public
-:class:`AxisymmetricHLLD` class conforms to :class:`~dpf2.core.PlasmaSolverBase`
-by providing a :meth:`step` method advancing the state by ``dt`` seconds.
+:class:`AxisymmetricHLLD` class conforms to
+:class:`~dpf2.core.bases.PlasmaSolverBase` by providing a :meth:`step` method
+advancing the state by ``dt`` seconds.
 
 The goal of the tests is not to provide a production ready plasma solver, but
 rather to exercise the interface and demonstrate the constrained transport
@@ -29,7 +30,7 @@ from typing import Dict
 
 import numpy as np
 
-from dpf2.core import PlasmaSolverBase
+from dpf2.core.bases import PlasmaSolverBase
 
 State = Dict[str, np.ndarray]
 


### PR DESCRIPTION
## Summary
- stop re-exporting solver base classes from `dpf2.core`
- import base classes via `dpf2.core.bases` across the codebase
- update solver modules and root package to reference unified base module

## Testing
- `pytest` *(fails: module 'numpy' has no attribute 'pi')*

------
https://chatgpt.com/codex/tasks/task_e_68aa929f4c8c832a8e68081466ff4cbf