### PR TITLE
Clarify collision and radiation model docstrings

### DIFF
--- a/src/dpf2/simulation/collision_model.py
+++ b/src/dpf2/simulation/collision_model.py
@@ -1,33 +1,20 @@
-"""
-collision_model.py
+"""Collision model utilities for particle and fluid simulations.
 
-Enhanced High-Fidelity Collision Model Module
--------------------------------------------
-Features:
-1. Dynamic Coulomb logarithm (Gericke–Murillo–Schlanges interpolation) for coupling regimes
-2. Quantum diffraction corrections (de Broglie wavelength)
-3. Spitzer collision frequencies: e–i, e–e, i–i, e-n
-4. Implicit electron–ion temperature relaxation (exact 2×2 solver)
-5. Full Fokker–Planck operator for e–i and e–e using Rosenbluth potentials
-6. Anisotropy relaxation solver (parallel/perpendicular temperatures)
-7. Collisional-radiative network via ADAS tables with unit conversion
-8. Energy-dependent charge-exchange from velocity distributions
-9. Braginskii transport coefficients for anisotropic conduction/resistivity
-10. GPU-accelerated kernels with explicit launch configs
-11. PIC collision handler plugin for WarpX
-12. Velocity-space diagnostics (Hermite moments)
-13. Checkpoint/restart of collisional state
-14. Automated unit/regression tests
-15. Electron-Neutral Collisions
-16. Relativistic Effects (Approximated)
-17. Quantum Effects (Approximated)
-18. Time-Dependent Effects (Approximated)
-19. Molecular Collisions (Approximated)
-20. Dust Collisions (Approximated)
-21. Non-LTE Effects (Approximated)
-22. Energy-Dependent Cross-Sections: Using lookup tables for more accurate collision rates.
-23. Consistent Formulas: Ensuring fluid and PIC solvers use the same collision models.
-24. D-D Fusion Reactions: Implementing basic D-D fusion reaction chains.
+Implemented features
+--------------------
+- Coulomb logarithm with quantum diffraction corrections
+- Spitzer collision frequencies and electron–neutral collisions
+- Implicit electron–ion temperature relaxation
+- Energy-dependent cross-section lookup tables
+- Braginskii transport coefficient helper
+- Simplified D–D fusion rates
+- Checkpoint and restart support
+
+Future Work
+-----------
+- Full Fokker–Planck operators and anisotropy relaxation
+- Collisional–radiative networks and additional reaction channels
+- GPU acceleration and detailed diagnostics
 """
 
 import numpy as np
@@ -59,6 +46,12 @@ m_d = 3.34358377e-27 # Deuterium mass
 # Abstract base for collision operators
 # --------------------------------------
 class CollisionOperator(PhysicsModule):
+    """Interface for collision models.
+
+    Subclasses are expected to implement the ``apply`` and ``diagnostics``
+    methods as well as basic checkpointing hooks.  No common functionality is
+    provided beyond this interface."""
+
     def apply(self, state: SimulationState, dt):
         raise NotImplementedError
 
@@ -132,6 +125,12 @@ def relax_ei_implicit(Te, Ti, νei, dt):
 # Energy-dependent cross-sections (example)
 # --------------------------------------
 class CrossSectionData:
+    """1D tabulated cross-section with simple interpolation.
+
+    The class expects an HDF5 file containing ``energy`` and ``cross_section``
+    datasets.  It performs minimal validation and does not track units.
+    Missing data results in zero cross-section values."""
+
     def __init__(self, filename):
         try:
             with h5py.File(filename, 'r') as f:
@@ -171,11 +170,16 @@ class CrossSectionData:
 # Collision Processes
 # --------------------------------------
 class CollisionProcess(PhysicsModule):
+    """Base class for individual collisional processes."""
+
     def apply(self, state: SimulationState, dt):
         raise NotImplementedError
 
 class BetheBlochStopping(CollisionProcess):
-    """Stopping power for ions using the Bethe-Bloch formula."""
+    """Stopping power for ions using the Bethe–Bloch formula.
+
+    The implementation neglects shell corrections and other high-order
+    effects and should be considered an order-of-magnitude estimate."""
     def __init__(self, name, Z_eff=1, I_mean_ev=13.6):
         self.name = name
         self.Z_eff = Z_eff
@@ -199,7 +203,10 @@ class BetheBlochStopping(CollisionProcess):
             logger.error(f"Error applying Bethe-Bloch stopping: {e}")
 
 class ElectronIonCollision(CollisionProcess):
-    """Electron-ion collisions using Spitzer collision frequency."""
+    """Electron–ion collisions using Spitzer frequencies.
+
+    Only a simple drag term is applied; energy diffusion and large-angle
+    scattering are not modelled."""
     def apply(self, solver):
         try:
             for name, spc in solver.species.items():
@@ -213,7 +220,7 @@ class ElectronIonCollision(CollisionProcess):
             logger.error(f"Error applying electron-ion collisions: {e}")
 
 class ElectronNeutralCollision(CollisionProcess):
-    """Electron-neutral collisions using a constant cross-section."""
+    """Electron–neutral collisions with a constant cross-section."""
     def __init__(self, sigma_en=1e-19):
         self.sigma_en = sigma_en
 
@@ -231,7 +238,10 @@ class ElectronNeutralCollision(CollisionProcess):
             logger.error(f"Error applying electron-neutral collisions: {e}")
 
 class IonizationProcess(CollisionProcess):
-    """Ionization of neutral atoms by electron impact."""
+    """Ionization of neutrals by electron impact.
+
+    Particle creation is represented only by rate sampling; actual particle
+    insertion is left as a placeholder."""
     def __init__(self, ionization_energy=13.6, cross_section_file="ionization_cross_section.h5"):
         self.ionization_energy = ionization_energy * e_charge  # Convert eV to Joules
         self.cross_section_data = CrossSectionData(cross_section_file)
@@ -255,7 +265,10 @@ class IonizationProcess(CollisionProcess):
             logger.error(f"Error applying ionization process: {e}")
 
 class RecombinationProcess(CollisionProcess):
-    """Radiative recombination of ions and electrons."""
+    """Radiative recombination of ions and electrons.
+
+    Particle removal is not yet implemented and requires a proper selection
+    mechanism."""
     def __init__(self, recombination_rate=1e-14):
         self.recombination_rate = recombination_rate
 
@@ -278,7 +291,9 @@ class RecombinationProcess(CollisionProcess):
 # D-D Fusion Reactions (simplified)
 # --------------------------------------
 class DDFusion(CollisionProcess):
-    """Deuterium-Deuterium fusion reactions (simplified)."""
+    """Deuterium–Deuterium fusion reactions (simplified).
+
+    Reaction products are not generated; only the rate is estimated."""
     def __init__(self, cross_section_file="dd_fusion_cross_section.h5"):
         self.cross_section_data = CrossSectionData(cross_section_file)
 
@@ -317,6 +332,13 @@ def braginskii_coeffs(ne, Te, Bmag):
 # Main CollisionModel integrating all
 # --------------------------------------
 class CollisionModel(CollisionOperator):
+    """Aggregate collision model for fluid simulations.
+
+    Implements basic electron–ion relaxation, optional ionization and
+    recombination rates, and utility routines for checkpointing.  The
+    collisional–radiative network and PIC coupling are skeletal and subject
+    to future expansion."""
+
     def __init__(self, config):
         self.config = config
         self.adas_file = config.get('adas_file', None)

--- a/src/dpf2/simulation/radiation_model.py
+++ b/src/dpf2/simulation/radiation_model.py
@@ -1,39 +1,18 @@
-"""
-radiation_model.py
+"""Radiation transport model used by the DPF2 simulations.
 
-Enhanced High-Fidelity Radiation Model with:
-- Synchrotron, Bremsstrahlung, and Line Emission
-- Advanced Compton Scattering (Klein-Nishina)
-- Dynamic Opacities (Temperature and Density Dependent)
-- Improved Photon Monte Carlo (Energy-Dependent Emission, Scattering)
-- Eddington Tensor Closure
-- Dynamic Line Radiation Calculation
-- Comprehensive Telemetry
-- Robust Error Handling
-- Configurable Parameters
-- Clearer Code and Documentation
-- Unit Tests (to be added in separate file)
-- Optimized Performance (Numba, efficient data structures)
-- Relativistic Effects (Approximated)
-- Polarization (Approximated)
-- Pair Production (Approximated)
-- Photoionization (Approximated)
-- Inverse Compton Scattering (Approximated)
-- Self-Absorption (Approximated)
-- Stimulated Emission (Approximated)
-- Doppler Broadening (Approximated)
-- Zeeman Splitting (Approximated)
-- Stark Broadening (Approximated)
-- Pressure Broadening (Approximated)
-- Radiative Recombination (Approximated)
-- Dielectronic Recombination (Approximated)
-- Three-Body Recombination (Approximated)
-- Autoionization (Approximated)
-- Charge Exchange (Approximated)
-- Molecular Radiation (Approximated)
-- Dust Radiation (Approximated)
-- Non-LTE Effects (Approximated)
-- Time-Dependent Effects (Approximated)
+Implemented features
+--------------------
+- Bremsstrahlung, line and synchrotron emissivities
+- Klein–Nishina Compton scattering
+- Configurable opacity models
+- Flux-limited diffusion and a basic photon Monte Carlo scheme
+- Simple telemetry and checkpoint helpers
+
+Future Work
+-----------
+- Polarization, pair production and other high-energy processes
+- Detailed non-LTE line transport and time-dependent effects
+- Expanded test coverage and performance tuning
 """
 
 import numpy as np
