### PR TITLE
docs: add MVP acceptance criteria

### DIFF
--- a/docs/acceptance/README.md
+++ b/docs/acceptance/README.md
@@ -1,0 +1,14 @@
+# MVP Acceptance Criteria
+
+This directory tracks completion criteria for the initial minimum viable product (MVP).
+Each requirement has an associated document describing the expected inputs, outputs,
+thresholds, and demonstration requirements. A task is only complete when a pull
+request links to the relevant document and provides a recorded demo or notebook
+verifying the criteria.
+
+## Requirements
+
+- [Resistive MHD Solver](resistive_mhd_solver.md)
+- [Dynamic Circuit Coupling](dynamic_circuit_coupling.md)
+- [Tabular EOS and Ionization](tabular_eos_ionization.md)
+- [Continuous Integration & Dependency Pinning](ci_dependency_pinning.md)

--- a/docs/acceptance/ci_dependency_pinning.md
+++ b/docs/acceptance/ci_dependency_pinning.md
@@ -1,0 +1,21 @@
+# Continuous Integration & Dependency Pinning
+
+Establish continuous integration (CI) that runs unit tests on each pull request
+and pin Python dependencies to reproducible versions.
+
+## Expected Inputs
+- CI configuration file (e.g., GitHub Actions workflow) specifying the test job.
+- `requirements.txt` or `pyproject.toml` with explicit version pins.
+
+## Expected Outputs
+- Automated CI run triggered by pull requests showing all tests pass.
+- Artifact or log proving dependency versions used in the run.
+
+## Acceptance Thresholds
+- All tests in the CI pipeline succeed.
+- Dependency files contain explicit version numbers for all packages.
+
+## Demonstration
+Provide a recording or linked CI run that demonstrates the automated tests
+succeed and lists the pinned dependencies. Reference this document in the pull
+request that adds the CI configuration.

--- a/docs/acceptance/dynamic_circuit_coupling.md
+++ b/docs/acceptance/dynamic_circuit_coupling.md
@@ -1,0 +1,22 @@
+# Dynamic Circuit Coupling
+
+Extend the circuit model to accept time-varying inductance and back-EMF feedback
+from the plasma and verify conservation of total energy.
+
+## Expected Inputs
+- Simulation configuration enabling circuit–plasma feedback with an inductance
+  model that changes during the run.
+- Reference analytic solution for current and voltage.
+
+## Expected Outputs
+- Time series of circuit current, voltage, and plasma inductance.
+- Computed initial and final total energy (circuit + plasma).
+
+## Acceptance Thresholds
+- Energy difference between initial and final states < 1% of the initial energy.
+- Simulated current trace within 10% of the analytic reference throughout the run.
+
+## Demonstration
+Provide a recorded demo or Jupyter notebook running the coupling example and
+showing that the outputs satisfy the thresholds. Link the demonstration in the
+associated pull request.

--- a/docs/acceptance/resistive_mhd_solver.md
+++ b/docs/acceptance/resistive_mhd_solver.md
@@ -1,0 +1,23 @@
+# Resistive MHD Solver
+
+Verify that a 2-D resistive MHD solver with HLLD fluxes and constrained transport
+can stably evolve a rundown/pinch scenario.
+
+## Expected Inputs
+- Configuration describing a 2-D coaxial geometry and RLC circuit coupling.
+- Initial plasma density and temperature profiles.
+- Time step and simulation duration sufficient to capture rundown and pinch.
+
+## Expected Outputs
+- Time series of magnetic field, density, and current profiles.
+- Diagnostic report of total system energy throughout the run.
+
+## Acceptance Thresholds
+- Relative magnetic divergence `|∇·B|/|B|` < 1e-6 at all times.
+- Energy conservation error < 1% between start and end of the simulation.
+- Simulation completes the full rundown without numerical instability.
+
+## Demonstration
+Provide a recorded demo or Jupyter notebook executing the solver with the
+above configuration and showing that the outputs meet the thresholds.
+Link the demo/notebook in the pull request implementing this feature.

--- a/docs/acceptance/tabular_eos_ionization.md
+++ b/docs/acceptance/tabular_eos_ionization.md
@@ -1,0 +1,22 @@
+# Tabular EOS and Ionization
+
+Integrate tabulated equation-of-state (EOS) tables and collisional ionization
+models into the simulation framework.
+
+## Expected Inputs
+- Configuration referencing at least one external EOS table.
+- Test states (density, temperature) covering the table range.
+
+## Expected Outputs
+- Pressure and internal energy values interpolated from the table.
+- Ionization fraction for each test state.
+
+## Acceptance Thresholds
+- Interpolated pressure and energy within 1% of reference table values for the
+  test states.
+- Ionization predictions within 5% of a trusted collisional-radiative model.
+
+## Demonstration
+Provide a recorded demo or notebook evaluating the EOS/ionization module on the
+specified test states and comparing to reference data. Link the demonstration in
+the pull request.


### PR DESCRIPTION
## Summary
- document MVP acceptance criteria for resistive MHD solver, dynamic circuit coupling, tabular EOS/ionization, and CI pinning
- require recorded demo or notebook to prove each criterion

## Testing
- `pytest -q` *(fails: No module named 'pydantic' and other missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3a661848832a9446abafb3522d6f