### PR TITLE
Add multigroup radiation coupling guard

### DIFF
--- a/src/dpf2/radiation/multigroup.py
+++ b/src/dpf2/radiation/multigroup.py
@@ -167,6 +167,12 @@ class MultiGroupDiffusion:
             total_loss = 0.0
             for g in range(self.group_count):
                 loss = self.opacities[g] * fe[i] * dt
+                # Prevent the coupling from removing more energy than
+                # available in the fluid cell.  This guards against
+                # pathological inputs where ``dt`` or the opacity are
+                # extremely large and ensures the scheme remains
+                # conservative.
+                loss = min(loss, fe[i] - total_loss)
                 self.energy[g][i] += loss
                 total_loss += loss
             fe[i] -= total_loss


### PR DESCRIPTION
## Summary
- prevent multigroup coupling from extracting more energy than available
- retain flux-limited diffusion and multi-group energy exchange features

## Testing
- `pytest -q tests/radiation/test_multigroup.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab385957fc832aa301c66b4e320976