### PR TITLE
Add baseline diagnostics tests and validation docs

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,24 @@
+# Validation Workflow
+
+This document describes how to validate the synthetic diagnostics in this
+repository. Benchmark definitions and expected diagnostic outputs are stored in
+`tests/benchmarks`.
+
+## Running the Benchmarks
+
+1. Install the package dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Execute the benchmark tests:
+   ```bash
+   pytest tests/benchmarks/test_diagnostic_baselines.py
+   ```
+   The tests compute neutron yield and X-ray spectra for the provided cases and
+   compare the results against the stored baselines.
+
+## Updating Baselines
+
+To update or add a benchmark, edit or create the JSON files in
+`tests/benchmarks` and ensure the expected outputs match the new results. Commit
+these baseline files together with any code changes.

--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -6,6 +6,10 @@ from typing import Any, ClassVar, Dict, List, Optional, Tuple, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, root_validator
 
+# Local diagnostic computation utilities
+from .neutron_yield import compute_neutron_yield
+from .xray_spectra import compute_xray_spectrum
+
 # Compatibility helpers -------------------------------------------------------
 
 def model_validator(*, mode: str = "after"):
@@ -300,4 +304,10 @@ class Diagnostics(ConfigSectionBase):
         return obj
 
 
-__all__ = ["Diagnostics", "DetectorArrayGenerator", "OutputField"]
+__all__ = [
+    "Diagnostics",
+    "DetectorArrayGenerator",
+    "OutputField",
+    "compute_neutron_yield",
+    "compute_xray_spectrum",
+]

--- a/src/dpf2/diagnostics/neutron_yield.py
+++ b/src/dpf2/diagnostics/neutron_yield.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+
+def compute_neutron_yield(reaction_rate: Sequence[float], dt: float) -> float:
+    """Compute total neutron yield from a reaction rate history.
+
+    Parameters
+    ----------
+    reaction_rate:
+        One dimensional array containing the neutron production rate in
+        neutrons/second for each time sample.
+    dt:
+        Time step between samples in seconds.
+
+    Returns
+    -------
+    float
+        Integrated neutron yield over the provided history.
+    """
+    if dt <= 0:
+        raise ValueError("dt must be positive")
+    total = 0.0
+    for val in reaction_rate:
+        total += float(val)
+    return total * dt

--- a/src/dpf2/diagnostics/xray_spectra.py
+++ b/src/dpf2/diagnostics/xray_spectra.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+from typing import Iterable, List, Tuple
+
+
+def compute_xray_spectrum(
+    energies: Iterable[float], intensities: Iterable[float], bins: Iterable[float]
+) -> Tuple[List[float], List[float]]:
+    """Generate an X-ray spectrum from photon energies.
+
+    Parameters
+    ----------
+    energies:
+        Sequence of photon energies in keV.
+    intensities:
+        Weighting for each photon, typically the photon count.
+    bins:
+        Bin edges for the resulting spectrum in keV.
+
+    Returns
+    -------
+    Tuple[List[float], List[float]]
+        List of bin centers and the corresponding weighted counts.
+    """
+    energies = [float(e) for e in energies]
+    intensities = [float(i) for i in intensities]
+    bins = [float(b) for b in bins]
+    if len(energies) != len(intensities):
+        raise ValueError("energies and intensities must be the same length")
+    if len(bins) < 2:
+        raise ValueError("bins must contain at least two edges")
+    counts: List[float] = [0.0 for _ in range(len(bins) - 1)]
+    for energy, weight in zip(energies, intensities):
+        for i in range(len(bins) - 1):
+            if bins[i] <= energy < bins[i + 1]:
+                counts[i] += weight
+                break
+    centers = [(bins[i] + bins[i + 1]) / 2.0 for i in range(len(bins) - 1)]
+    return centers, counts

--- a/tests/benchmarks/simple_case.json
+++ b/tests/benchmarks/simple_case.json
@@ -1,0 +1,9 @@
+{
+  "reaction_rate": [0.0, 1.0, 2.0, 1.0],
+  "dt": 1.0,
+  "expected_yield": 4.0,
+  "energies": [1.0, 1.5, 2.0, 2.5, 3.0],
+  "intensities": [1, 1, 1, 1, 1],
+  "bins": [1.0, 2.0, 3.0, 4.0],
+  "expected_spectrum": [2.0, 2.0, 1.0]
+}

--- a/tests/benchmarks/test_diagnostic_baselines.py
+++ b/tests/benchmarks/test_diagnostic_baselines.py
@@ -1,0 +1,41 @@
+import json
+from math import isclose
+from pathlib import Path
+
+import importlib.util
+
+BASE = Path(__file__).resolve().parents[2] / "src" / "dpf2" / "diagnostics"
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, BASE / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+compute_neutron_yield = _load("neutron_yield").compute_neutron_yield
+compute_xray_spectrum = _load("xray_spectra").compute_xray_spectrum
+
+
+def load_case() -> dict:
+    case_path = Path(__file__).with_name('simple_case.json')
+    with case_path.open() as fh:
+        return json.load(fh)
+
+
+def test_neutron_yield_baseline():
+    data = load_case()
+    rate = data['reaction_rate']
+    yield_val = compute_neutron_yield(rate, data['dt'])
+    assert isclose(yield_val, data['expected_yield'])
+
+
+def test_xray_spectrum_baseline():
+    data = load_case()
+    centers, spectrum = compute_xray_spectrum(
+        data['energies'], data['intensities'], data['bins']
+    )
+    expected = data['expected_spectrum']
+    assert all(isclose(a, b) for a, b in zip(spectrum, expected))
+    # ensure bin centers computed correctly for coverage
+    assert all(isclose(c, e) for c, e in zip(centers, [1.5, 2.5, 3.5]))


### PR DESCRIPTION
## Summary
- add lightweight neutron yield and X-ray spectrum diagnostic utilities
- include canonical benchmark case with expected outputs
- document validation workflow and how to run benchmarks

## Testing
- `pytest tests/benchmarks/test_diagnostic_baselines.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aaac031a74832a9355504cf43c667f