### PR TITLE
Add curved mesh mapping and reflective boundary support

### DIFF
--- a/src/dpf2/mesh/boundaries.py
+++ b/src/dpf2/mesh/boundaries.py
@@ -7,7 +7,7 @@ from typing import Literal
 
 def apply_bc(
     field: list,
-    bc: Literal["periodic", "neumann", "dirichlet"],
+    bc: Literal["periodic", "neumann", "dirichlet", "reflective", "absorbing"],
     axis: int,
     side: Literal["low", "high"],
     ghosts: int = 1,
@@ -37,7 +37,17 @@ def apply_bc(
                     field[i] = _copy_plane(field[ghosts + i])
                 else:
                     field[-ghosts + i] = _copy_plane(field[-2 * ghosts + i])
+            elif bc == "reflective":
+                if side == "low":
+                    field[i] = _copy_plane(field[2 * ghosts - 1 - i])
+                else:
+                    field[-ghosts + i] = _copy_plane(field[-ghosts - 1 - i])
             elif bc == "dirichlet":
+                target = field[i] if side == "low" else field[-ghosts + i]
+                for j in range(len(target)):
+                    for k in range(len(target[j])):
+                        target[j][k] = 0.0
+            elif bc == "absorbing":
                 target = field[i] if side == "low" else field[-ghosts + i]
                 for j in range(len(target)):
                     for k in range(len(target[j])):
@@ -62,7 +72,19 @@ def apply_bc(
                 else:
                     for i in range(len(field)):
                         field[i][-ghosts + j] = field[i][-2 * ghosts + j][:]
+            elif bc == "reflective":
+                if side == "low":
+                    for i in range(len(field)):
+                        field[i][j] = field[2 * ghosts - 1 - i][j][:]
+                else:
+                    for i in range(len(field)):
+                        field[i][-ghosts + j] = field[-ghosts - 1 - i][j][:]
             elif bc == "dirichlet":
+                for i in range(len(field)):
+                    target = field[i][j] if side == "low" else field[i][-ghosts + j]
+                    for k in range(len(target)):
+                        target[k] = 0.0
+            elif bc == "absorbing":
                 for i in range(len(field)):
                     target = field[i][j] if side == "low" else field[i][-ghosts + j]
                     for k in range(len(target)):
@@ -89,7 +111,23 @@ def apply_bc(
                     for i in range(len(field)):
                         for j in range(len(field[i])):
                             field[i][j][-ghosts + k] = field[i][j][-2 * ghosts + k]
+            elif bc == "reflective":
+                if side == "low":
+                    for i in range(len(field)):
+                        for j in range(len(field[i])):
+                            field[i][j][k] = field[2 * ghosts - 1 - i][j][k]
+                else:
+                    for i in range(len(field)):
+                        for j in range(len(field[i])):
+                            field[i][j][-ghosts + k] = field[-ghosts - 1 - i][j][-ghosts + k]
             elif bc == "dirichlet":
+                for i in range(len(field)):
+                    for j in range(len(field[i])):
+                        if side == "low":
+                            field[i][j][k] = 0.0
+                        else:
+                            field[i][j][-ghosts + k] = 0.0
+            elif bc == "absorbing":
                 for i in range(len(field)):
                     for j in range(len(field[i])):
                         if side == "low":

--- a/src/dpf2/mesh/mesh3d.py
+++ b/src/dpf2/mesh/mesh3d.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import Callable, List, Tuple
 import numpy as np
 
 
@@ -96,6 +96,86 @@ class Mesh3D:
             self.dx * self.dz,
             self.dx * self.dy,
         )
+
+    # ------------------------------------------------------------------
+    def map_curved_boundary(self, func: Callable[[float, float], float]) -> np.ndarray:
+        """Return coordinates of a curved ``z`` surface.
+
+        The provided ``func`` is expected to take ``(x, y)`` coordinates and
+        return the ``z`` location of the curved surface.  The function is
+        evaluated at the cell centers of the top boundary and a two-dimensional
+        array of surface locations is returned.  This utility is intentionally
+        lightweight and does not attempt any advanced geometric processing; it
+        merely offers a convenient way for tests or simple applications to map
+        a planar mesh onto a curved physical boundary.
+        """
+
+        surface = [[0.0 for _ in range(self.ny)] for _ in range(self.nx)]
+        for i in range(self.nx):
+            x_c = 0.5 * (self.x[i] + self.x[i + 1])
+            for j in range(self.ny):
+                y_c = 0.5 * (self.y[j] + self.y[j + 1])
+                surface[i][j] = func(x_c, y_c)
+        return surface
+
+    # ------------------------------------------------------------------
+    def interpolate_ghost_cells(
+        self,
+        field: np.ndarray,
+        axis: int,
+        side: str,
+        ghosts: int,
+        surface: Callable[[float, float], float],
+        value: Callable[[float, float, float], float],
+    ) -> None:
+        """Linearly interpolate ghost-cell values for a curved boundary.
+
+        Parameters
+        ----------
+        field:
+            Numpy array with ghost cells on all sides.  The array is modified in
+            place.
+        axis:
+            Direction normal to the boundary: ``0`` for ``x``, ``1`` for ``y``
+            and ``2`` for ``z``.
+        side:
+            ``"low"`` or ``"high"`` indicating which side to operate on.
+        ghosts:
+            Number of ghost cells present in ``field``.
+        surface, value:
+            ``surface`` provides the physical location of the curved boundary
+            while ``value`` supplies the desired field value at that location.
+
+        Only a straightforward linear extrapolation is implemented which is
+        sufficient for regression tests and simple applications.
+        """
+
+        arr = field
+        if axis != 2:  # pragma: no cover - only ``z`` boundaries are supported
+            raise NotImplementedError("only z-axis interpolation is implemented")
+
+        k_int = ghosts if side == "low" else ghosts + self.nz - 1
+        k_ghost = k_int - 1 if side == "low" else k_int + 1
+
+        for i in range(self.nx):
+            ii = ghosts + i
+            x_c = 0.5 * (self.x[i] + self.x[i + 1])
+            for j in range(self.ny):
+                jj = ghosts + j
+                y_c = 0.5 * (self.y[j] + self.y[j + 1])
+                z_c = 0.5 * (self.z[k_int - ghosts] + self.z[k_int - ghosts + 1])
+                boundary_z = surface(x_c, y_c)
+                boundary_value = value(x_c, y_c, boundary_z)
+                distance_surface = (
+                    z_c - boundary_z if side == "low" else boundary_z - z_c
+                )
+                if distance_surface == 0:
+                    arr[ii][jj][k_ghost] = boundary_value
+                else:
+                    interior = arr[ii][jj][k_int]
+                    arr[ii][jj][k_ghost] = interior + (
+                        (boundary_value - interior) * self.dz / distance_surface
+                    )
 
 __all__ = ["Mesh3D", "MeshCell3D"]
 

--- a/tests/mesh/test_mesh3d_curved_and_walls.py
+++ b/tests/mesh/test_mesh3d_curved_and_walls.py
@@ -1,0 +1,50 @@
+import math
+
+from dpf2.mesh import Mesh3D, apply_bc
+
+
+def test_curved_surface_and_interpolation():
+    mesh = Mesh3D(0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1, 1, 1)
+    surface_fn = lambda x, y: 1 + 0.1 * math.sin(math.pi * x) * math.sin(math.pi * y)
+    surface = mesh.map_curved_boundary(surface_fn)
+    expected_surface = surface_fn(0.5, 0.5)
+    assert len(surface) == 1 and len(surface[0]) == 1
+    assert abs(surface[0][0] - expected_surface) <= 1e-8
+
+    g = 1
+    field = [
+        [
+            [0.0 for _ in range(mesh.nz + 2 * g)] for _ in range(mesh.ny + 2 * g)
+        ]
+        for _ in range(mesh.nx + 2 * g)
+    ]
+    field[g][g][g] = 10.0
+
+    value_fn = lambda x, y, z: 20.0
+    mesh.interpolate_ghost_cells(
+        field, axis=2, side="high", ghosts=g, surface=surface_fn, value=value_fn
+    )
+
+    z_c = 0.5 * (mesh.z[-2] + mesh.z[-1])
+    z_surf = surface_fn(0.5, 0.5)
+    expected = 10.0 + (20.0 - 10.0) * mesh.dz / (z_surf - z_c)
+    assert abs(field[g][g][g + 1] - expected) <= 1e-8
+
+
+def test_reflective_and_absorbing_bc():
+    mesh = Mesh3D(0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 1, 1, 1)
+    g = 1
+    field = [
+        [
+            [0.0 for _ in range(mesh.nz + 2 * g)] for _ in range(mesh.ny + 2 * g)
+        ]
+        for _ in range(mesh.nx + 2 * g)
+    ]
+    field[1][1][1] = 5.0
+
+    apply_bc(field, "reflective", axis=0, side="low", ghosts=g)
+    apply_bc(field, "reflective", axis=0, side="high", ghosts=g)
+    assert field[0][1][1] == field[2][1][1] == 5.0
+
+    apply_bc(field, "absorbing", axis=1, side="low", ghosts=g)
+    assert field[1][0][1] == 0.0


### PR DESCRIPTION
## Summary
- add mapping utility and ghost-cell interpolation for curved 3D meshes
- extend mesh boundary helper with reflective and absorbing conditions
- add regression tests for curved domains and wall boundary types

## Testing
- `venv/bin/pytest tests/mesh -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac01eb0a4832ab72f7b4e085eaca4