### PR TITLE
docs: clarify experimental optional features

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,17 @@ mkdocs serve
 pip install .
 ```
 
-Optional extras can be installed to enable additional features:
+Optional extras can be installed to enable additional, experimental features:
 
 ```bash
-# Install with Flask-based server support
+
+# Install with Flask-based server support (experimental)
 pip install .[server]
 
-# Install with WarpX accelerator support
+# Install with WarpX accelerator support (experimental)
 pip install .[warpx]
 
-# Install with OpenCensus-based telemetry support
+# Install with OpenCensus-based telemetry and tracing support (experimental)
 pip install .[telemetry]
 
 # Install all optional features
@@ -53,15 +54,23 @@ result = simulation.run()
 
 Configuration files use the `DPFConfig` schema defined in this repository. See `examples/quickstart.ipynb` for a walk-through in a Jupyter notebook.
 
-## Tracing
+## Server Mode (Experimental)
 
-The standalone `dpf_simulation` entry point can emit OpenCensus trace spans around major simulation stages. Enable this optional feature with the `--enable-tracing` flag (install via the `telemetry` extra):
+A lightweight Flask server is provided for remote execution and basic job management. The implementation is not production ready and exposes only minimal endpoints. Install the `[server]` extra and launch with `python -m dpf2.simulation.dpf_simulator_server`. See [`src/dpf2/simulation/dpf_simulator_server.py`](src/dpf2/simulation/dpf_simulator_server.py) and [`tests/test_api_endpoints.py`](tests/test_api_endpoints.py) for the current interface.
+
+## WarpX Accelerator Support (Experimental)
+
+Preliminary integration with [WarpX](https://warpx.readthedocs.io) enables particle-in-cell acceleration via `pywarpx`. The feature is incomplete and intended for experimentation only. Install the `[warpx]` extra and consult [`src/dpf2/warpx_settings.py`](src/dpf2/warpx_settings.py) and [`tests/test_warpx_settings.py`](tests/test_warpx_settings.py) for examples of the configuration schema.
+
+## Telemetry and Tracing (Experimental)
+
+The standalone `dpf_simulation` entry point can emit OpenCensus trace spans around major simulation stages. Enable this optional tracing feature with the `--enable-tracing` flag (requires the `[telemetry]` extra):
 
 ```bash
 dpf_simulation --config-file config.json --enable-tracing
 ```
 
-When tracing is disabled, the simulation runs without importing the tracing library.
+Telemetry streaming through ADIOS2 is available only in certain backends and lacks comprehensive tests. See [`src/dpf2/simulation/dpf_simulator_amrex_backend.py`](src/dpf2/simulation/dpf_simulator_amrex_backend.py) for the experimental implementation and [`src/dpf2/simulation/dpf_simulation.py`](src/dpf2/simulation/dpf_simulation.py) for the tracing hooks. Tracing behaviour is exercised in [`tests/test_dpf_simulation_run.py`](tests/test_dpf_simulation_run.py).
 
 ## Repository Layout
 
@@ -70,6 +79,6 @@ When tracing is disabled, the simulation runs without importing the tracing libr
 - `tests/` – unit and integration tests
 - `examples/` – example scripts and notebook
 
-## AI Surrogate Models
+## AI Surrogate Models (Experimental)
 
-The package defines a flexible `SurrogateModel` interface allowing inference with PyTorch or ONNX models. Surrogates can be plugged into simulations to replace expensive physics modules. See the `dpf2.ai` module for details.
+The package defines a flexible `SurrogateModel` interface allowing inference with PyTorch or ONNX models, but no pretrained models are included. These classes require the user to install `torch` or `onnxruntime` separately. Surrogates can be plugged into simulations to replace expensive physics modules. See [`src/dpf2/ai/surrogate.py`](src/dpf2/ai/surrogate.py) and [`tests/test_ai_surrogate.py`](tests/test_ai_surrogate.py) for the current interface and coverage.


### PR DESCRIPTION
## Summary
- Document server mode as an experimental Flask interface and link to implementation and tests
- Mark WarpX accelerator, telemetry/tracing, and AI surrogate support as experimental with pointers to code and tests
- Note required extras or external packages for these optional features

## Testing
- `pytest tests/test_api_endpoints.py tests/test_warpx_settings.py tests/test_dpf_simulation_run.py tests/test_ai_surrogate.py -q` *(fails: ModuleNotFoundError: werkzeug, pydantic, numpy)*
- `pip install numpy pydantic flask flask-sock werkzeug PyYAML -q` *(fails: No matching distribution found for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68adf2d053a0832a8c209d9d28241a6c