### PR TITLE
Add diagnostics for Bohm sheath boundary updates

### DIFF
--- a/src/dpf2/simulation/sheath_model.py
+++ b/src/dpf2/simulation/sheath_model.py
@@ -94,6 +94,10 @@ class BohmSheath:
         self.ion_mass = ion_mass
         self.axis = axis
 
+        # Expose last computed sheath properties for diagnostics/testing
+        self.last_velocity = 0.0
+        self.last_potential = 0.0
+
     # ------------------------------------------------------------------
     def _bohm_velocity(self) -> float:
         """Return the Bohm velocity based on the stored temperature/mass."""
@@ -160,6 +164,12 @@ class BohmSheath:
 
         v_bohm = self._bohm_velocity()
         phi_s = self._sheath_potential()
+
+        # Record the quantities used for boundary updates so that callers can
+        # inspect them after application.  This is helpful for debugging and
+        # for unit tests that wish to verify the Bohm criterion is enforced.
+        self.last_velocity = v_bohm
+        self.last_potential = phi_s
 
         # Determine grid spacing along the sheath-normal axis for field estimate
         spacing = 1.0

--- a/tests/test_bohm_sheath.py
+++ b/tests/test_bohm_sheath.py
@@ -107,6 +107,22 @@ def test_apply_updates_momentum_array():
     assert np.all(momentum[2, :, :, -2] == 0.0)
 
 
+def test_apply_updates_momentum_array_with_density():
+    """Momentum updates scale with the local density at the boundary."""
+    density = np.full((4, 4, 4), 2.0)
+    momentum = np.zeros((3, 4, 4, 4))
+    sheath = BohmSheath(electron_temperature=2.0, ion_mass=1.67e-27)
+    sheath.apply(density, momentum)
+    v_bohm = np.sqrt(e_charge * 2.0 / 1.67e-27)
+    mass_ratio = 1.67e-27 / (2 * np.pi * m_e)
+    phi_s = 2.0 * np.log(np.sqrt(mass_ratio))
+    assert np.allclose(momentum[2, :, :, -1], 2.0 * v_bohm)
+    assert np.all(momentum[2, :, :, -2] == 0.0)
+    # Confirm the sheath object recorded the values used for the update
+    assert np.isclose(sheath.last_velocity, v_bohm)
+    assert np.isclose(sheath.last_potential, phi_s)
+
+
 def test_apply_handles_all_axes():
     """The sheath orientation can be changed via the ``axis`` parameter."""
     mass_ratio = 1.67e-27 / (2 * np.pi * m_e)


### PR DESCRIPTION
## Summary
- expose last computed Bohm sheath velocity and potential for debugging
- test that Bohm sheath momentum updates scale with density and record diagnostic values

## Testing
- `pytest -q` *(fails: No module named 'numpy' and other missing dependencies)*
- `pip install numpy pydantic werkzeug -q` *(fails: Could not find a version that satisfies the requirement numpy due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68aa92a03db8832aba69662e68bdaff1