### PR TITLE
Add diagnostics, structured IO, and provenance tracking

### DIFF
--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, root_validator
 # Local diagnostic computation utilities
 from .neutron_yield import compute_neutron_yield
 from .xray_spectra import compute_xray_spectrum
+from .scope_trace import compute_scope_trace
 
 # Compatibility helpers -------------------------------------------------------
 
@@ -310,4 +311,5 @@ __all__ = [
     "OutputField",
     "compute_neutron_yield",
     "compute_xray_spectrum",
+    "compute_scope_trace",
 ]

--- a/src/dpf2/diagnostics/scope_trace.py
+++ b/src/dpf2/diagnostics/scope_trace.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Sequence, Tuple, List
+
+
+def compute_scope_trace(times: Sequence[float], values: Sequence[float]) -> Tuple[List[float], List[float]]:
+    """Baseline subtract a scope trace.
+
+    Parameters
+    ----------
+    times:
+        Sample times in seconds.
+    values:
+        Measured quantity at each time sample.
+
+    Returns
+    -------
+    Tuple[List[float], List[float]]
+        The original times and baseline-subtracted values.
+    """
+    times_list = [float(t) for t in times]
+    values_list = [float(v) for v in values]
+    if len(times_list) != len(values_list):
+        raise ValueError("times and values must be the same length")
+    if not times_list:
+        return [], []
+    mean = sum(values_list) / len(values_list)
+    values_processed = [v - mean for v in values_list]
+    return times_list, values_processed

--- a/src/dpf2/io/__init__.py
+++ b/src/dpf2/io/__init__.py
@@ -1,1 +1,5 @@
 from .data_writer import DataWriter
+from .structured import StructuredOutputWriter
+from .restart import RestartManager
+
+__all__ = ["DataWriter", "StructuredOutputWriter", "RestartManager"]

--- a/src/dpf2/io/restart.py
+++ b/src/dpf2/io/restart.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+class RestartManager:
+    """Handle writing and reading simple restart files."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+
+    def save(self, state: Dict[str, Any]) -> None:
+        """Persist simulation state to a restart file."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as f:
+            json.dump(state, f, sort_keys=True)
+
+    def load(self) -> Dict[str, Any]:
+        """Load simulation state from the restart file."""
+        with self.path.open("r", encoding="utf-8") as f:
+            return json.load(f)

--- a/src/dpf2/io/structured.py
+++ b/src/dpf2/io/structured.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+try:  # optional yaml support
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+
+class StructuredOutputWriter:
+    """Write structured diagnostic output such as JSON or YAML."""
+
+    def __init__(self, output_dir: str) -> None:
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def write_json(self, data: Dict[str, Any], name: str) -> Path:
+        path = self.output_dir / (name if name.endswith(".json") else f"{name}.json")
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+        return path
+
+    def write_yaml(self, data: Dict[str, Any], name: str) -> Path:
+        if yaml is None:
+            raise RuntimeError("yaml package is required for YAML output")
+        path = self.output_dir / (name if name.endswith(".yaml") else f"{name}.yaml")
+        with path.open("w", encoding="utf-8") as f:
+            yaml.safe_dump(data, f)
+        return path

--- a/src/dpf2/metadata.py
+++ b/src/dpf2/metadata.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import uuid
+import subprocess
 from datetime import datetime, timezone
 import re
 from pathlib import Path
@@ -150,11 +151,21 @@ class Metadata(ConfigSectionBase):
     # ------------------------------------------------------------------
     @classmethod
     def with_defaults(cls) -> "Metadata":
+        commit = "unknown"
+        repo = Path(__file__).resolve().parents[2]
+        try:
+            commit = (
+                subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo)
+                .decode()
+                .strip()
+            )
+        except Exception:  # pragma: no cover - git not available
+            pass
         return cls(
             schema_version="1.0",
             sim_version="0.1",
             created_by="unknown",
-            commit_hash="none",
+            commit_hash=commit,
             run_uuid=str(uuid.uuid4()),
             creation_time=datetime.now(timezone.utc),
         )
