### PR TITLE
Add metadata to structured outputs and expand IO tests

### DIFF
--- a/src/dpf2/io/structured.py
+++ b/src/dpf2/io/structured.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import subprocess
 from pathlib import Path
 from typing import Any, Dict
 
@@ -13,20 +15,45 @@ except Exception:  # pragma: no cover - optional dependency
 class StructuredOutputWriter:
     """Write structured diagnostic output such as JSON or YAML."""
 
-    def __init__(self, output_dir: str) -> None:
+    def __init__(self, output_dir: str, config: Dict[str, Any] | None = None) -> None:
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.metadata = {
+            "config_hash": self._hash_config(config),
+            "git_commit": self._git_commit(),
+        }
+
+    @staticmethod
+    def _hash_config(config: Dict[str, Any] | None) -> str:
+        if config is None:
+            return "unknown"
+        data = json.dumps(config, sort_keys=True).encode("utf-8")
+        return hashlib.sha256(data).hexdigest()
+
+    @staticmethod
+    def _git_commit() -> str:
+        try:
+            repo = Path(__file__).resolve().parents[2]
+            return (
+                subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=repo)
+                .decode()
+                .strip()
+            )
+        except Exception:  # pragma: no cover - git not available
+            return "unknown"
 
     def write_json(self, data: Dict[str, Any], name: str) -> Path:
         path = self.output_dir / (name if name.endswith(".json") else f"{name}.json")
+        payload = {"data": data, "metadata": self.metadata}
         with path.open("w", encoding="utf-8") as f:
-            json.dump(data, f, indent=2, sort_keys=True)
+            json.dump(payload, f, indent=2, sort_keys=True)
         return path
 
     def write_yaml(self, data: Dict[str, Any], name: str) -> Path:
         if yaml is None:
             raise RuntimeError("yaml package is required for YAML output")
         path = self.output_dir / (name if name.endswith(".yaml") else f"{name}.yaml")
+        payload = {"data": data, "metadata": self.metadata}
         with path.open("w", encoding="utf-8") as f:
-            yaml.safe_dump(data, f)
+            yaml.safe_dump(payload, f)
         return path

--- a/tests/io/test_restart_and_diagnostics.py
+++ b/tests/io/test_restart_and_diagnostics.py
@@ -77,9 +77,13 @@ def test_diagnostic_functions(tmp_path: Path) -> None:
     assert abs(v_out[0] + 1.5) < 1e-12
     assert abs(v_out[-1] - 1.5) < 1e-12
 
-    # structured output writing
-    writer = StructuredOutputWriter(tmp_path)
+    # structured output writing with metadata
+    cfg2 = {"c": 3}
+    writer = StructuredOutputWriter(tmp_path, config=cfg2)
     path = writer.write_json({"a": 1}, "diag")
     with path.open() as f:
-        data = json.load(f)
-    assert data["a"] == 1
+        payload = json.load(f)
+    assert payload["data"]["a"] == 1
+    expected2 = hashlib.sha256(json.dumps(cfg2, sort_keys=True).encode()).hexdigest()
+    assert payload["metadata"]["config_hash"] == expected2
+    assert payload["metadata"]["git_commit"]


### PR DESCRIPTION
## Summary
- track config hash and git commit in structured JSON/YAML diagnostics
- verify restart round-trip and metadata propagation in IO tests
- test diagnostic utilities and structured writer output

## Testing
- `pytest -q tests/io/test_restart_and_diagnostics.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab3865c80c832a96e32368a6db368d