### PR TITLE
Add tabulated kinetics tests and fallback support

### DIFF
--- a/src/dpf2/chemistry/kinetics.py
+++ b/src/dpf2/chemistry/kinetics.py
@@ -11,8 +11,15 @@ coefficients typically originate from reduced FLYCHK/CRM datasets.
 
 from pathlib import Path
 
-try:  # pragma: no cover - fallback for minimal environments
-    import numpy as np  # type: ignore
+# ``numpy`` is optional; when unavailable or when a minimal stub is provided
+# in the test environment we fall back to lightweight implementations.
+try:  # pragma: no cover - runtime check for real numpy
+    import numpy as _np  # type: ignore
+    # ``numpy_stub`` used in tests lacks ``loadtxt``/``interp``; trigger the
+    # fallback below in that case.
+    if not hasattr(_np, "loadtxt"):
+        raise ModuleNotFoundError
+    np = _np
 except ModuleNotFoundError:  # pragma: no cover
     import csv
     import types

--- a/tests/chemistry/test_kinetics.py
+++ b/tests/chemistry/test_kinetics.py
@@ -1,5 +1,6 @@
-from pathlib import Path
 import importlib.util
+from pathlib import Path
+import sys
 
 import pytest
 
@@ -8,7 +9,6 @@ root = Path(__file__).resolve().parents[2]
 kin_path = root / "src" / "dpf2" / "chemistry" / "kinetics.py"
 spec_k = importlib.util.spec_from_file_location("kinetics", kin_path)
 kinetics_mod = importlib.util.module_from_spec(spec_k)
-import sys
 sys.modules["kinetics"] = kinetics_mod
 spec_k.loader.exec_module(kinetics_mod)  # type: ignore[attr-defined]
 
@@ -24,8 +24,8 @@ def test_rate_table_interpolation():
     table = RateTable.from_csv(data_path("crm_dummy.csv"))
     ion = table.ion_rate([10.0])[0]
     rec = table.rec_rate([10.0])[0]
-    assert ion == pytest.approx(5.0)
-    assert rec == pytest.approx(0.0)
+    assert abs(ion - 5.0) < 1e-12
+    assert abs(rec - 0.0) < 1e-12
 
 
 def test_kinetics_converges_to_flychk():


### PR DESCRIPTION
## Summary
- ensure optional NumPy fallback for tabulated ionisation/recombination kinetics
- add light-weight tests against reference FLYCHK/CRM tables

## Testing
- `pytest tests/chemistry/test_kinetics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aab613d864832a91917bb43a0e9685