### PR TITLE
Expose plasma inductance feedback

### DIFF
--- a/examples/closed_loop_coupling_config.json
+++ b/examples/closed_loop_coupling_config.json
@@ -1,0 +1,13 @@
+{
+  "circuit": {
+    "L_ext": 1e-6,
+    "R_ext": 0.0,
+    "C_ext": 1e-6,
+    "V0": 20000.0,
+    "switch_delay": 0.0,
+    "switching_model": "ideal",
+    "trigger_jitter_stddev": 0.0,
+    "enable_field_triggered_switch_closure": false,
+    "abort_on_no_current": false
+  }
+}

--- a/src/dpf2/circuit_solver.py
+++ b/src/dpf2/circuit_solver.py
@@ -12,12 +12,14 @@ All quantities are in SI units.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, Any
 
 import numpy as np
 from scipy.integrate import solve_ivp
 
 from .circuit_config import CircuitConfig
+from .core.circuit import RLCCircuitSolver
+from .core.bases import PlasmaSolverBase
 
 __all__ = ["CircuitSolver", "RLCCircuit", "run_circuit_simulation"]
 
@@ -123,7 +125,11 @@ def _profile_to_interp(profile, t_scale: float, y_scale: float):
 
 
 def run_circuit_simulation(
-    cfg: CircuitConfig, t_end: float, num_points: int = 1000
+    cfg: CircuitConfig,
+    t_end: float,
+    num_points: int = 1000,
+    plasma_solver: PlasmaSolverBase | None = None,
+    plasma_state: Any | None = None,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Run RLC discharge with optional plasma and mutual inductance.
 
@@ -148,6 +154,28 @@ def run_circuit_simulation(
     C = cfg.C_ext * 1e-6
     V0 = cfg.V0 * 1e3
     delay = cfg.switch_delay * 1e-9
+
+    if plasma_solver is not None:
+        # Explicit coupling with a plasma model using the lightweight circuit solver
+        dt = t_end * 1e-6 / (num_points - 1)
+        circuit = RLCCircuitSolver(L_ext=L_ext, R_ext=R, C_ext=C, V0=V0)
+        t_total = np.linspace(0.0, t_end * 1e-6, num_points)
+
+        current = circuit.currents[-1]
+        voltage = circuit.voltages[-1]
+        plasma_solver.step(plasma_state, 0.0, current, voltage)
+        for _ in range(1, num_points):
+            feedback = {"Lp": plasma_solver.inductance, "emf": plasma_solver.back_emf}
+            current, voltage = circuit.step(current, 0.0, dt, feedback)
+            plasma_solver.step(plasma_state, dt, current, voltage)
+
+        return (
+            t_total,
+            np.asarray(circuit.currents),
+            np.asarray(circuit.voltages),
+            np.zeros_like(t_total),
+            np.zeros_like(t_total),
+        )
 
     lp_func, dlpdt_func = _profile_to_interp(cfg.plasma_inductance_profile, 1e-6, 1e-6)
     m_func, _ = _profile_to_interp(cfg.mutual_inductance_profile, 1e-6, 1e-6)

--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -217,7 +217,13 @@ class HallMHDSolver(PlasmaSolverBase):
         if self.refine is not None:
             self.refine(state)
 
-    def step(self, state: MHDState, dt: float) -> MHDState:  # pragma: no cover - skeleton
+    def step(
+        self,
+        state: MHDState,
+        dt: float,
+        current: float = 0.0,
+        voltage: float = 0.0,
+    ) -> MHDState:  # pragma: no cover - skeleton
         """Advance the state by ``dt`` seconds using a higher-order MHD update.
 
         A MUSCL-Hancock Godunov scheme with a corner-transport-upwind
@@ -349,15 +355,12 @@ class HallMHDSolver(PlasmaSolverBase):
         self.apply_boundary_conditions(new_state)
         self.amr_refinement(new_state)
 
-        if self.circuit is not None:
-            L_new = self.compute_plasma_inductance(new_state, self.current)
-            dL = (L_new - self.inductance) / max(dt, 1.0e-30)
-            back_emf = -dL * self.current
-            self.current, circuit_voltage = self.circuit.step(
-                self.current, back_emf, dt
-            )
-            self.inductance = L_new
-            self.back_emf = circuit_voltage
+        # Expose plasma inductance and induced EMF for external circuit solvers
+        L_new = self.compute_plasma_inductance(new_state, current)
+        dL = (L_new - self.inductance) / max(dt, 1.0e-30)
+        emf = -dL * current
+        self.inductance = L_new
+        self.back_emf = emf
 
         return new_state
 

--- a/tests/core/test_circuit_coupling.py
+++ b/tests/core/test_circuit_coupling.py
@@ -1,6 +1,7 @@
 from math import isclose
 from pathlib import Path
 import importlib.util
+import importlib
 import sys
 import types
 
@@ -16,13 +17,14 @@ sys.modules.setdefault("dpf2", pkg)
 sys.modules.setdefault("dpf2.core", core_pkg)
 sys.modules.setdefault("dpf2.physics", physics_pkg)
 
-circuit_spec = importlib.util.spec_from_file_location(
-    "dpf2.core.circuit", module_base / "core/circuit.py"
+solver_spec = importlib.util.spec_from_file_location(
+    "dpf2.circuit_solver", module_base / "circuit_solver.py"
 )
-circuit_mod = importlib.util.module_from_spec(circuit_spec)
-sys.modules["dpf2.core.circuit"] = circuit_mod
-circuit_spec.loader.exec_module(circuit_mod)  # type: ignore[misc]
-RLCCircuitSolver = circuit_mod.RLCCircuitSolver
+solver_mod = importlib.util.module_from_spec(solver_spec)
+sys.modules["dpf2.circuit_solver"] = solver_mod
+solver_spec.loader.exec_module(solver_mod)  # type: ignore[misc]
+run_circuit_simulation = solver_mod.run_circuit_simulation
+CircuitConfig = importlib.import_module("dpf2.circuit_config").CircuitConfig
 
 plasma_spec = importlib.util.spec_from_file_location(
     "dpf2.physics.simple_plasma", module_base / "physics/simple_plasma.py"
@@ -42,6 +44,14 @@ class DummyPlasma(ZeroDPlasma):
             emf = k * current
             return Lp, emf
         super().__init__(model)
+        self.inductance = 0.0
+        self.back_emf = 0.0
+
+    def step(self, state, dt, current, voltage):
+        super().step(state, dt, current, voltage)
+        self.inductance = self.circuit_feedback["Lp"]
+        self.back_emf = self.circuit_feedback["emf"]
+        return state
 
 
 def test_energy_conservation():
@@ -50,20 +60,31 @@ def test_energy_conservation():
     V0 = 1.0
     k = 0.1  # dLp/dt
 
-    circuit = RLCCircuitSolver(L_ext=L_ext, R_ext=0.0, C_ext=C_ext, V0=V0)
+    cfg = CircuitConfig(
+        L_ext=L_ext,
+        R_ext=0.0,
+        C_ext=C_ext,
+        V0=V0,
+        switch_delay=0.0,
+        switching_model="ideal",
+        trigger_jitter_stddev=0.0,
+        enable_field_triggered_switch_closure=False,
+        abort_on_no_current=False,
+    )
+
     plasma = DummyPlasma(k)
 
-    dt = 1e-3
-    steps = 1000
-
-    current = circuit.currents[-1]
-    voltage = circuit.voltages[-1]
-    plasma.step(None, 0.0, current, voltage)
-    for _ in range(steps):
-        current, voltage = circuit.step(current, 0.0, dt, plasma.circuit_feedback)
-        plasma.step(None, dt, current, voltage)
+    t, current, voltage, _, _ = run_circuit_simulation(
+        cfg, t_end=1e6, num_points=1001, plasma_solver=plasma
+    )
 
     initial_energy = 0.5 * C_ext * V0 ** 2
-    Lp = plasma.circuit_feedback["Lp"]
-    final_energy = 0.5 * L_ext * current ** 2 + 0.5 * C_ext * voltage ** 2 + 0.5 * Lp * current ** 2
+    final_current = current[-1]
+    final_voltage = voltage[-1]
+    Lp = plasma.inductance
+    final_energy = (
+        0.5 * L_ext * final_current ** 2
+        + 0.5 * C_ext * final_voltage ** 2
+        + 0.5 * Lp * final_current ** 2
+    )
     assert isclose(initial_energy, final_energy, rel_tol=1e-3)


### PR DESCRIPTION
## Summary
- Allow `HallMHDSolver.step` to report plasma inductance and induced EMF
- Extend `run_circuit_simulation` for closed-loop plasma coupling
- Document closed-loop setup with example config and regression test

## Testing
- `pytest tests/core/test_circuit_coupling.py tests/test_rlc_solver.py tests/test_hall_mhd_solver.py` *(fails: No module named 'pydantic')*
- `pip install pydantic==1.10.7 scipy==1.11.4` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68aac0258c88832ab55d996b27d6cbb5