### PR TITLE
Add scope trace diagnostics to benchmark suite

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -14,8 +14,10 @@ repository. Benchmark definitions and expected diagnostic outputs are stored in
    ```bash
    pytest tests/benchmarks/test_diagnostic_baselines.py
    ```
-   The tests compute neutron yield and X-ray spectra for the provided cases and
-   compare the results against the stored baselines.
+   The tests compute neutron yield, X-ray spectra, and scope traces for the
+   provided cases and compare the results against the stored baselines. These
+   tests run in continuous integration to ensure diagnostic calculations remain
+   consistent with the reference outputs.
 
 ## Updating Baselines
 

--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -11,6 +11,12 @@ from .neutron_yield import compute_neutron_yield
 from .xray_spectra import compute_xray_spectrum
 from .scope_trace import compute_scope_trace
 
+__all__ = [
+    "compute_neutron_yield",
+    "compute_xray_spectrum",
+    "compute_scope_trace",
+]
+
 # Compatibility helpers -------------------------------------------------------
 
 def model_validator(*, mode: str = "after"):

--- a/tests/benchmarks/simple_case.json
+++ b/tests/benchmarks/simple_case.json
@@ -5,5 +5,8 @@
   "energies": [1.0, 1.5, 2.0, 2.5, 3.0],
   "intensities": [1, 1, 1, 1, 1],
   "bins": [1.0, 2.0, 3.0, 4.0],
-  "expected_spectrum": [2.0, 2.0, 1.0]
+  "expected_spectrum": [2.0, 2.0, 1.0],
+  "scope_times": [0.0, 1.0, 2.0, 3.0],
+  "scope_values": [1.0, 2.0, 3.0, 4.0],
+  "expected_scope": [-1.5, -0.5, 0.5, 1.5]
 }

--- a/tests/benchmarks/test_diagnostic_baselines.py
+++ b/tests/benchmarks/test_diagnostic_baselines.py
@@ -15,6 +15,7 @@ def _load(name: str):
 
 compute_neutron_yield = _load("neutron_yield").compute_neutron_yield
 compute_xray_spectrum = _load("xray_spectra").compute_xray_spectrum
+compute_scope_trace = _load("scope_trace").compute_scope_trace
 
 
 def load_case() -> dict:
@@ -39,3 +40,11 @@ def test_xray_spectrum_baseline():
     assert all(isclose(a, b) for a, b in zip(spectrum, expected))
     # ensure bin centers computed correctly for coverage
     assert all(isclose(c, e) for c, e in zip(centers, [1.5, 2.5, 3.5]))
+
+
+def test_scope_trace_baseline():
+    data = load_case()
+    times, trace = compute_scope_trace(data['scope_times'], data['scope_values'])
+    assert all(isclose(t, e) for t, e in zip(times, data['scope_times']))
+    expected = data['expected_scope']
+    assert all(isclose(a, b) for a, b in zip(trace, expected))


### PR DESCRIPTION
## Summary
- expose compute_* helpers from diagnostics package
- add scope trace baseline case and regression test
- document how to validate neutron, X-ray, and scope diagnostics

## Testing
- `pytest tests/benchmarks/test_diagnostic_baselines.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab2b9ec12c832aa3a0dff59c2714e3