### PR TITLE
feat: add Hall-MHD solver with resistive CTU update

### DIFF
--- a/src/dpf2/physics/hall_mhd.py
+++ b/src/dpf2/physics/hall_mhd.py
@@ -230,6 +230,15 @@ class HallMHD(ResistiveMHD):
         U_new = U.copy()
         for i in range(n):
             U_new[i] -= dt / dx * (fluxes[i + 1] - fluxes[i])
+        # Apply diffusive/resistive source terms.  ``ResistiveMHD`` implements
+        # a collection of local physics processes (Ohmic heating, viscosity,
+        # thermal conduction, etc.) via ``source_terms``.  The Hall model only
+        # requires the resistive piece so we explicitly zero the cleaning
+        # contribution returned for ``psi`` (handled separately below).
+        for i in range(n):
+            src = self.source_terms(U_new[i])
+            src[8] = 0.0  # divergence cleaning for ``psi`` handled explicitly
+            U_new[i] += dt * src
 
         self.divergence_cleaning(U_new, mesh, dt)
         return U_new


### PR DESCRIPTION
## Summary
- implement Hall-MHD model with CTU update and Hall term
- integrate resistive source terms and circuit inductance feedback hooks
- exercise solver against shock-tube and Alfvén-wave problems

## Testing
- `pytest -q tests/physics/test_hall_mhd.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab2b9a12a8832ab1b1395ba07e4324