### PR TITLE
Add flake8 and extras to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,11 @@ jobs:
       - name: Install dependencies
         run: |
           pip install .[server,warpx]
-          pip install ruff mypy pytest
-      - name: Lint
+          pip install ruff flake8 mypy pytest
+      - name: Ruff
         run: ruff check .
+      - name: Flake8
+        run: flake8 .
       - name: Type check
         run: mypy .
       - name: Test


### PR DESCRIPTION
## Summary
- run flake8 alongside ruff, mypy, and pytest
- install optional extras in CI

## Testing
- `pip install '.[server,warpx]' ruff flake8 mypy pytest` *(failed: Could not find a version that satisfies the requirement setuptools>=61)*
- `ruff check .`
- `flake8 .` *(command not found)*
- `mypy .`
- `pytest` *(62 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68aa92b67e38832aa5c1c8bfd02e0086