### PR TITLE
Integrate circuit-plasma feedback

### DIFF
--- a/examples/dynamic_coupling_config.json
+++ b/examples/dynamic_coupling_config.json
@@ -1,0 +1,11 @@
+{
+  "circuit": {
+    "L_ext": 1e-6,
+    "R_ext": 0.05,
+    "C_ext": 1e-6,
+    "V0": 20000.0
+  },
+  "plasma_inductance_profile": [[0.0, 0.0], [2e-6, 5e-7], [4e-6, 1e-6]],
+  "mutual_inductance_profile": [[0.0, 2e-7], [4e-6, 2e-7]],
+  "mutual_current_profile": [[0.0, 0.0], [4e-6, 1.0]]
+}

--- a/src/dpf2/core/bases.py
+++ b/src/dpf2/core/bases.py
@@ -11,11 +11,22 @@ from typing import Any
 
 
 class PlasmaSolverBase(ABC):
-    """Interface for plasma solvers."""
+    """Interface for plasma solvers coupled to an external circuit."""
 
     @abstractmethod
-    def step(self, state: Any, dt: float) -> Any:
-        """Advance the plasma state by ``dt`` seconds."""
+    def step(self, state: Any, dt: float, current: float, voltage: float) -> Any:
+        """Advance the plasma state by ``dt`` seconds.
+
+        Parameters
+        ----------
+        state:
+            Current plasma state object.
+        dt:
+            Time step in seconds.
+        current, voltage:
+            Instantaneous circuit current and capacitor voltage supplied by
+            the circuit solver for coupling.
+        """
         raise NotImplementedError
 
 

--- a/src/dpf2/core/simulation.py
+++ b/src/dpf2/core/simulation.py
@@ -79,12 +79,9 @@ class DPFSimulation:
 
             feedback = None
             if self.plasma_solver is not None:
-                try:
-                    result = self.plasma_solver.step(
-                        self.plasma_state, dt, self.current, self.voltage
-                    )
-                except TypeError:
-                    result = self.plasma_solver.step(self.plasma_state, dt)
+                result = self.plasma_solver.step(
+                    self.plasma_state, dt, self.current, self.voltage
+                )
                 if isinstance(result, tuple):
                     self.plasma_state, feedback = result
                 else:

--- a/src/dpf2/physics/simple_plasma.py
+++ b/src/dpf2/physics/simple_plasma.py
@@ -22,7 +22,9 @@ class ZeroDPlasma(PlasmaSolverBase):
     time: float = 0.0
     circuit_feedback: dict[str, float] = field(init=False, default_factory=dict)
 
-    def step(self, state: Any, dt: float, current: float = 0.0, voltage: float = 0.0) -> Any:
+    def step(self, state: Any, dt: float, current: float, voltage: float) -> Any:
+        """Advance the dummy plasma state and compute circuit feedback."""
+
         self.time += dt
         Lp, dLpdt = self.inductance(self.time, current, voltage)
         self.circuit_feedback = {"Lp": Lp, "dLpdt": dLpdt}


### PR DESCRIPTION
## Summary
- expose circuit current and voltage histories while supporting mutual inductance and back‑EMF
- allow plasma solvers to receive circuit current and voltage each step and propagate feedback to the circuit
- document dynamic circuit-plasma coupling via example config

## Testing
- `pytest tests/core/test_circuit_coupling.py`
- `pytest tests/core/test_circuit_coupling.py tests/test_circuit_model.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aaac01f464832a8cffd6979546594b