### PR TITLE
Add tests and docs for Mesh3D support

### DIFF
--- a/src/dpf2/physics/mhd.py
+++ b/src/dpf2/physics/mhd.py
@@ -115,11 +115,12 @@ class ResistiveMHD:
     ) -> float:
         """Return a CFL-limited stable timestep for ``mesh``.
 
-        The routine inspects the mesh spacing in each coordinate direction and
-        computes an estimate of the maximum allowable timestep using the
-        fastest characteristic speeds of the system.  The implementation is
-        intentionally simple but works for both :class:`~dpf2.mesh.Mesh2D`
-        and :class:`~dpf2.mesh.Mesh3D` instances.
+        ``Mesh3D`` support relies on the geometric helpers provided by the
+        mesh itself: the cell volume and the areas of faces normal to each
+        coordinate direction.  For two-dimensional meshes the routine falls
+        back to the spacing in ``r`` (treated as ``x``) and ``z``.  The
+        resulting estimate is intentionally simple but sufficient for unit
+        tests and lightweight examples.
         """
 
         if isinstance(mesh, Mesh3D):


### PR DESCRIPTION
## Summary
- ensure Mesh3D tests import numpy and validate indexing, neighbors and metrics
- clarify ResistiveMHD stable timestep documentation for 3D meshes

## Testing
- `pytest tests/mesh/test_mesh3d.py tests/mesh/test_mesh3d_boundaries.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aab60f5a1c832a96f678dfa580e934