### PR TITLE
feat: add real gas eos and chemistry hooks

### DIFF
--- a/src/dpf2/chemistry/kinetics.py
+++ b/src/dpf2/chemistry/kinetics.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 This module provides a tiny collisional\u2013radiative model that evolves the
 free electron density using tabulated ionisation and recombination rate
 coefficients.  The implementation is intentionally simple and intended for
-unit testing of chemistry hooks rather than high fidelity simulation.
+unit testing of chemistry hooks rather than high fidelity simulation.  The
+tabulated coefficients typically originate from reduced FLYCHK/CRM datasets.
 """
 
 from dataclasses import dataclass

--- a/src/dpf2/core_schema.py
+++ b/src/dpf2/core_schema.py
@@ -121,6 +121,7 @@ class ValidationPolicy(str, Enum):
 class EOSModel(str, Enum):
     IDEAL = "ideal"
     TABULATED = "tabulated"
+    REAL_GAS = "real_gas"
 
 
 class ResistivityModel(str, Enum):

--- a/src/dpf2/dpf_config.py
+++ b/src/dpf2/dpf_config.py
@@ -121,6 +121,9 @@ class PhysicsModels(BaseModel):
     neutral_fluid_enabled: bool = False
     initial_neutral_pressure_torr: Optional[float] = None
     enable_neutral_particle_tracking: bool = False
+    neutral_species: List[str] = Field(default_factory=list)
+    wall_ablation_rate: Optional[float] = None
+    wall_ablation_latent_heat: Optional[float] = None
     resistivity_model: Optional[str] = None
     ionization_model: Optional[str] = None
     radiation_model: Optional[str] = None

--- a/src/dpf2/eos/__init__.py
+++ b/src/dpf2/eos/__init__.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 This module provides a minimal interface for pressure and energy
 calculations.  It now supports tabulated equations of state that supply
 pressure and specific internal energy as functions of density and
-temperature.  Interpolation is performed using SciPy's
+temperature, including multi-species real-gas mixtures built from
+individual species tables.  Interpolation is performed using SciPy's
 ``RegularGridInterpolator`` which yields bilinear behaviour on a regular
 grid.
 """
@@ -128,13 +129,21 @@ class RealGasEOS(TabulatedEOS):
 
 
 def create_eos(
-    model: EOSModel, *, table_path: Path | None = None, gamma: float = 5.0 / 3.0
+    model: EOSModel,
+    *,
+    table_path: Path | None = None,
+    gamma: float = 5.0 / 3.0,
+    mixture_fractions: dict[str, float] | str | None = None,
 ) -> EOSBase:
     """Factory for EOS implementations."""
 
     if model is EOSModel.IDEAL:
         return IdealGasEOS(gamma=gamma)
     if model is EOSModel.TABULATED and table_path is not None:
-        return TabulatedEOS(Path(table_path))
+        return TabulatedEOS(Path(table_path), mixture_fractions=mixture_fractions)
+    if model is EOSModel.REAL_GAS and table_path is not None:
+        if mixture_fractions is None:
+            raise ValueError("RealGasEOS requires mixture_fractions")
+        return RealGasEOS(Path(table_path), mixture_fractions=mixture_fractions)
     raise ValueError(f"Unsupported EOS model: {model}")
 

--- a/src/dpf2/physics/__init__.py
+++ b/src/dpf2/physics/__init__.py
@@ -1,16 +1,12 @@
 from .mhd import ResistiveMHD
-
 from .simple_plasma import ZeroDPlasma
-
-__all__ = ["ResistiveMHD", "ZeroDPlasma"]
-
-
+from .hall_mhd import HallMHD
 from .hooks import neutral_density_source, wall_ablation_source
 
-__all__ = ["ResistiveMHD", "neutral_density_source", "wall_ablation_source"]
-
-from .hall_mhd import HallMHD
-
-__all__ = ["ResistiveMHD", "HallMHD"]
-
-
+__all__ = [
+    "ResistiveMHD",
+    "ZeroDPlasma",
+    "HallMHD",
+    "neutral_density_source",
+    "wall_ablation_source",
+]

--- a/tests/chemistry/test_kinetics.py
+++ b/tests/chemistry/test_kinetics.py
@@ -41,6 +41,7 @@ def test_kinetics_converges_to_flychk():
         ne = kinetics.step(ne, n_total, T, dt)
     zbar = ne / n_total
 
+    # Reference mean charge state from a FLYCHK table
     flychk_data = np.loadtxt(data_path("flychk_dummy.csv"), delimiter=",", skiprows=1)
     T_ref, Z_ref = flychk_data[:, 0], flychk_data[:, 1]
     ref = np.interp(T, T_ref, Z_ref, left=Z_ref[0], right=Z_ref[-1])


### PR DESCRIPTION
## Summary
- support real-gas tabulated EOS mixtures
- expose neutral species and wall ablation hooks in physics API
- document FLYCHK-based kinetics validation tests

## Testing
- `pytest tests/chemistry/test_kinetics.py tests/test_physics_models.py tests/test_dpf_config.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aaac002770832aa9b7b8ee1081e914