### PR TITLE
Document z-only ghost-cell interpolation and test axis errors

### DIFF
--- a/src/dpf2/mesh/mesh3d.py
+++ b/src/dpf2/mesh/mesh3d.py
@@ -144,6 +144,9 @@ class Mesh3D:
     ) -> None:
         """Linearly interpolate ghost-cell values for a curved boundary.
 
+        This helper currently only supports boundaries normal to the ``z`` axis.
+        Passing ``axis`` as ``0`` or ``1`` will raise :class:`NotImplementedError`.
+
         Parameters
         ----------
         field:
@@ -151,7 +154,7 @@ class Mesh3D:
             place.
         axis:
             Direction normal to the boundary: ``0`` for ``x``, ``1`` for ``y``
-            and ``2`` for ``z``.
+            and ``2`` for ``z``.  Only ``axis=2`` is implemented.
         side:
             ``"low"`` or ``"high"`` indicating which side to operate on.
         ghosts:

--- a/tests/test_field_manager_boundary_shapes.py
+++ b/tests/test_field_manager_boundary_shapes.py
@@ -1,6 +1,11 @@
 import numpy as np
 import importlib.util
 from pathlib import Path
+import sys
+
+# Ensure the numpy stub provides ``ndarray`` for type hints.
+if not hasattr(np, "ndarray"):
+    np.ndarray = np.Array  # type: ignore[attr-defined]
 
 # Import FieldManager directly from the source file to avoid triggering package
 # level imports that require heavy dependencies.
@@ -9,6 +14,14 @@ spec = importlib.util.spec_from_file_location("field_utils", utils_path)
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 FieldManager = module.FieldManager
+
+# Import Mesh3D without triggering package-level imports
+mesh_path = Path(__file__).resolve().parents[1] / "src" / "dpf2" / "mesh" / "mesh3d.py"
+mesh_spec = importlib.util.spec_from_file_location("mesh3d", mesh_path)
+mesh_module = importlib.util.module_from_spec(mesh_spec)
+sys.modules[mesh_spec.name] = mesh_module
+mesh_spec.loader.exec_module(mesh_module)
+Mesh3D = mesh_module.Mesh3D
 
 def test_apply_boundary_conditions_preserves_shape_and_updates_boundaries():
     nx = ny = nz = 4
@@ -88,3 +101,25 @@ def test_apply_boundary_conditions_periodic_wraps_values():
         # Ghost cells should wrap to the opposite interior values
         assert np.all(arr[:, 0, :, :] == arr[:, -2, :, :])
         assert np.all(arr[:, -1, :, :] == arr[:, 1, :, :])
+
+
+def test_interpolate_ghost_cells_raises_for_non_z_axis():
+    import pytest
+
+    mesh = Mesh3D(0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 2, 2, 2)
+    g = 1
+    field = np.zeros((mesh.nx + 2 * g, mesh.ny + 2 * g, mesh.nz + 2 * g))
+
+    surface = lambda x, y: 0.0
+    value = lambda x, y, z: 0.0
+
+    for axis in (0, 1):
+        with pytest.raises(NotImplementedError):
+            mesh.interpolate_ghost_cells(
+                field=field,
+                axis=axis,
+                side="low",
+                ghosts=g,
+                surface=surface,
+                value=value,
+            )


### PR DESCRIPTION
## Summary
- note in `Mesh3D.interpolate_ghost_cells` that only z-normal boundaries are supported and other axes raise `NotImplementedError`
- add a regression test verifying non-z axes trigger the error

## Testing
- `pytest tests/test_field_manager_boundary_shapes.py` *(fails: 'Array' object has no attribute 'fill')*
- `pytest tests/test_field_manager_boundary_shapes.py::test_interpolate_ghost_cells_raises_for_non_z_axis -q`

------
https://chatgpt.com/codex/tasks/task_e_68adf2c90fe4832a92f27cf441249df5