### PR TITLE
Enable mesh-aware Hall-MHD updates

### DIFF
--- a/src/dpf2/physics/hall_mhd.py
+++ b/src/dpf2/physics/hall_mhd.py
@@ -6,6 +6,7 @@ from typing import Any
 import numpy as np
 
 from .mhd import ResistiveMHD
+from ..mesh import Mesh2D, Mesh3D
 
 
 @dataclass
@@ -178,12 +179,15 @@ class HallMHD(ResistiveMHD):
         smax = max(self.max_speed(UL, direction), self.max_speed(UR, direction))
         return 0.5 * (F_L + F_R) - 0.5 * smax * (UR - UL)
 
-    def divergence_cleaning(self, U: np.ndarray, dx: float, dt: float) -> None:
+    def divergence_cleaning(
+        self, U: np.ndarray, mesh: Mesh2D | Mesh3D, dt: float
+    ) -> None:
         """Apply a simplified Dedner divergence-cleaning step in 1-D."""
 
         if self.c_h == 0.0 and self.c_p == 0.0:
             return
 
+        dx = mesh.dx
         Bx = U[:, 5]
         psi = U[:, 8]
         divB = np.gradient(Bx, dx, edge_order=2)
@@ -193,10 +197,11 @@ class HallMHD(ResistiveMHD):
         U[:, 8] = psi
 
     def ctu_update(
-        self, U: np.ndarray, dx: float, dt: float, *, periodic: bool = False
+        self, U: np.ndarray, mesh: Mesh2D | Mesh3D, dt: float, *, periodic: bool = False
     ) -> np.ndarray:
         """Advance ``U`` by one CTU step in the ``x``-direction."""
 
+        dx = mesh.dx
         n = U.shape[0]
         By = U[:, 6]
         Bz = U[:, 7]
@@ -221,7 +226,7 @@ class HallMHD(ResistiveMHD):
         for i in range(n):
             U_new[i] -= dt / dx * (fluxes[i + 1] - fluxes[i])
 
-        self.divergence_cleaning(U_new, dx, dt)
+        self.divergence_cleaning(U_new, mesh, dt)
         return U_new
 
 

--- a/tests/mesh/test_mesh3d_hall_mhd.py
+++ b/tests/mesh/test_mesh3d_hall_mhd.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from dpf2.mesh import Mesh3D
+from dpf2.physics import HallMHD
+
+
+def test_hall_mhd_ctu_update_on_mesh3d():
+    mesh = Mesh3D(0.0, 2.0, 0.0, 1.0, 0.0, 1.0, 2, 1, 1)
+    model = HallMHD()
+
+    left = np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
+    right = np.array([0.125, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0])
+    U = np.vstack([
+        model.conservative_variables(left),
+        model.conservative_variables(right),
+    ])
+
+    dt = 0.1 * mesh.dx / max(
+        model.max_speed(U[0], "x"), model.max_speed(U[1], "x")
+    )
+    U_new = model.ctu_update(U, mesh, dt, periodic=True)
+
+    assert U_new.shape == U.shape
+    initial_mass = sum(cell[0] for cell in U)
+    final_mass = sum(cell[0] for cell in U_new)
+    assert np.isclose(initial_mass, final_mass)

--- a/tests/physics/test_hall_mhd.py
+++ b/tests/physics/test_hall_mhd.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from dpf2.physics import HallMHD
 from dpf2.core.circuit import RLCCircuitSolver
+from dpf2.mesh import Mesh3D
 
 
 def _shock_setup():
@@ -16,10 +17,12 @@ def _shock_setup():
 def test_shock_propagation():
     model, U_left, U_right = _shock_setup()
     U = np.vstack([U_left, U_right])
-    dx = 1.0
-    dt = 0.1 * dx / max(model.max_speed(U_left, "x"), model.max_speed(U_right, "x"))
+    mesh = Mesh3D(0.0, 2.0, 0.0, 1.0, 0.0, 1.0, 2, 1, 1)
+    dt = 0.1 * mesh.dx / max(
+        model.max_speed(U_left, "x"), model.max_speed(U_right, "x")
+    )
     for _ in range(5):
-        U = model.ctu_update(U, dx, dt)
+        U = model.ctu_update(U, mesh, dt)
 
     assert U[1, 0] > U_right[0]
     for state in U:
@@ -31,6 +34,7 @@ def test_shock_propagation():
 def test_alfven_wave_propagation():
     model = HallMHD()
     n = 32
+    mesh = Mesh3D(0.0, float(n), 0.0, 1.0, 0.0, 1.0, n, 1, 1)
     x = np.arange(n)
     rho0 = 1.0
     B0 = 1.0
@@ -43,12 +47,11 @@ def test_alfven_wave_propagation():
         prim = np.array([rho0, 0.0, vy[i], 0.0, 1.0, 0.0, By[i], B0])
         U[i] = model.conservative_variables(prim)
 
-    dx = 1.0
     ca = B0 / np.sqrt(rho0)
-    dt = 0.4 * dx / ca
+    dt = 0.4 * mesh.dx / ca
 
     for _ in range(5):
-        U = model.ctu_update(U, dx, dt, periodic=True)
+        U = model.ctu_update(U, mesh, dt, periodic=True)
 
     final_By = U[:, 6]
     assert np.isclose(np.max(np.abs(final_By)), amp, rtol=0.2)


### PR DESCRIPTION
## Summary
- Allow HallMHD divergence cleaning and CTU update to take Mesh2D/Mesh3D and query cell spacing
- Exercise HallMHD on a Mesh3D in existing physics tests
- Add regression test verifying CTU update on a 3‑D mesh with periodic boundaries

## Testing
- `pytest tests/mesh/test_mesh3d.py tests/mesh/test_mesh3d_boundaries.py tests/mesh/test_mesh3d_curved_and_walls.py tests/mesh/test_mesh3d_hall_mhd.py tests/physics/test_hall_mhd.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aacb5c67c0832ab0051364a3de49cd