### PR TITLE
Add 3D mesh exports

### DIFF
--- a/src/dpf2/mesh/mesh3d.py
+++ b/src/dpf2/mesh/mesh3d.py
@@ -96,3 +96,6 @@ class Mesh3D:
             self.dx * self.dz,
             self.dx * self.dy,
         )
+
+__all__ = ["Mesh3D", "MeshCell3D"]
+


### PR DESCRIPTION
## Summary
- Expose Mesh3D and MeshCell3D via module `__all__`
- Mesh3D supports neighbor queries and volume/area metrics for structured grids
- Resistive MHD routines accept both 2-D and 3-D meshes

## Testing
- `pytest tests/mesh/test_mesh3d.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68aaabfbc018832abed10d8530433b09