### PR TITLE
refactor: simplify bases docstring

### DIFF
--- a/src/dpf2/core/bases.py
+++ b/src/dpf2/core/bases.py
@@ -1,7 +1,5 @@
-"""Abstract base classes for solver components.
-
-This file provides canonical interfaces for plasma, circuit and
-diagnostics modules.  Other copies in the repository should import
+"""This file provides canonical interfaces for plasma, circuit and
+diagnostics modules. Other copies in the repository should import
 from here to avoid duplication."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- clarify core base interfaces docstring

## Testing
- `python -m py_compile src/dpf2/core/bases.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68adf2b49a2c832a9ec8dddb4d6c1ce1