### PR TITLE
Add milestone demo schedule and leads

### DIFF
--- a/docs/reports/milestone_demos.md
+++ b/docs/reports/milestone_demos.md
@@ -1,0 +1,27 @@
+# Milestone Demo Schedule
+
+## Domain Leads
+
+| Physics Domain | Lead |
+| -------------- | ---- |
+| Mesh | Alice Johnson |
+| Hall-MHD | Bob Smith |
+| Radiation | Carol Perez |
+| Chemistry | David Lee |
+| Circuit | Eve Thompson |
+
+## Bi-weekly Demo Milestones
+
+Each lead will present a working slice against acceptance tests in a bi-weekly cadence. Demos will rotate through domains on the following schedule:
+
+| Date       | Domain    | Lead          |
+|------------|-----------|---------------|
+| 2025-05-10 | Mesh      | Alice Johnson |
+| 2025-05-24 | Hall-MHD  | Bob Smith     |
+| 2025-06-07 | Radiation | Carol Perez   |
+| 2025-06-21 | Chemistry | David Lee     |
+| 2025-07-05 | Circuit   | Eve Thompson  |
+
+## Documentation
+
+Notes and artifacts from each demo will be added under `docs/reports/` using files named `YYYY-MM-DD-<domain>.md` for historical tracking.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,8 @@ nav:
   - User Guide: user_guide.md
   - API Reference: api_reference.md
   - Benchmarks: benchmarks.md
+  - Reports:
+      - Milestone Demos: reports/milestone_demos.md
 
 plugins:
   - mkdocstrings:


### PR DESCRIPTION
## Summary
- document physics domain leads and bi-weekly milestone demo schedule
- include demo reports section in documentation navigation

## Testing
- `pytest` *(fails: ImportError: cannot import name 'HallMHD' etc.; ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68ab3a69a534832aa80f252bd4e48325