### PR TITLE
Add Mesh3D utilities and regression tests

### DIFF
--- a/src/dpf2/mesh/mesh3d.py
+++ b/src/dpf2/mesh/mesh3d.py
@@ -110,12 +110,12 @@ class Mesh3D:
         a planar mesh onto a curved physical boundary.
         """
 
-        surface = [[0.0 for _ in range(self.ny)] for _ in range(self.nx)]
+        surface = np.zeros((self.nx, self.ny))
         for i in range(self.nx):
             x_c = 0.5 * (self.x[i] + self.x[i + 1])
             for j in range(self.ny):
                 y_c = 0.5 * (self.y[j] + self.y[j + 1])
-                surface[i][j] = func(x_c, y_c)
+                surface[i, j] = func(x_c, y_c)
         return surface
 
     # ------------------------------------------------------------------

--- a/tests/mesh/test_mesh3d.py
+++ b/tests/mesh/test_mesh3d.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from dpf2.mesh import Mesh3D
+from dpf2.mesh import Mesh3D, apply_bc
 
 
 def test_cell_indexing_and_centers():
@@ -45,3 +45,22 @@ def test_metric_calculations():
     assert np.isclose(ax, 0.5)  # dy * dz
     assert np.isclose(ay, 0.5)  # dx * dz
     assert np.isclose(az, 0.25)  # dx * dy
+
+
+def test_periodic_boundary_application():
+    mesh = Mesh3D(0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 2, 1, 1)
+    g = 1
+    field = [
+        [
+            [0.0 for _ in range(mesh.nz + 2 * g)] for _ in range(mesh.ny + 2 * g)
+        ]
+        for _ in range(mesh.nx + 2 * g)
+    ]
+    field[g][g][g] = 1.0
+    field[g + 1][g][g] = 2.0
+
+    apply_bc(field, "periodic", axis=0, side="low", ghosts=g)
+    apply_bc(field, "periodic", axis=0, side="high", ghosts=g)
+
+    assert field[0][g][g] == 2.0
+    assert field[-1][g][g] == 1.0


### PR DESCRIPTION
## Summary
- Return NumPy arrays from `Mesh3D.map_curved_boundary` for easier downstream use
- Extend 3‑D mesh tests with periodic boundary coverage

## Testing
- `pytest tests/mesh/test_mesh3d.py tests/mesh/test_mesh3d_boundaries.py tests/mesh/test_mesh3d_curved_and_walls.py tests/mesh/test_mesh3d_hall_mhd.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aad5780db8832ab3a8e3f55116e92d