### PR TITLE
Add robust file loader for DPFConfig and cleanup CLI imports

### DIFF
--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -3,9 +3,9 @@ import logging
 
 import click
 
-from ..core.config import DPFConfig
-from ..core.simulation import DPFSimulation
-from ..exceptions import ConfigurationError, SimulationRuntimeError
+from dpf2.core.config import DPFConfig
+from dpf2.core.simulation import DPFSimulation
+from dpf2.exceptions import ConfigurationError, SimulationRuntimeError
 
 logger = logging.getLogger(__name__)
 

--- a/src/dpf2/core/config.py
+++ b/src/dpf2/core/config.py
@@ -1,6 +1,13 @@
 """Configuration schema for DPF simulations."""
 from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import ValidationError
 from pydantic.dataclasses import dataclass as pydantic_dataclass
+
+from ..exceptions import ConfigurationError
 
 
 @pydantic_dataclass
@@ -20,3 +27,44 @@ class DPFConfig:
     nz_cells: int = 200
     cfl_number: float = 0.5
     end_time: float = 10e-6
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "DPFConfig":
+        """Load configuration parameters from a JSON file.
+
+        Parameters
+        ----------
+        path:
+            Path to a JSON file containing configuration data.
+
+        Returns
+        -------
+        DPFConfig
+            A new configuration instance populated with values from the file.
+
+        Raises
+        ------
+        ConfigurationError
+            If the file is missing, contains invalid JSON, or fails validation.
+        """
+
+        file_path = Path(path)
+        try:
+            raw = file_path.read_text()
+        except FileNotFoundError as e:  # pragma: no cover - simple error path
+            raise ConfigurationError(f"Configuration file not found: {file_path}") from e
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise ConfigurationError(f"Error decoding JSON from {file_path}: {e}") from e
+
+        if not isinstance(data, dict):
+            raise ConfigurationError(
+                f"Configuration file {file_path} did not contain a JSON object"
+            )
+
+        try:
+            return cls(**data)
+        except (TypeError, ValidationError) as e:
+            raise ConfigurationError(f"Error validating configuration: {e}") from e


### PR DESCRIPTION
## Summary
- add `DPFConfig.from_file` for loading configuration from JSON with validation and helpful errors
- switch CLI imports to absolute paths and continue using `DPFConfig.from_file`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68adf2b11248832aa4ac4c87488ef0c5