### PR TITLE
Add Hall-MHD circuit coupling and robust RLC solver

### DIFF
--- a/src/dpf2/core/__init__.py
+++ b/src/dpf2/core/__init__.py
@@ -4,12 +4,11 @@ Base classes for solver components now live in :mod:`dpf2.core.bases` and
 are no longer re-exported here.
 """
 
-from .config import DPFConfig
-from .simulation import DPFSimulation
-from .external_circuit import ExternalCircuit
+try:  # pragma: no cover - optional heavy dependencies
+    from .config import DPFConfig
+    from .simulation import DPFSimulation
+    from .external_circuit import ExternalCircuit
 
-__all__ = [
-    "DPFConfig",
-    "DPFSimulation",
-    "ExternalCircuit",
-]
+    __all__ = ["DPFConfig", "DPFSimulation", "ExternalCircuit"]
+except Exception:  # pragma: no cover - fallback when pydantic is unavailable
+    __all__: list[str] = []

--- a/src/dpf2/core/circuit.py
+++ b/src/dpf2/core/circuit.py
@@ -114,13 +114,24 @@ class RLCCircuitSolver(CircuitSolverBase):
         V_mutual = -M * dIm_dt
 
         if use_emf:
-            dIdt = (self.V0 + V_mutual - self.R_ext * current - voltage - emf) / Ltot
+            numerator = (
+                self.V0
+                + V_mutual
+                - self.R_ext * current
+                - voltage
+                - emf
+                - back_emf
+            )
         else:
-            dIdt = (self.V0 + V_mutual - self.R_ext * current - voltage - dLpdt * current) / Ltot
-
-        dIdt = (
-            self.V0 + V_mutual - self.R_ext * current - voltage - dLpdt * current - back_emf
-        ) / Ltot
+            numerator = (
+                self.V0
+                + V_mutual
+                - self.R_ext * current
+                - voltage
+                - dLpdt * current
+                - back_emf
+            )
+        dIdt = numerator / Ltot
 
         dVdt = -current / self.C_ext
 

--- a/src/dpf2/physics/hall_mhd.py
+++ b/src/dpf2/physics/hall_mhd.py
@@ -72,10 +72,16 @@ class HallMHD(ResistiveMHD):
         state: np.ndarray,
         dt: float,
         current: float = 0.0,
-
         voltage: float = 0.0,
+        *,
+        circuit: Any | None = None,
     ) -> np.ndarray:
-        """Lightweight advance that updates circuit feedback only.
+        """Update circuit coupling information.
+
+        The routine performs a very small subset of a full time advance.  It
+        estimates the instantaneous plasma self–inductance from the magnetic
+        energy and communicates this to an external circuit model.  No update
+        of the plasma state itself is performed.
 
         Parameters
         ----------
@@ -88,25 +94,11 @@ class HallMHD(ResistiveMHD):
         voltage:
             Deprecated and ignored.  Previously represented an externally
             applied back‑EMF.
-
-        The routine estimates the plasma inductance and associated back‑EMF
-        ``emf = Lp * dI/dt + I * dLp/dt`` which are exposed through the
-        ``circuit_feedback`` attribute for use by external circuit solvers.
-
-        *,
-        circuit: Any | None = None,
-    ) -> np.ndarray:
-        """Update circuit feedback and optionally couple to an external circuit.
-
-        The plasma state ``state`` itself is not modified by this routine;
-        rather it estimates the instantaneous plasma inductance from the
-        magnetic energy and communicates it to an external circuit model.  If
-        ``circuit`` is supplied the circuit's ``step`` method is invoked using
-        the plasma current and the induced back‑EMF ``-d(L_p)/dt * I``.  The
-        external circuit is expected to expose a ``step(current, back_emf, dt,
-        plasma_feedback)`` method matching
-        :class:`~dpf2.core.circuit.RLCCircuitSolver`.
-
+        circuit:
+            Optional circuit solver implementing ``step(current, back_emf, dt,
+            plasma_feedback)``.  When provided the circuit is advanced using the
+            computed feedback terms and the updated current/back‑EMF are stored
+            on the model instance.
         """
 
         prev_I = self.current
@@ -119,7 +111,6 @@ class HallMHD(ResistiveMHD):
         emf = Lp * dIdt + current * dLpdt
 
         back_emf = -dLpdt * self.current
-
 
         self.inductance = Lp
         self.back_emf = emf


### PR DESCRIPTION
## Summary
- Expose explicit circuit coupling in `HallMHD.step`, tracking inductance and back‑EMF
- Make `RLCCircuitSolver` handle either explicit EMF or `dL/dt` terms when updating current
- Allow importing `dpf2.core` without heavy optional dependencies

## Testing
- ⚠️ `pytest tests/physics/test_hall_mhd.py tests/core/test_circuit_coupling.py tests/test_rlc_solver.py` *(missing `pydantic` and `numpy` dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68aab6107e84832a83a30420ce608338