### PR TITLE
Add provenance metadata to IO writers and restart files

### DIFF
--- a/src/dpf2/io/data_writer.py
+++ b/src/dpf2/io/data_writer.py
@@ -1,8 +1,11 @@
 """Utilities for writing simulation output."""
 from __future__ import annotations
 
+import hashlib
+import json
+import subprocess
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict
 
 try:
     import h5py
@@ -18,19 +21,52 @@ from ..mesh import Mesh2D
 
 
 class DataWriter:
-    """Write simulation data to disk."""
+    """Write simulation data to disk with provenance metadata."""
 
-    def __init__(self, output_dir: str) -> None:
+    def __init__(self, output_dir: str, config: Dict[str, Any] | None = None) -> None:
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.metadata = {
+            "config_hash": self._hash_config(config),
+            "git_commit": self._git_commit(),
+        }
 
-    def write_hdf5(self, data: Dict[str, float], time: float) -> None:
+    @staticmethod
+    def _hash_config(config: Dict[str, Any] | None) -> str:
+        if config is None:
+            return "unknown"
+        data = json.dumps(config, sort_keys=True).encode("utf-8")
+        return hashlib.sha256(data).hexdigest()
+
+    @staticmethod
+    def _git_commit() -> str:
+        try:
+            repo = Path(__file__).resolve().parents[2]
+            return (
+                subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo)
+                .decode()
+                .strip()
+            )
+        except Exception:  # pragma: no cover - git not available
+            return "unknown"
+
+    def write_hdf5(self, data: Dict[str, float], time: float) -> Path:
         if h5py is None:
             raise RuntimeError("h5py is required for HDF5 output")
         fname = self.output_dir / f"data_{time:.6e}.h5"
         with h5py.File(fname, "w") as f:
+            f.create_dataset("time", data=time)
             for key, value in data.items():
                 f.create_dataset(key, data=value)
+            f.create_dataset("metadata", data=json.dumps(self.metadata))
+        return fname
+
+    def write_json(self, data: Dict[str, float], time: float) -> Path:
+        fname = self.output_dir / f"data_{time:.6e}.json"
+        payload = {"time": time, "data": data, "metadata": self.metadata}
+        with fname.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, sort_keys=True)
+        return fname
 
     def write_vtk(self, mesh: Mesh2D, data: Dict[str, float], time: float) -> None:
         if meshio is None:

--- a/src/dpf2/io/restart.py
+++ b/src/dpf2/io/restart.py
@@ -1,23 +1,53 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import subprocess
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 
 class RestartManager:
-    """Handle writing and reading simple restart files."""
+    """Handle writing and reading restart files with provenance metadata."""
 
-    def __init__(self, path: Path | str) -> None:
+    def __init__(self, path: Path | str, config: Dict[str, Any] | None = None) -> None:
         self.path = Path(path)
+        self.metadata = {
+            "config_hash": self._hash_config(config),
+            "git_commit": self._git_commit(),
+        }
+
+    @staticmethod
+    def _hash_config(config: Dict[str, Any] | None) -> str:
+        if config is None:
+            return "unknown"
+        data = json.dumps(config, sort_keys=True).encode("utf-8")
+        return hashlib.sha256(data).hexdigest()
+
+    @staticmethod
+    def _git_commit() -> str:
+        try:
+            repo = Path(__file__).resolve().parents[2]
+            return (
+                subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo)
+                .decode()
+                .strip()
+            )
+        except Exception:  # pragma: no cover - git not available
+            return "unknown"
 
     def save(self, state: Dict[str, Any]) -> None:
-        """Persist simulation state to a restart file."""
+        """Persist simulation state and metadata to a restart file."""
+        payload = {"state": state, "metadata": self.metadata}
         self.path.parent.mkdir(parents=True, exist_ok=True)
         with self.path.open("w", encoding="utf-8") as f:
-            json.dump(state, f, sort_keys=True)
+            json.dump(payload, f, sort_keys=True)
 
-    def load(self) -> Dict[str, Any]:
-        """Load simulation state from the restart file."""
+    def load(self) -> Tuple[Dict[str, Any], Dict[str, str]]:
+        """Load simulation state and metadata from the restart file."""
         with self.path.open("r", encoding="utf-8") as f:
-            return json.load(f)
+            payload = json.load(f)
+        if "state" in payload:
+            return payload["state"], payload.get("metadata", {})
+        # backwards compatibility: file contained only state
+        return payload, {}

--- a/tests/io/test_restart_and_diagnostics.py
+++ b/tests/io/test_restart_and_diagnostics.py
@@ -1,6 +1,9 @@
+import hashlib
 import json
 import importlib.util
 from pathlib import Path
+
+import h5py
 
 # Load diagnostic functions without importing the package (avoids pydantic dependency)
 ROOT = Path(__file__).resolve().parents[2]
@@ -16,15 +19,40 @@ compute_neutron_yield = _load("neutron_yield").compute_neutron_yield
 compute_xray_spectrum = _load("xray_spectra").compute_xray_spectrum
 compute_scope_trace = _load("scope_trace").compute_scope_trace
 
-from dpf2.io import RestartManager, StructuredOutputWriter
+from dpf2.io import DataWriter, RestartManager, StructuredOutputWriter
 
 
 def test_restart_roundtrip(tmp_path: Path) -> None:
     state = {"time": 1.0, "current": [1.0, 2.0, 3.0]}
-    mgr = RestartManager(tmp_path / "restart.json")
+    cfg = {"a": 1}
+    mgr = RestartManager(tmp_path / "restart.json", config=cfg)
     mgr.save(state)
-    loaded = mgr.load()
+    loaded, meta = mgr.load()
     assert loaded == state
+    assert meta["config_hash"] == hashlib.sha256(
+        json.dumps(cfg, sort_keys=True).encode()
+    ).hexdigest()
+    assert meta["git_commit"]
+
+
+def test_data_writer_metadata(tmp_path: Path) -> None:
+    data = {"density": 1.0}
+    cfg = {"b": 2}
+    writer = DataWriter(tmp_path, config=cfg)
+    writer.write_hdf5(data, 0.0)
+    writer.write_json(data, 0.0)
+
+    with h5py.File(tmp_path / "data_0.000000e+00.h5", "r") as f:
+        meta = json.loads(f["metadata"][()])
+    expected = hashlib.sha256(json.dumps(cfg, sort_keys=True).encode()).hexdigest()
+    assert meta["config_hash"] == expected
+    assert meta["git_commit"]
+
+    with (tmp_path / "data_0.000000e+00.json").open() as fh:
+        payload = json.load(fh)
+    assert payload["data"] == data
+    assert payload["metadata"]["config_hash"] == expected
+    assert payload["metadata"]["git_commit"]
 
 
 def test_diagnostic_functions(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- extend DataWriter with JSON/HDF5 output embedding git commit and config hash
- record provenance in restart files and return metadata on load
- test restart roundtrip and metadata presence for IO writers

## Testing
- `pytest tests/io -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab2b9f743c832ab6073fdd8536b3e0