### PR TITLE
fix: remove docstring escape warnings in multigroup radiation

### DIFF
--- a/src/dpf2/radiation/multigroup.py
+++ b/src/dpf2/radiation/multigroup.py
@@ -21,7 +21,7 @@ __all__ = ["MultiGroupDiffusion"]
 
 @dataclass
 class MultiGroupDiffusion:
-    """Diffusion model for user-defined radiation energy groups.
+    r"""Diffusion model for user-defined radiation energy groups.
 
     Parameters
     ----------
@@ -49,7 +49,7 @@ class MultiGroupDiffusion:
     # ------------------------------------------------------------------
     @property
     def diffusion_coefficients(self) -> np.ndarray:
-        """Return diffusion coefficient for each group.
+        r"""Return diffusion coefficient for each group.
 
         The standard approximation :math:`D_g = c/(3\kappa_g)` is used."""
 


### PR DESCRIPTION
## Summary
- use raw string docstrings in multigroup radiation to avoid invalid escape warnings

## Testing
- `pytest tests/radiation/test_multigroup.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab2b9b6540832aabea4f0f5e603a71