### PR TITLE
feat: couple plasma inductance with circuit solver

### DIFF
--- a/examples/plasma_circuit_coupling.py
+++ b/examples/plasma_circuit_coupling.py
@@ -58,10 +58,11 @@ def main() -> None:
     plasma.step(None, 0.0, current, voltage)
 
     for _ in range(steps):
-        current, voltage = circuit.step(current, 0.0, dt, plasma.circuit_feedback)
+        feedback = {"Lp": plasma.inductance, "emf": plasma.back_emf}
+        current, voltage = circuit.step(current, 0.0, dt, feedback)
         plasma.step(None, dt, current, voltage)
 
-    Lp = plasma.circuit_feedback["Lp"]
+    Lp = plasma.inductance
     initial_energy = 0.5 * circuit.C_ext * circuit.V0 ** 2
     final_energy = (
         0.5 * circuit.L_ext * current ** 2

--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -203,6 +203,7 @@ class HallMHDSolver(PlasmaSolverBase):
     current: float = 0.0
     inductance: float = 0.0
     back_emf: float = 0.0
+    circuit_feedback: dict[str, float] | None = field(init=False, default=None)
     last_pressure: np.ndarray | None = field(init=False, default=None)
     last_ionization: np.ndarray | None = field(init=False, default=None)
     last_rad_loss: np.ndarray | None = field(init=False, default=None)
@@ -236,6 +237,7 @@ class HallMHDSolver(PlasmaSolverBase):
         """
 
         self.apply_boundary_conditions(state)
+        self.current = current
 
         rho = state.rho.copy()
         mom = state.mom.copy()
@@ -362,12 +364,17 @@ class HallMHDSolver(PlasmaSolverBase):
         self.apply_boundary_conditions(new_state)
         self.amr_refinement(new_state)
 
-        # Expose plasma inductance and induced EMF for external circuit solvers
+        # Expose plasma inductance and induced EMF for circuit coupling
         L_new = self.compute_plasma_inductance(new_state, current)
         dL = (L_new - self.inductance) / max(dt, 1.0e-30)
         emf = -dL * current
         self.inductance = L_new
         self.back_emf = emf
+        self.circuit_feedback = {"Lp": L_new, "emf": emf}
+
+        # Optionally advance the coupled circuit solver in a closed loop
+        if self.circuit is not None:
+            self.current, _ = self.circuit.step(current, 0.0, dt, self.circuit_feedback)
 
         return new_state
 

--- a/src/dpf2/physics/simple_plasma.py
+++ b/src/dpf2/physics/simple_plasma.py
@@ -18,15 +18,19 @@ class ZeroDPlasma(PlasmaSolverBase):
     time, current and voltage.
     """
 
-    inductance: Callable[[float, float, float], tuple[float, float]]
+    inductance_model: Callable[[float, float, float], tuple[float, float]]
     time: float = 0.0
     circuit_feedback: dict[str, float] = field(init=False, default_factory=dict)
+    inductance: float = 0.0
+    back_emf: float = 0.0
 
     def step(self, state: Any, dt: float, current: float, voltage: float) -> Any:
         """Advance the dummy plasma state and compute circuit feedback."""
 
         self.time += dt
-        Lp, emf = self.inductance(self.time, current, voltage)
+        Lp, emf = self.inductance_model(self.time, current, voltage)
+        self.inductance = Lp
+        self.back_emf = emf
         self.circuit_feedback = {"Lp": Lp, "emf": emf}
         return state
 

--- a/tests/core/test_circuit_coupling.py
+++ b/tests/core/test_circuit_coupling.py
@@ -1,33 +1,31 @@
 from math import isclose
 from pathlib import Path
 import importlib.util
-import importlib
 import sys
 import types
 
-module_base = Path(__file__).resolve().parents[2] / "src/dpf2"
+a = Path(__file__).resolve().parents[2] / "src/dpf2"
 
 pkg = types.ModuleType("dpf2")
-pkg.__path__ = [str(module_base)]  # type: ignore[attr-defined]
+pkg.__path__ = [str(a)]  # type: ignore[attr-defined]
 core_pkg = types.ModuleType("dpf2.core")
-core_pkg.__path__ = [str(module_base / "core")]  # type: ignore[attr-defined]
+core_pkg.__path__ = [str(a / "core")]  # type: ignore[attr-defined]
 physics_pkg = types.ModuleType("dpf2.physics")
-physics_pkg.__path__ = [str(module_base / "physics")]  # type: ignore[attr-defined]
+physics_pkg.__path__ = [str(a / "physics")]  # type: ignore[attr-defined]
 sys.modules.setdefault("dpf2", pkg)
 sys.modules.setdefault("dpf2.core", core_pkg)
 sys.modules.setdefault("dpf2.physics", physics_pkg)
 
-solver_spec = importlib.util.spec_from_file_location(
-    "dpf2.circuit_solver", module_base / "circuit_solver.py"
+core_spec = importlib.util.spec_from_file_location(
+    "dpf2.core.circuit", a / "core/circuit.py"
 )
-solver_mod = importlib.util.module_from_spec(solver_spec)
-sys.modules["dpf2.circuit_solver"] = solver_mod
-solver_spec.loader.exec_module(solver_mod)  # type: ignore[misc]
-run_circuit_simulation = solver_mod.run_circuit_simulation
-CircuitConfig = importlib.import_module("dpf2.circuit_config").CircuitConfig
+core_mod = importlib.util.module_from_spec(core_spec)
+sys.modules["dpf2.core.circuit"] = core_mod
+core_spec.loader.exec_module(core_mod)  # type: ignore[misc]
+RLCCircuitSolver = core_mod.RLCCircuitSolver
 
 plasma_spec = importlib.util.spec_from_file_location(
-    "dpf2.physics.simple_plasma", module_base / "physics/simple_plasma.py"
+    "dpf2.physics.simple_plasma", a / "physics/simple_plasma.py"
 )
 plasma_mod = importlib.util.module_from_spec(plasma_spec)
 sys.modules["dpf2.physics.simple_plasma"] = plasma_mod
@@ -35,56 +33,37 @@ plasma_spec.loader.exec_module(plasma_mod)  # type: ignore[misc]
 ZeroDPlasma = plasma_mod.ZeroDPlasma
 
 
-class DummyPlasma(ZeroDPlasma):
-    """Plasma with linearly increasing inductance."""
-
-    def __init__(self, k: float):
-        def model(t, current, voltage):
-            Lp = k * t
-            emf = k * current
-            return Lp, emf
-        super().__init__(model)
-        self.inductance = 0.0
-        self.back_emf = 0.0
-
-    def step(self, state, dt, current, voltage):
-        super().step(state, dt, current, voltage)
-        self.inductance = self.circuit_feedback["Lp"]
-        self.back_emf = self.circuit_feedback["emf"]
-        return state
-
-
 def test_energy_conservation():
-    L_ext = 1.0
-    C_ext = 1.0
-    V0 = 1.0
-    k = 0.1  # dLp/dt
+    """Circuit/plasma coupling conserves total energy."""
 
-    cfg = CircuitConfig(
-        L_ext=L_ext,
-        R_ext=0.0,
-        C_ext=C_ext,
-        V0=V0,
-        switch_delay=0.0,
-        switching_model="ideal",
-        trigger_jitter_stddev=0.0,
-        enable_field_triggered_switch_closure=False,
-        abort_on_no_current=False,
-    )
+    circuit = RLCCircuitSolver(L_ext=1.0, R_ext=0.0, C_ext=1.0, V0=1.0)
 
-    plasma = DummyPlasma(k)
+    k = 0.1
 
-    t, current, voltage, _, _ = run_circuit_simulation(
-        cfg, t_end=1e6, num_points=1001, plasma_solver=plasma
-    )
+    def model(t, current, voltage):
+        Lp = k * t
+        emf = k * current
+        return Lp, emf
 
-    initial_energy = 0.5 * C_ext * V0 ** 2
-    final_current = current[-1]
-    final_voltage = voltage[-1]
+    plasma = ZeroDPlasma(model)
+
+    dt = 1e-3
+    steps = 1000
+
+    current = circuit.currents[-1]
+    voltage = circuit.voltages[-1]
+    plasma.step(None, 0.0, current, voltage)
+
+    for _ in range(steps):
+        feedback = {"Lp": plasma.inductance, "emf": plasma.back_emf}
+        current, voltage = circuit.step(current, 0.0, dt, feedback)
+        plasma.step(None, dt, current, voltage)
+
     Lp = plasma.inductance
+    initial_energy = 0.5 * circuit.C_ext * circuit.V0 ** 2
     final_energy = (
-        0.5 * L_ext * final_current ** 2
-        + 0.5 * C_ext * final_voltage ** 2
-        + 0.5 * Lp * final_current ** 2
+        0.5 * circuit.L_ext * current ** 2
+        + 0.5 * circuit.C_ext * voltage ** 2
+        + 0.5 * Lp * current ** 2
     )
     assert isclose(initial_energy, final_energy, rel_tol=1e-3)


### PR DESCRIPTION
## Summary
- expose plasma inductance and induced EMF each timestep in HallMHDSolver
- propagate inductance/EMF to RLCCircuitSolver for current and voltage updates
- add example and test demonstrating closed-loop circuit/plasma coupling with conserved energy

## Testing
- `pytest tests/core/test_circuit_coupling.py -q`
- `pytest tests/physics/test_hall_mhd.py::test_circuit_exchange -q`


------
https://chatgpt.com/codex/tasks/task_e_68aacb62f664832abb02231a5bdebb38