### PR TITLE
Integrate radiation energy exchange and add conservation tests

### DIFF
--- a/src/dpf2/core_schema.py
+++ b/src/dpf2/core_schema.py
@@ -286,6 +286,18 @@ class RadiationSettings(ConfigSectionBase):
             "group": "MultiGroup",
         },
     )
+
+    @model_validator(mode="after")
+    def _validate_groups(cls, values: Self) -> Self:
+        """Ensure opacity lists match the configured group count."""
+        if values.group_opacities and len(values.group_opacities) != values.group_count:
+            raise ValueError("group_opacities must match group_count")
+        for mat, vals in values.material_opacities.items():
+            if len(vals) != values.group_count:
+                raise ValueError(
+                    f"material_opacities for {mat} must match group_count"
+                )
+        return values
 # ---------------------------------------------------------------------------
 # Root configuration model
 

--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -251,21 +251,6 @@ class HallMHDSolver(PlasmaSolverBase):
         T = self.eos.temperature(rho, specific_e)
         p = self.eos.pressure(rho, T)
         zbar = self.chemistry.ionization_state(rho, T)
-        if self.radiation is not None:
-            if hasattr(self.radiation, "couple"):
-                energy_before = energy.copy()
-                flat = energy_before.ravel().tolist()
-                updated = self.radiation.couple(flat, dt)
-                energy = np.array(updated).reshape(energy.shape)
-                self.last_rad_loss = (energy_before - energy) / dt
-            else:
-                rad_loss = self.radiation.loss(rho, T * zbar)
-                energy -= dt * rad_loss
-                self.last_rad_loss = rad_loss
-        else:
-            self.last_rad_loss = None
-        self.last_pressure = p
-        self.last_ionization = zbar
 
         # --- High-order Godunov fluxes (MUSCL-Hancock) ---
         gamma = getattr(self.eos, "gamma", 5.0 / 3.0)
@@ -310,7 +295,39 @@ class HallMHDSolver(PlasmaSolverBase):
         energy -= dt * denergy
         mom -= dt * dmom
 
+        if self.radiation is not None:
+            if hasattr(self.radiation, "couple"):
+                energy_before = energy.copy()
+                flat = energy_before.ravel().tolist()
+                updated = self.radiation.couple(flat, dt)
+                energy = np.array(updated).reshape(energy.shape)
+                self.last_rad_loss = (energy_before - energy) / dt
+            else:
+                v_tmp = mom / rho[..., None]
+                B2_tmp = np.sum(B**2, axis=-1)
+                kinetic_tmp = 0.5 * rho * np.sum(v_tmp**2, axis=-1)
+                magnetic_tmp = 0.5 * B2_tmp
+                e_internal_tmp = energy - kinetic_tmp - magnetic_tmp
+                specific_tmp = e_internal_tmp / rho
+                T_tmp = self.eos.temperature(rho, specific_tmp)
+                zbar_tmp = self.chemistry.ionization_state(rho, T_tmp)
+                rad_loss = self.radiation.loss(rho, T_tmp * zbar_tmp)
+                energy -= dt * rad_loss
+                self.last_rad_loss = rad_loss
+        else:
+            self.last_rad_loss = None
+
         v = mom / rho[..., None]
+        B2 = np.sum(B**2, axis=-1)
+        kinetic = 0.5 * rho * np.sum(v**2, axis=-1)
+        magnetic = 0.5 * B2
+        e_internal = energy - kinetic - magnetic
+        specific_e = e_internal / rho
+        T = self.eos.temperature(rho, specific_e)
+        p = self.eos.pressure(rho, T)
+        zbar = self.chemistry.ionization_state(rho, T)
+        self.last_pressure = p
+        self.last_ionization = zbar
 
         # --- Constrained transport via electric fields ---
         J = _curl(B)

--- a/tests/radiation/test_multigroup.py
+++ b/tests/radiation/test_multigroup.py
@@ -113,3 +113,30 @@ def test_resistive_mhd_multi_cell_energy_conservation():
 
     total_after = sum(cell[4] for cell in U) + sum(sum(g) for g in rad.energy)
     assert math.isclose(total_before, total_after)
+
+
+def test_couple_balances_loss_and_gain():
+    rad = MultiGroupDiffusion(opacities=[0.1, 0.2])
+    fluid = [5.0, 7.0]
+    before = [list(g) for g in rad.energy]
+    updated = rad.couple(fluid, dt=1.0)
+    fluid_loss = sum(fb - fa for fb, fa in zip(fluid, updated))
+    rad_gain = sum(sum(g_new) - sum(g_old) for g_old, g_new in zip(before, rad.energy))
+    assert math.isclose(fluid_loss, rad_gain)
+
+
+def test_resistive_mhd_balances_loss_and_gain():
+    rad = MultiGroupDiffusion(opacities=[0.1, 0.2])
+    mhd = ResistiveMHD()
+    U = [[0.0] * 9 for _ in range(2)]
+    for cell in U:
+        cell[0] = 1.0
+        cell[4] = 10.0
+    fluid_before = [cell[4] for cell in U]
+    rad_before = [list(g) for g in rad.energy]
+
+    mhd.apply_radiation(U, rad, dt=1.0)
+
+    fluid_loss = sum(b - cell[4] for b, cell in zip(fluid_before, U))
+    rad_gain = sum(sum(g_new) - sum(g_old) for g_old, g_new in zip(rad_before, rad.energy))
+    assert math.isclose(fluid_loss, rad_gain)


### PR DESCRIPTION
## Summary
- invoke radiation coupling during Hall MHD energy update to track fluid losses
- extend `RadiationSettings` schema with validation for group opacity lengths
- add multi-group radiation tests confirming fluid energy loss equals radiation gain

## Testing
- `./venv/bin/python -m pytest tests/radiation/test_multigroup.py -q`
- `./venv/bin/python -m pytest tests/test_core_schema_config.py -q`
- ⚠️ `./venv/bin/python -m pytest tests/test_hall_mhd_solver.py tests/test_core_schema_config.py -q` (missing SciPy dependency)


------
https://chatgpt.com/codex/tasks/task_e_68aacb5f2308832aa7cc2114fc70ee2d