@@ -70,6 +49,11 @@ logger.addHandler(ch)
 # Photon data structure for Monte Carlo
 # --------------------------------------
 class Photon:
+    """Lightweight Monte Carlo photon particle.
+
+    Only the position, direction, energy and group are evolved.  Polarization
+    is stored but not used by the current algorithms."""
+
     __slots__ = ('pos', 'dir', 'energy', 'group', 'polarization')
 
     def __init__(self, pos, dir, energy, group, polarization=None):
@@ -109,6 +93,12 @@ def klein_nishina_cross_section(E):
 # High-Fidelity Radiation Model Class
 # --------------------------------------
 class RadiationModel(PhysicsModule):
+    """Multi-group radiation transport model with simplified coupling.
+
+    Supports emission processes, flux-limited diffusion and Monte Carlo photon
+    transport.  Coupling to the fluid momentum, polarization effects and many
+    high-energy processes are not yet represented."""
+
     def __init__(self, amrex_geom, config: RadiationConfig):
         self.geom = amrex_geom
         self.config = config


### PR DESCRIPTION
## Summary
- Update collision model module and class docstrings to reflect implemented features
- Streamline radiation model documentation and add Future Work sections
- Document current limitations for key classes

## Testing
- `pytest` *(fails: TypeError: cannot set 'model_validate' attribute of immutable type 'object')*

------
https://chatgpt.com/codex/tasks/task_e_68adf2bc0a88832a911fee1ef90078f2