### PR TITLE
Add optional extras and document installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,23 @@ mkdocs serve
 ## Installation
 
 ```bash
-pip install -e .
+pip install .
 ```
 
 Optional extras can be installed to enable additional features:
 
 ```bash
 # Install with Flask-based server support
-pip install -e .[server]
+pip install .[server]
 
 # Install with WarpX accelerator support
-pip install -e .[warpx]
+pip install .[warpx]
+
+# Install with OpenCensus-based telemetry support
+pip install .[telemetry]
 
 # Install all optional features
-pip install -e .[server,warpx]
+pip install .[server,warpx,telemetry]
 ```
 
 ## Quickstart
@@ -52,7 +55,7 @@ Configuration files use the `DPFConfig` schema defined in this repository. See `
 
 ## Tracing
 
-The standalone `dpf_simulation` entry point can emit OpenCensus trace spans around major simulation stages. Enable this optional feature with the `--enable-tracing` flag (requires the `opencensus` package):
+The standalone `dpf_simulation` entry point can emit OpenCensus trace spans around major simulation stages. Enable this optional feature with the `--enable-tracing` flag (install via the `telemetry` extra):
 
 ```bash
 dpf_simulation --config-file config.json --enable-tracing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,21 +8,20 @@ version = "0.1.0"
 description = "Minimal Dense Plasma Focus simulator"
 requires-python = ">=3.10"
 dependencies = [
-    "flask",
     "h5py",
     "matplotlib",
     "numba",
     "numpy",
     "pydantic",
     "scipy",
-    "sympy",
-    "werkzeug"
+    "sympy"
 ]
 
 [project.optional-dependencies]
 server = [
     "flask",
-    "flask_sock"
+    "flask-sock",
+    "werkzeug"
 ]
 warpx = [
     "pywarpx",


### PR DESCRIPTION
## Summary
- Move Flask-related packages from core requirements into `server` optional extra
- Support `warpx` and `telemetry` extras in `pyproject.toml`
- Document extras and installation in README

## Testing
- `pip install --no-build-isolation .[server]` *(fails: Cannot import 'setuptools.build_meta')*
- `pytest` *(fails: missing required packages such as numpy and pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68aa92b04fa0832a9d656ca24f3e7f35