### PR TITLE
Align TabulatedEOS energy lookup with temperature and add tests

### DIFF
--- a/src/dpf2/simulation/eos.py
+++ b/src/dpf2/simulation/eos.py
@@ -216,36 +216,44 @@ class TabulatedEOS:
             logger.error(f"Error interpolating electron pressure: {e}")
             raise
 
-    def ion_energy(self, rho, p):
-        """
-        Returns the ion internal energy at a given density and pressure.
+    def ion_energy(self, rho, T):
+        """Return ion internal energy for the given density and temperature.
 
-        Args:
-            rho (np.ndarray): Mass density (kg/m^3).
-            p (np.ndarray): Pressure (Pa).
+        Parameters
+        ----------
+        rho: np.ndarray
+            Mass density (kg/m^3).
+        T: np.ndarray
+            Temperature (K).
 
-        Returns:
-            np.ndarray: Ion internal energy (J/kg).
+        Returns
+        -------
+        np.ndarray
+            Ion specific internal energy (J/kg).
         """
         try:
-            return self.e_interp(np.stack([rho, p], axis=-1))
+            return self.e_interp(np.stack([rho, T], axis=-1))
         except Exception as e:
             logger.error(f"Error interpolating ion energy: {e}")
             raise
 
-    def electron_energy(self, rho, p):
-        """
-        Returns the electron internal energy at a given density and pressure.
+    def electron_energy(self, rho, T):
+        """Return electron internal energy for the given density and temperature.
 
-        Args:
-            rho (np.ndarray): Mass density (kg/m^3).
-            p (np.ndarray): Pressure (Pa).
+        Parameters
+        ----------
+        rho: np.ndarray
+            Mass density (kg/m^3).
+        T: np.ndarray
+            Temperature (K).
 
-        Returns:
-            np.ndarray: Electron internal energy (J/kg).
+        Returns
+        -------
+        np.ndarray
+            Electron specific internal energy (J/kg).
         """
         try:
-            return self.e_interp(np.stack([rho, p], axis=-1))
+            return self.e_interp(np.stack([rho, T], axis=-1))
         except Exception as e:
             logger.error(f"Error interpolating electron energy: {e}")
             raise

--- a/tests/test_simulation_tabulated_eos_table.py
+++ b/tests/test_simulation_tabulated_eos_table.py
@@ -1,0 +1,30 @@
+import numpy as np
+import h5py
+
+from dpf2.simulation.eos import TabulatedEOS
+
+
+def make_table(path):
+    rho = np.array([1.0, 2.0])
+    T = np.array([10.0, 20.0])
+    p = rho[:, None] * T[None, :]
+    e = T[None, :] / rho[:, None]
+    with h5py.File(path, "w") as f:
+        f.create_dataset("rho", data=rho)
+        f.create_dataset("T", data=T)
+        f.create_dataset("p", data=p)
+        f.create_dataset("e", data=e)
+
+
+def test_interpolation(tmp_path):
+    path = tmp_path / "table.h5"
+    make_table(path)
+    eos = TabulatedEOS(path)
+    rho = np.array([1.5])
+    T = np.array([15.0])
+    expected_p = rho * T
+    expected_e = T / rho
+    np.testing.assert_allclose(eos.ion_pressure(rho, T), expected_p)
+    np.testing.assert_allclose(eos.electron_pressure(rho, T), expected_p)
+    np.testing.assert_allclose(eos.ion_energy(rho, T), expected_e)
+    np.testing.assert_allclose(eos.electron_energy(rho, T), expected_e)


### PR DESCRIPTION
## Summary
- ensure `TabulatedEOS` energy methods take density and temperature instead of pressure
- add regression test for `simulation.eos.TabulatedEOS` against a synthetic EOS table

## Testing
- `pytest tests/test_simulation_tabulated_eos_table.py` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aa92a7f234832abada3eb3149705bd