### PR TITLE
feat: add short flags for cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install .[server,warpx,telemetry]
 Run a simulation using a configuration file:
 
 ```bash
-dpf2 simulate config.json -o results.json
+dpf2 simulate -c config.json -o results.json
 ```
 
 Or run a simulation programmatically:

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -29,7 +29,7 @@ These and other modules can be extended by subclassing their respective base cla
 Run the CLI against the provided sample configuration:
 
 ```bash
-dpf2 simulate examples/config.json -o results.json
+dpf2 simulate -c examples/config.json -o results.json
 ```
 
 For an interactive walk-through, open the Jupyter notebook in the `examples/quickstart.ipynb` file.

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -16,8 +16,8 @@ def main() -> None:
 
 
 @main.command()
-@click.option("--config", type=click.Path(exists=False), help="Path to config file")
-@click.option("--output", type=click.Path(), default="output", help="Output directory")
+@click.option("-c", "--config", type=click.Path(exists=False), help="Path to config file")
+@click.option("-o", "--output", type=click.Path(), default="output", help="Output directory")
 def simulate(config: str | None, output: str) -> None:
     """Run a DPF simulation."""
     try:

--- a/tests/test_cli_simulate.py
+++ b/tests/test_cli_simulate.py
@@ -1,0 +1,55 @@
+import sys
+import types
+
+import click
+from click.testing import CliRunner
+
+
+# Provide a minimal stub for the optional pydantic dependency so the CLI can be
+# imported without installing the real package.
+pydantic_stub = types.ModuleType("pydantic")
+pydantic_dataclasses = types.ModuleType("pydantic.dataclasses")
+
+
+def _identity_dataclass(cls=None, **kwargs):  # pragma: no cover - trivial stub
+    return cls
+
+
+pydantic_dataclasses.dataclass = _identity_dataclass
+pydantic_stub.dataclasses = pydantic_dataclasses
+sys.modules.setdefault("pydantic", pydantic_stub)
+sys.modules.setdefault("pydantic.dataclasses", pydantic_dataclasses)
+
+
+import importlib
+
+cli_main = importlib.import_module("dpf2.cli.main")
+main = cli_main.main
+
+
+def test_simulate_accepts_short_flags(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.json"
+    output_dir = tmp_path / "out"
+
+    captured = {}
+
+    def fake_from_file(path):
+        captured["config"] = path
+        return object()
+
+    class DummySim:
+        def __init__(self, cfg):
+            captured["cfg"] = cfg
+
+        def run(self, output_dir):
+            captured["output"] = output_dir
+
+    monkeypatch.setattr(cli_main.DPFConfig, "from_file", staticmethod(fake_from_file), raising=False)
+    monkeypatch.setattr(cli_main, "DPFSimulation", DummySim)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["simulate", "-c", str(config_path), "-o", str(output_dir)])
+
+    assert result.exit_code == 0
+    assert captured["config"] == str(config_path)
+    assert captured["output"] == str(output_dir)


### PR DESCRIPTION
## Summary
- add -c and -o short options to `dpf2 simulate`
- refresh quickstart docs to match new flags
- test new CLI flags

## Testing
- `pip install pydantic -q` (failed: Could not find a version that satisfies the requirement pydantic)
- `pytest tests/test_cli_simulate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68adf2b207f0832a95598a65f241be43