### PR TITLE
Add 3D mesh support and solver utilities

### DIFF
--- a/src/dpf2/mesh/__init__.py
+++ b/src/dpf2/mesh/__init__.py
@@ -1,1 +1,4 @@
 from .mesh2d import Mesh2D, MeshCell
+from .mesh3d import Mesh3D, MeshCell3D
+
+__all__ = ["Mesh2D", "MeshCell", "Mesh3D", "MeshCell3D"]

--- a/src/dpf2/mesh/mesh3d.py
+++ b/src/dpf2/mesh/mesh3d.py
@@ -1,0 +1,98 @@
+"""3D Cartesian mesh utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+import numpy as np
+
+
+@dataclass
+class MeshCell3D:
+    """Represents a single cell in the 3D mesh."""
+    x_index: int
+    y_index: int
+    z_index: int
+    x_center: float
+    y_center: float
+    z_center: float
+
+
+class Mesh3D:
+    """Simple 3D Cartesian mesh.
+
+    Parameters
+    ----------
+    x_min, x_max : float
+        Domain extent in ``x`` [m].
+    y_min, y_max : float
+        Domain extent in ``y`` [m].
+    z_min, z_max : float
+        Domain extent in ``z`` [m].
+    nx, ny, nz : int
+        Number of cells in the ``x``, ``y`` and ``z`` directions.
+    """
+
+    def __init__(
+        self,
+        x_min: float,
+        x_max: float,
+        y_min: float,
+        y_max: float,
+        z_min: float,
+        z_max: float,
+        nx: int,
+        ny: int,
+        nz: int,
+    ) -> None:
+        self.x = np.linspace(x_min, x_max, nx + 1)
+        self.y = np.linspace(y_min, y_max, ny + 1)
+        self.z = np.linspace(z_min, z_max, nz + 1)
+        self.dx = self.x[1] - self.x[0]
+        self.dy = self.y[1] - self.y[0]
+        self.dz = self.z[1] - self.z[0]
+        self.nx = nx
+        self.ny = ny
+        self.nz = nz
+        self.cells: List[MeshCell3D] = self._create_cells()
+
+    # ------------------------------------------------------------------
+    def _create_cells(self) -> List[MeshCell3D]:
+        cells: List[MeshCell3D] = []
+        for i in range(self.nx):
+            x_c = 0.5 * (self.x[i] + self.x[i + 1])
+            for j in range(self.ny):
+                y_c = 0.5 * (self.y[j] + self.y[j + 1])
+                for k in range(self.nz):
+                    z_c = 0.5 * (self.z[k] + self.z[k + 1])
+                    cells.append(MeshCell3D(i, j, k, x_c, y_c, z_c))
+        return cells
+
+    # ------------------------------------------------------------------
+    def get_neighbors(self, i: int, j: int, k: int) -> List[Tuple[int, int, int]]:
+        """Return indices of neighboring cells to ``(i, j, k)``."""
+        neighbors: List[Tuple[int, int, int]] = []
+        for di, dj, dk in [
+            (-1, 0, 0),
+            (1, 0, 0),
+            (0, -1, 0),
+            (0, 1, 0),
+            (0, 0, -1),
+            (0, 0, 1),
+        ]:
+            ni, nj, nk = i + di, j + dj, k + dk
+            if 0 <= ni < self.nx and 0 <= nj < self.ny and 0 <= nk < self.nz:
+                neighbors.append((ni, nj, nk))
+        return neighbors
+
+    # ------------------------------------------------------------------
+    def cell_volume(self) -> float:
+        """Return the volume of a single cell."""
+        return self.dx * self.dy * self.dz
+
+    def face_areas(self) -> Tuple[float, float, float]:
+        """Return the areas of cell faces normal to ``x``, ``y`` and ``z``."""
+        return (
+            self.dy * self.dz,
+            self.dx * self.dz,
+            self.dx * self.dy,
+        )

--- a/src/dpf2/physics/mhd.py
+++ b/src/dpf2/physics/mhd.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 import numpy as np
 
+from ..mesh import Mesh2D, Mesh3D
+
 
 @dataclass
 class ResistiveMHD:
@@ -82,6 +84,32 @@ class ResistiveMHD:
         v2 = v_x ** 2 + v_y ** 2 + v_z ** 2
         B2 = B_x ** 2 + B_y ** 2 + B_z ** 2
         return (E - 0.5 * rho * v2 - 0.5 * B2) * (self.gamma - 1.0)
+
+    # ------------------------------------------------------------------
+    # Mesh-aware helpers
+    # ------------------------------------------------------------------
+    def stable_timestep(
+        self, U: np.ndarray, mesh: Mesh2D | Mesh3D, cfl: float = 0.8
+    ) -> float:
+        """Return a CFL-limited stable timestep for ``mesh``.
+
+        The routine inspects the mesh spacing in each coordinate direction and
+        computes an estimate of the maximum allowable timestep using the
+        fastest characteristic speeds of the system.  The implementation is
+        intentionally simple but works for both :class:`~dpf2.mesh.Mesh2D`
+        and :class:`~dpf2.mesh.Mesh3D` instances.
+        """
+
+        if isinstance(mesh, Mesh3D):
+            spacings = [mesh.dx, mesh.dy, mesh.dz]
+            directions = ["x", "y", "z"]
+        else:  # Mesh2D treated as x-z
+            spacings = [mesh.dr, mesh.dz]
+            directions = ["x", "z"]
+
+        speeds = [self.max_speed(U, d) for d in directions]
+        dt = min(s / v if v > 0 else np.inf for s, v in zip(spacings, speeds))
+        return cfl * dt
 
     # ------------------------------------------------------------------
     # Fluxes

--- a/tests/mesh/test_mesh3d.py
+++ b/tests/mesh/test_mesh3d.py
@@ -1,0 +1,47 @@
+import numpy as np
+
+from dpf2.mesh import Mesh3D
+
+
+def test_cell_indexing_and_centers():
+    mesh = Mesh3D(0.0, 2.0, 0.0, 2.0, 0.0, 2.0, 2, 2, 2)
+    first = mesh.cells[0]
+    last = mesh.cells[-1]
+    assert (first.x_index, first.y_index, first.z_index) == (0, 0, 0)
+    assert np.isclose(first.x_center, 0.5)
+    assert np.isclose(first.y_center, 0.5)
+    assert np.isclose(first.z_center, 0.5)
+    assert (last.x_index, last.y_index, last.z_index) == (1, 1, 1)
+    assert np.isclose(last.x_center, 1.5)
+    assert np.isclose(last.y_center, 1.5)
+    assert np.isclose(last.z_center, 1.5)
+
+
+def test_neighbor_retrieval():
+    mesh = Mesh3D(0.0, 3.0, 0.0, 3.0, 0.0, 3.0, 3, 3, 3)
+    neighbors = set(mesh.get_neighbors(1, 1, 1))
+    expected = {
+        (0, 1, 1),
+        (2, 1, 1),
+        (1, 0, 1),
+        (1, 2, 1),
+        (1, 1, 0),
+        (1, 1, 2),
+    }
+    assert neighbors == expected
+
+    boundary = set(mesh.get_neighbors(0, 0, 0))
+    assert boundary == {(1, 0, 0), (0, 1, 0), (0, 0, 1)}
+
+
+def test_metric_calculations():
+    mesh = Mesh3D(0.0, 1.0, 0.0, 2.0, 0.0, 3.0, 2, 4, 3)
+    vol = mesh.cell_volume()
+    ax, ay, az = mesh.face_areas()
+    assert np.isclose(mesh.dx, 0.5)
+    assert np.isclose(mesh.dy, 0.5)
+    assert np.isclose(mesh.dz, 1.0)
+    assert np.isclose(vol, 0.25)
+    assert np.isclose(ax, 0.5)  # dy * dz
+    assert np.isclose(ay, 0.5)  # dx * dz
+    assert np.isclose(az, 0.25)  # dx * dy


### PR DESCRIPTION
## Summary
- implement Mesh3D/MeshCell3D for structured Cartesian grids with neighbor and metric helpers
- expose new mesh classes and add stable_timestep helper in ResistiveMHD accepting 3-D meshes
- test Mesh3D indexing, neighbor lookup, and metric calculations

## Testing
- `python -m py_compile src/dpf2/mesh/mesh3d.py src/dpf2/mesh/__init__.py src/dpf2/physics/mhd.py tests/mesh/test_mesh3d.py`
- `pytest tests/mesh/test_mesh3d.py tests/test_mhd.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: No matching distribution found for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa57f2f9c832a896a738ac5f1fa89