### PR TITLE
Add CTU Hall-MHD solver with circuit coupling

### DIFF
--- a/src/dpf2/core/circuit.py
+++ b/src/dpf2/core/circuit.py
@@ -63,7 +63,7 @@ class RLCCircuitSolver(CircuitSolverBase):
     def step(
         self,
         current: float,
-        voltage: float,
+        back_emf: float,
         dt: float,
         plasma_feedback: dict[str, float] | None = None,
     ) -> tuple[float, float]:
@@ -71,8 +71,10 @@ class RLCCircuitSolver(CircuitSolverBase):
 
         Parameters
         ----------
-        current, voltage:
-            Present values of the circuit current and capacitor voltage.
+        current:
+            Present value of the circuit current.
+        back_emf:
+            Voltage induced by the plasma (opposes the driving voltage).
         dt:
             Time step in seconds.
         plasma_feedback:
@@ -84,6 +86,7 @@ class RLCCircuitSolver(CircuitSolverBase):
             construction time.
         """
 
+        voltage = self.voltages[-1]
         t = self.time[-1]
         Lp = 0.0
         dLpdt = 0.0
@@ -103,7 +106,9 @@ class RLCCircuitSolver(CircuitSolverBase):
 
         Ltot = self.L_ext + Lp
         V_mutual = -M * dIm_dt
-        dIdt = (self.V0 + V_mutual - self.R_ext * current - voltage - dLpdt * current) / Ltot
+        dIdt = (
+            self.V0 + V_mutual - self.R_ext * current - voltage - dLpdt * current - back_emf
+        ) / Ltot
         dVdt = -current / self.C_ext
 
         new_current = current + dIdt * dt

--- a/src/dpf2/physics/hall_mhd.py
+++ b/src/dpf2/physics/hall_mhd.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
+
 import numpy as np
 
 from .mhd import ResistiveMHD
@@ -65,23 +67,41 @@ class HallMHD(ResistiveMHD):
             return 0.0
         return 2.0 * mag_energy / (self.current**2)
 
-    def step(self, state: np.ndarray, dt: float, current: float = 0.0, voltage: float = 0.0) -> np.ndarray:
-        """Lightweight advance that updates circuit feedback only.
+    def step(
+        self,
+        state: np.ndarray,
+        dt: float,
+        current: float = 0.0,
+        *,
+        circuit: Any | None = None,
+    ) -> np.ndarray:
+        """Update circuit feedback and optionally couple to an external circuit.
 
-        The plasma state is not modified; however the routine stores the
-        supplied ``current`` and ``voltage`` (treated as a back‑EMF) and
-        estimates the plasma inductance and its time derivative for use by
-        external circuit solvers.  The information is exposed via the
-        ``circuit_feedback`` attribute.
+        The plasma state ``state`` itself is not modified by this routine;
+        rather it estimates the instantaneous plasma inductance from the
+        magnetic energy and communicates it to an external circuit model.  If
+        ``circuit`` is supplied the circuit's ``step`` method is invoked using
+        the plasma current and the induced back‑EMF ``-d(L_p)/dt * I``.  The
+        external circuit is expected to expose a ``step(current, back_emf, dt,
+        plasma_feedback)`` method matching
+        :class:`~dpf2.core.circuit.RLCCircuitSolver`.
         """
 
         self.current = current
-        self.back_emf = voltage
 
         Lp = self.plasma_inductance(state)
         dLpdt = (Lp - self.inductance) / max(dt, 1.0e-30)
+        back_emf = -dLpdt * self.current
+
         self.inductance = Lp
         self.circuit_feedback = {"Lp": Lp, "dLpdt": dLpdt}
+
+        if circuit is not None:
+            self.current, self.back_emf = circuit.step(
+                self.current, back_emf, dt, self.circuit_feedback
+            )
+        else:
+            self.back_emf = 0.0
 
         return state
 
@@ -122,6 +142,70 @@ class HallMHD(ResistiveMHD):
             F[4] += self.current * self.back_emf
 
         return F
