### PR TITLE
Add configurable PML boundary support

### DIFF
--- a/src/dpf2/simulation/config_schema.py
+++ b/src/dpf2/simulation/config_schema.py
@@ -119,13 +119,17 @@ class GeometryConfig(BaseModel):
 
 class FieldManagerConfig(BaseModel):
     """Configuration for the FieldManager."""
-    boundary_conditions: Dict[str, str] = Field(
+    boundary_conditions: Dict[str, Any] = Field(
         default_factory=lambda: {
             'x_lo': 'periodic', 'x_hi': 'periodic',
             'y_lo': 'periodic', 'y_hi': 'periodic',
             'z_lo': 'periodic', 'z_hi': 'periodic'
         },
-        description="Boundary conditions for the electromagnetic fields."
+        description=(
+            "Boundary conditions for the electromagnetic fields.  Extra keys such as"
+            " 'pml_thickness', 'pml_sigma' and 'pml_profile' may be supplied to"
+            " configure perfectly matched layers."
+        ),
     )
     field_smoothing_enabled: bool = Field(False, description="Enable field smoothing")
     field_smoothing_iterations: int = Field(0, description="Number of iterations for field smoothing")

--- a/src/dpf2/simulation/utils.py
+++ b/src/dpf2/simulation/utils.py
@@ -227,40 +227,35 @@ class FieldManager:
                 profile = self.boundary_conditions.get('pml_profile', 'exponential')
                 factors = _pml_factors(thickness, sigma, profile)
 
-                def _apply(axis_slc, interior):
-                    facs = factors[::-1] if side == 'lo' else factors
-                    if axis == 0:
-                        facs = facs[:, None, None]
-                    elif axis == 1:
-                        facs = facs[None, :, None]
-                    else:
-                        facs = facs[None, None, :]
-                    field[axis_slc] = interior * facs
+                # Determine the slices selecting the ghost region and its
+                # neighbouring interior cell.  All heavy lifting is then done
+                # via broadcasting so the logic is identical for all axes.
+                ghost_slice = [slice(None)] * 3
+                interior_slice = [slice(None)] * 3
+                if side == 'lo':
+                    ghost_slice[axis] = slice(0, thickness)
+                    interior_slice[axis] = thickness
+                    facs = factors[::-1]
+                else:
+                    ghost_slice[axis] = slice(-thickness, None)
+                    interior_slice[axis] = -thickness - 1
+                    facs = factors
 
-                if axis == 0:
-                    interior_idx = thickness if side == 'lo' else -thickness - 1
-                    interior = np.copy(field[interior_idx, :, :])[None, :, :]
-                    sl = slice(0, thickness) if side == 'lo' else slice(-thickness, None)
-                    _apply((sl, slice(None), slice(None)), interior)
-                    if thickness < g:
-                        zero_sl = slice(thickness, g) if side == 'lo' else slice(-g, -thickness)
-                        field[zero_sl, :, :] = 0.0
-                elif axis == 1:
-                    interior_idx = thickness if side == 'lo' else -thickness - 1
-                    interior = np.copy(field[:, interior_idx, :])[:, None, :]
-                    sl = slice(0, thickness) if side == 'lo' else slice(-thickness, None)
-                    _apply((slice(None), sl, slice(None)), interior)
-                    if thickness < g:
-                        zero_sl = slice(thickness, g) if side == 'lo' else slice(-g, -thickness)
-                        field[:, zero_sl, :] = 0.0
-                elif axis == 2:
-                    interior_idx = thickness if side == 'lo' else -thickness - 1
-                    interior = np.copy(field[:, :, interior_idx])[:, :, None]
-                    sl = slice(0, thickness) if side == 'lo' else slice(-thickness, None)
-                    _apply((slice(None), slice(None), sl), interior)
-                    if thickness < g:
-                        zero_sl = slice(thickness, g) if side == 'lo' else slice(-g, -thickness)
-                        field[:, :, zero_sl] = 0.0
+                # Broadcast the damping factors along the appropriate axis
+                reshape = [1, 1, 1]
+                reshape[axis] = thickness
+                interior = np.expand_dims(field[tuple(interior_slice)], axis)
+                field[tuple(ghost_slice)] = interior * facs.reshape(reshape)
+
+                # If ghost region is larger than the PML thickness, zero out the
+                # remaining cells to avoid reflections from undamped zones.
+                if thickness < g:
+                    zero_slice = [slice(None)] * 3
+                    if side == 'lo':
+                        zero_slice[axis] = slice(thickness, g)
+                    else:
+                        zero_slice[axis] = slice(-g, -thickness)
+                    field[tuple(zero_slice)] = 0.0
             else:
                 logger.warning(f"Unknown boundary condition: {bc} - defaulting to periodic.")
                 field = np.roll(field, shift=g, axis=axis)

--- a/tests/test_pml_boundary.py
+++ b/tests/test_pml_boundary.py
@@ -26,16 +26,23 @@ def test_pml_absorbs_outgoing_wave():
 
     x = np.arange(nx)
     fm.E[0, :, 0, 0] = np.sin(2 * np.pi * x / nx)
+    fm.B[1, :, 0, 0] = np.sin(2 * np.pi * x / nx)
 
-    interior_before = fm.E[0, -3, 0, 0]
+    interior_E_before = fm.E[0, -3, 0, 0]
+    interior_B_before = fm.B[1, -3, 0, 0]
     fm.apply_boundary_conditions(None)
 
     # Expect exponential damping in the ghost cells
-    expected_1 = interior_before * np.exp(-boundary_conditions["pml_sigma"] * 1)
-    expected_2 = interior_before * np.exp(-boundary_conditions["pml_sigma"] * 2)
+    expected_1 = interior_E_before * np.exp(-boundary_conditions["pml_sigma"] * 1)
+    expected_2 = interior_E_before * np.exp(-boundary_conditions["pml_sigma"] * 2)
+    expected_B1 = interior_B_before * np.exp(-boundary_conditions["pml_sigma"] * 1)
+    expected_B2 = interior_B_before * np.exp(-boundary_conditions["pml_sigma"] * 2)
 
     assert np.isclose(fm.E[0, -2, 0, 0], expected_1)
     assert np.isclose(fm.E[0, -1, 0, 0], expected_2)
+    assert np.isclose(fm.B[1, -2, 0, 0], expected_B1)
+    assert np.isclose(fm.B[1, -1, 0, 0], expected_B2)
 
     # Ensure interior cell is unchanged (no reflection)
-    assert np.isclose(fm.E[0, -3, 0, 0], interior_before)
+    assert np.isclose(fm.E[0, -3, 0, 0], interior_E_before)
+    assert np.isclose(fm.B[1, -3, 0, 0], interior_B_before)


### PR DESCRIPTION
## Summary
- extend FieldManager boundary handling with PML damping in ghost cells
- allow PML thickness and attenuation to be configured via boundary settings
- test that PML absorbs outgoing waves without reflections for E and B fields

## Testing
- `pytest tests/test_pml_boundary.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aa92a418d8832a8114a02c5318461c