@@ -191,6 +202,26 @@ class Metadata(ConfigSectionBase):
         data = self.model_dump(by_alias=True, exclude={"summary_id"}, exclude_none=True)
         serialized = json.dumps(data, sort_keys=True, default=str)
         return hashlib.sha256(serialized.encode()).hexdigest()
+
+    # Provenance utilities ------------------------------------------------
+    def apply_provenance(
+        self, config: Dict[str, Any], repo_dir: Optional[Path] = None
+    ) -> "Metadata":
+        """Attach config hash and git commit information to this metadata."""
+        repo_dir = repo_dir or Path(__file__).resolve().parents[2]
+        commit = self.commit_hash
+        try:
+            commit = (
+                subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo_dir)
+                .decode()
+                .strip()
+            )
+        except Exception:  # pragma: no cover - git not available
+            pass
+        cfg_hash = hashlib.sha256(
+            json.dumps(config, sort_keys=True, default=str).encode()
+        ).hexdigest()
+        return self.model_copy(update={"commit_hash": commit, "config_hash": cfg_hash})
 
     # ------------------------------------------------------------------
     @model_validator(mode="after")

--- a/tests/io/test_restart_and_diagnostics.py
+++ b/tests/io/test_restart_and_diagnostics.py
@@ -1,0 +1,57 @@
+import json
+import importlib.util
+from pathlib import Path
+
+# Load diagnostic functions without importing the package (avoids pydantic dependency)
+ROOT = Path(__file__).resolve().parents[2]
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, ROOT / f"src/dpf2/diagnostics/{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+compute_neutron_yield = _load("neutron_yield").compute_neutron_yield
+compute_xray_spectrum = _load("xray_spectra").compute_xray_spectrum
+compute_scope_trace = _load("scope_trace").compute_scope_trace
+
+from dpf2.io import RestartManager, StructuredOutputWriter
+
+
+def test_restart_roundtrip(tmp_path: Path) -> None:
+    state = {"time": 1.0, "current": [1.0, 2.0, 3.0]}
+    mgr = RestartManager(tmp_path / "restart.json")
+    mgr.save(state)
+    loaded = mgr.load()
+    assert loaded == state
+
+
+def test_diagnostic_functions(tmp_path: Path) -> None:
+    # neutron yield
+    rate = [1.0, 2.0, 3.0, 4.0]
+    dt = 0.5
+    assert compute_neutron_yield(rate, dt) == 5.0
+
+    # xray spectrum
+    energies = [1.0, 2.0, 5.0, 7.0]
+    intensities = [1.0, 1.0, 1.0, 1.0]
+    bins = [0.0, 3.0, 6.0, 9.0]
+    centers, counts = compute_xray_spectrum(energies, intensities, bins)
+    assert counts == [2.0, 1.0, 1.0]
+    assert centers == [1.5, 4.5, 7.5]
+
+    # scope trace baseline subtraction
+    times = [0.0, 1.0, 2.0, 3.0]
+    values = [0.0, 1.0, 2.0, 3.0]
+    t_out, v_out = compute_scope_trace(times, values)
+    assert t_out == times
+    assert abs(v_out[0] + 1.5) < 1e-12
+    assert abs(v_out[-1] - 1.5) < 1e-12
+
+    # structured output writing
+    writer = StructuredOutputWriter(tmp_path)
+    path = writer.write_json({"a": 1}, "diag")
+    with path.open() as f:
+        data = json.load(f)
+    assert data["a"] == 1


### PR DESCRIPTION
## Summary
- implement scope trace diagnostic and expose neutron yield & x-ray helpers
- add structured JSON/YAML writer and restart manager
- record git commit and config hash in metadata
- cover restart round-trip and diagnostic outputs with tests

## Testing
- `pytest tests/io/test_restart_and_diagnostics.py -q`
- `pytest tests/io tests/test_metadata.py tests/test_diagnostics.py -q` *(fails: No module named 'pydantic')*
- `pip install pydantic -q` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aad57c7b40832abfe76aa37b88742c