### PR TITLE
Integrate multigroup radiation coupling and opacity config

### DIFF
--- a/src/dpf2/core_schema.py
+++ b/src/dpf2/core_schema.py
@@ -247,6 +247,25 @@ class ConfigSectionBase(BaseModel):
             for name, field in self.model_fields.items()
         }
 
+
+# ---------------------------------------------------------------------------
+# Radiation configuration
+
+
+class RadiationSettings(ConfigSectionBase):
+    """Basic radiation configuration including group opacities."""
+
+    config_section_id: ClassVar[str] = "radiation"
+
+    group_opacities: List[float] = Field(
+        default_factory=list,
+        alias="groupOpacities",
+        metadata={
+            "units": "1/m",
+            "category": "Radiation",
+            "group": "MultiGroup",
+        },
+    )
 # ---------------------------------------------------------------------------
 # Root configuration model
 
@@ -265,6 +284,11 @@ class DPFConfig(BaseModel):
     )
     physics: PhysicsModels = Field(
         ..., alias="physics", metadata={"units": "-", "category": "Model", "group": "Physics"}
+    )
+    radiation: RadiationSettings = Field(
+        default_factory=RadiationSettings.with_defaults,
+        alias="radiation",
+        metadata={"units": "-", "category": "Model", "group": "Radiation"},
     )
     circuit: CircuitConfig = Field(
         ..., alias="circuit", metadata={"units": "-", "category": "Model", "group": "Circuit"}
@@ -367,6 +391,7 @@ class DPFConfig(BaseModel):
             ),
             initial=InitialConditions.with_defaults(),
             physics=PhysicsModels.with_defaults(),
+            radiation=RadiationSettings.with_defaults(),
             circuit=CircuitConfig.with_defaults(),
             amrex=AmrexSettings.with_defaults(),
             warpx=WarpXSettings.with_defaults(
@@ -533,6 +558,7 @@ if __name__ == "__main__":
 __all__ = [
     "ConfigSectionBase",
     "DPFConfig",
+    "RadiationSettings",
     "TimeVoltageProfile",
     "DetectorConfig",
     "ConfigOverride",

--- a/src/dpf2/physics/mhd.py
+++ b/src/dpf2/physics/mhd.py
@@ -227,14 +227,19 @@ class ResistiveMHD:
         """
 
         idx = self.equations.index("energy")
-        if not isinstance(U[0], (list, tuple)):
-            updated = radiation.couple([U[idx]], dt)
-            U[idx] = updated[0]
-        else:
+        # Determine if ``U`` is a single state vector or a 2-D array of
+        # multiple cells.  ``numpy`` arrays report the number of dimensions via
+        # ``ndim`` whereas the lightweight stubs used in the tests expose
+        # list-like behaviour.  We therefore inspect the first element for a
+        # ``len`` attribute instead of relying on ``isinstance`` checks.
+        if hasattr(U[0], "__len__"):
             energies = [row[idx] for row in U]
             updated = radiation.couple(energies, dt)
             for i, val in enumerate(updated):
                 U[i][idx] = val
+        else:
+            updated = radiation.couple([U[idx]], dt)
+            U[idx] = updated[0]
 
     # ------------------------------------------------------------------
     # Source terms

--- a/tests/radiation/test_multigroup.py
+++ b/tests/radiation/test_multigroup.py
@@ -77,3 +77,14 @@ def test_group_coupling_distribution():
     expected = [0.1 * 9.0, 0.2 * 9.0]
     assert all(math.isclose(rad.energy[g][0], expected[g]) for g in range(2))
     assert math.isclose(U[4], 9.0 - sum(expected))
+
+
+def test_couple_conserves_energy_multi_cell():
+    rad = MultiGroupDiffusion(opacities=[0.1, 0.2])
+    fluid = [5.0, 7.0]
+    total_before = sum(fluid) + sum(sum(g) for g in rad.energy)
+
+    updated = rad.couple(fluid, dt=1.0)
+
+    total_after = sum(updated) + sum(sum(g) for g in rad.energy)
+    assert math.isclose(total_before, total_after)


### PR DESCRIPTION
## Summary
- Route MHD energy updates through MultiGroupDiffusion.couple with robust detection of multi-cell states
- Introduce `RadiationSettings` with group opacity configuration
- Add regression tests confirming multigroup coupling conserves total energy

## Testing
- `pytest tests/radiation/test_multigroup.py`

------
https://chatgpt.com/codex/tasks/task_e_68aab0a75630832a86ccaeb62fa16675