### PR TITLE
Ensure only PhysicsModule subclasses register

### DIFF
--- a/src/dpf2/simulation/module_registry.py
+++ b/src/dpf2/simulation/module_registry.py
@@ -46,7 +46,7 @@ class ModuleRegistry:
 
         # Check if module_class is a subclass of PhysicsModule
         if not issubclass(module_class, PhysicsModule):
-            raise TypeError("module_class must be a subclass of PhysicsModule.")
+            raise TypeError(f"{module_class.__name__} must be a subclass of PhysicsModule.")
 
         self.modules[module_class] = {
             'config_schema': config_schema,

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -9,5 +9,6 @@ class NotPhysics:
 
 def test_register_non_physicsmodule_raises_type_error():
     registry = ModuleRegistry()
-    with pytest.raises(TypeError, match="subclass of PhysicsModule"):
+    msg = f"{NotPhysics.__name__} must be a subclass of PhysicsModule"
+    with pytest.raises(TypeError, match=msg):
         registry.register(NotPhysics)


### PR DESCRIPTION
## Summary
- require modules to inherit from `PhysicsModule` when registering
- test that registering a non-PhysicsModule raises `TypeError`

## Testing
- `pytest tests/test_module_registry.py -q` *(fails: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68aa92a91a54832a878e280cbe86478b