### PR TITLE
Apply boundary conditions per component and verify field shapes

### DIFF
--- a/src/dpf2/simulation/utils.py
+++ b/src/dpf2/simulation/utils.py
@@ -184,8 +184,18 @@ class FieldManager:
             bc = self.boundary_conditions.get(bc_key, 'periodic')
             side = 'lo' if bc_key.endswith('lo') else 'hi'
             if bc == 'periodic':
-                # Periodic boundary conditions
-                field = np.roll(field, shift=g, axis=axis)
+                # Periodic boundary conditions: copy opposite interior values into
+                # ghost cells without shifting the interior.  This maintains the
+                # original field orientation while wrapping boundary data.
+                if axis == 0:
+                    field[:g, :, :] = field[-2 * g:-g, :, :]
+                    field[-g:, :, :] = field[g:2 * g, :, :]
+                elif axis == 1:
+                    field[:, :g, :] = field[:, -2 * g:-g, :]
+                    field[:, -g:, :] = field[:, g:2 * g, :]
+                elif axis == 2:
+                    field[:, :, :g] = field[:, :, -2 * g:-g]
+                    field[:, :, -g:] = field[:, :, g:2 * g]
             elif bc == 'neumann':
                 # Neumann (zero-gradient) boundary conditions
                 if axis == 0:
@@ -262,9 +272,18 @@ class FieldManager:
                         zero_sl = slice(thickness, g) if side == 'lo' else slice(-g, -thickness)
                         field[:, :, zero_sl] = 0.0
             else:
-                logger.warning(f"Unknown boundary condition: {bc} - defaulting to periodic.")
-                field = np.roll(field, shift=g, axis=axis)
-            return field
+                logger.warning(
+                    f"Unknown boundary condition: {bc} - defaulting to periodic."
+                )
+                if axis == 0:
+                    field[:g, :, :] = field[-2 * g:-g, :, :]
+                    field[-g:, :, :] = field[g:2 * g, :, :]
+                elif axis == 1:
+                    field[:, :g, :] = field[:, -2 * g:-g, :]
+                    field[:, -g:, :] = field[:, g:2 * g, :]
+                elif axis == 2:
+                    field[:, :, :g] = field[:, :, -2 * g:-g]
+                    field[:, :, -g:] = field[:, :, g:2 * g]
 
         # Apply boundary conditions to each field component in-place without
         # creating temporary stacked arrays.  This ensures that ``E``, ``B`` and

--- a/tests/test_field_manager_boundary_shapes.py
+++ b/tests/test_field_manager_boundary_shapes.py
@@ -1,5 +1,14 @@
 import numpy as np
-from dpf2.simulation.utils import FieldManager
+import importlib.util
+from pathlib import Path
+
+# Import FieldManager directly from the source file to avoid triggering package
+# level imports that require heavy dependencies.
+utils_path = Path(__file__).resolve().parents[1] / "src" / "dpf2" / "simulation" / "utils.py"
+spec = importlib.util.spec_from_file_location("field_utils", utils_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+FieldManager = module.FieldManager
 
 def test_apply_boundary_conditions_preserves_shape_and_updates_boundaries():
     nx = ny = nz = 4
@@ -41,3 +50,41 @@ def test_apply_boundary_conditions_preserves_shape_and_updates_boundaries():
         assert np.all(arr[:, :, :, -1] == 0.0)
         # Interior cells remain unchanged
         assert np.all(arr[:, 1:-1, 1:-1, 1:-1] == 1.0)
+
+
+def test_apply_boundary_conditions_periodic_wraps_values():
+    nx = ny = nz = 4
+    boundary_conditions = {
+        "x_lo": "periodic",
+        "x_hi": "periodic",
+        "y_lo": "periodic",
+        "y_hi": "periodic",
+        "z_lo": "periodic",
+        "z_hi": "periodic",
+        "ghost_cells": 1,
+    }
+    fm = FieldManager(
+        grid_shape=(nx, ny, nz),
+        dx=1.0,
+        dy=1.0,
+        dz=1.0,
+        domain_lo=(0.0, 0.0, 0.0),
+        boundary_conditions=boundary_conditions,
+    )
+
+    # Populate fields with distinct values along the x-axis
+    for arr in (fm.E, fm.B, fm.J):
+        for i in range(nx):
+            arr[:, i, :, :] = i
+
+    fm.apply_boundary_conditions(None)
+
+    expected_shape = (3, nx, ny, nz)
+    assert fm.E.shape == expected_shape
+    assert fm.B.shape == expected_shape
+    assert fm.J.shape == expected_shape
+
+    for arr in (fm.E, fm.B, fm.J):
+        # Ghost cells should wrap to the opposite interior values
+        assert np.all(arr[:, 0, :, :] == arr[:, -2, :, :])
+        assert np.all(arr[:, -1, :, :] == arr[:, 1, :, :])


### PR DESCRIPTION
## Summary
- Update FieldManager to apply boundary conditions in place per component, avoiding `np.stack`
- Preserve field shapes and handle periodic wrapping explicitly
- Add tests for Dirichlet and periodic boundary conditions ensuring shape integrity

## Testing
- `venv/bin/python -m pytest tests/test_field_manager_boundary_shapes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa92a1cd54832abbae5214843b83a2