+
+    # ------------------------------------------------------------------
+    # Riemann solver and CTU update
+    # ------------------------------------------------------------------
+    def riemann_solver(
+        self,
+        UL: np.ndarray,
+        UR: np.ndarray,
+        direction: str,
+        J_L: np.ndarray | None = None,
+        J_R: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """Simple Rusanov solver for the Hall-MHD system."""
+
+        F_L = self.flux_function(UL, direction, J=J_L)
+        F_R = self.flux_function(UR, direction, J=J_R)
+        smax = max(self.max_speed(UL, direction), self.max_speed(UR, direction))
+        return 0.5 * (F_L + F_R) - 0.5 * smax * (UR - UL)
+
+    def divergence_cleaning(self, U: np.ndarray, dx: float, dt: float) -> None:
+        """Apply a simplified Dedner divergence-cleaning step in 1-D."""
+
+        if self.c_h == 0.0 and self.c_p == 0.0:
+            return
+
+        Bx = U[:, 5]
+        psi = U[:, 8]
+        divB = np.gradient(Bx, dx, edge_order=2)
+        psi -= dt * (self.c_h ** 2 * divB + self.c_p ** 2 * psi)
+        Bx -= dt * np.gradient(psi, dx, edge_order=2)
+        U[:, 5] = Bx
+        U[:, 8] = psi
+
+    def ctu_update(
+        self, U: np.ndarray, dx: float, dt: float, *, periodic: bool = False
+    ) -> np.ndarray:
+        """Advance ``U`` by one CTU step in the ``x``-direction."""
+
+        n = U.shape[0]
+        By = U[:, 6]
+        Bz = U[:, 7]
+        J = np.zeros((n, 3))
+        J[:, 1] = -np.gradient(Bz, dx, edge_order=2)
+        J[:, 2] = np.gradient(By, dx, edge_order=2)
+
+        fluxes = np.zeros((n + 1, len(self.equations)))
+        for i in range(n - 1):
+            fluxes[i + 1] = self.riemann_solver(
+                U[i], U[i + 1], "x", J[i], J[i + 1]
+            )
+
+        if periodic:
+            fluxes[0] = self.riemann_solver(U[-1], U[0], "x", J[-1], J[0])
+            fluxes[-1] = fluxes[0]
+        else:
+            fluxes[0] = self.flux_function(U[0], "x", J=J[0])
+            fluxes[-1] = self.flux_function(U[-1], "x", J=J[-1])
+
+        U_new = U.copy()
+        for i in range(n):
+            U_new[i] -= dt / dx * (fluxes[i + 1] - fluxes[i])
+
+        self.divergence_cleaning(U_new, dx, dt)
+        return U_new
 
 
 __all__ = ["HallMHD"]

--- a/tests/physics/test_hall_mhd.py
+++ b/tests/physics/test_hall_mhd.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from dpf2.physics import HallMHD
-from dpf2.core import ExternalCircuit
+from dpf2.core.circuit import RLCCircuitSolver
 
 
 def _shock_setup():
@@ -18,14 +18,8 @@ def test_shock_propagation():
     U = np.vstack([U_left, U_right])
     dx = 1.0
     dt = 0.1 * dx / max(model.max_speed(U_left, "x"), model.max_speed(U_right, "x"))
-
     for _ in range(5):
-        F_L = model.flux_function(U[0], "x")
-        F_R = model.flux_function(U[1], "x")
-        smax = max(model.max_speed(U[0], "x"), model.max_speed(U[1], "x"))
-        flux = 0.5 * (F_L + F_R) - 0.5 * smax * (U[1] - U[0])
-        U[0] -= dt / dx * flux
-        U[1] += dt / dx * flux
+        U = model.ctu_update(U, dx, dt)
 
     assert U[1, 0] > U_right[0]
     for state in U:
@@ -54,21 +48,7 @@ def test_alfven_wave_propagation():
     dt = 0.4 * dx / ca
 
     for _ in range(5):
-        By = U[:, 6]
-        Jz = np.gradient(By, dx)
-        J = np.zeros((n, 3))
-        J[:, 2] = Jz
-        fluxes = np.zeros((n + 1, 9))
-        for i in range(n):
-            UL = U[i]
-            UR = U[(i + 1) % n]
-            F_L = model.flux_function(UL, "x", J=J[i])
-            F_R = model.flux_function(UR, "x", J=J[(i + 1) % n])
-            smax = max(model.max_speed(UL, "x"), model.max_speed(UR, "x"))
-            fluxes[i + 1] = 0.5 * (F_L + F_R) - 0.5 * smax * (UR - UL)
-        fluxes[0] = fluxes[n]
-        for i in range(n):
-            U[i] -= dt / dx * (fluxes[i + 1] - fluxes[i])
+        U = model.ctu_update(U, dx, dt, periodic=True)
 
     final_By = U[:, 6]
     assert np.isclose(np.max(np.abs(final_By)), amp, rtol=0.2)
@@ -76,15 +56,13 @@ def test_alfven_wave_propagation():
 
 def test_circuit_exchange():
     model, state, _ = _shock_setup()
-    circuit = ExternalCircuit(inductance=1.0)
+    circuit = RLCCircuitSolver(L_ext=1.0, R_ext=0.0, C_ext=1.0, V0=0.5)
+    circuit.voltages[-1] = 0.0
     dt = 1.0e-6
     current = 1.0
-    voltage = 0.5
 
-    # plasma step updates feedback
-    state = model.step(state, dt, current=current, voltage=voltage)
+    state = model.step(state, dt, current=current, circuit=circuit)
     assert model.circuit_feedback is not None
 
-    # circuit consumes the feedback and updates its current
-    new_current, _ = circuit.step(current, voltage, dt, model.circuit_feedback)
-    assert new_current != current
+    # coupling updated the circuit current
+    assert model.current != current


### PR DESCRIPTION
## Summary
- extend HallMHD with Rusanov Riemann solver, CTU update and divergence cleaning
- couple plasma current/back-EMF to RLC circuit solver
- update Hall-MHD tests for new solver and circuit integration

## Testing
- `pytest tests/physics/test_hall_mhd.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68aab0a63a28832aba876cfc46f2e009