### PR TITLE
Use package-relative imports in simulation modules

### DIFF
--- a/src/dpf2/simulation/collision_model.py
+++ b/src/dpf2/simulation/collision_model.py
@@ -23,14 +23,8 @@ import math
 from scipy.interpolate import interp1d, RegularGridInterpolator
 from numba import njit, prange, cuda
 import logging
-
-try:  # Prefer package-relative imports
-    from .models import PhysicsModule, SimulationState  # Import SimulationState
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from models import PhysicsModule, SimulationState  # type: ignore
-
 import types
-from models import PhysicsModule, SimulationState  # Import SimulationState
+from .models import PhysicsModule, SimulationState
 
 from typing import List, Dict, Tuple, Optional
 
@@ -187,14 +181,18 @@ class BetheBlochStopping(CollisionProcess):
 
     """Stopping power for ions using the Bethe-Bloch formula."""
 
-    def __init__(self, name, Z_eff: int = 1, I_mean_ev: float = 13.6, speed_of_light: float = 299792458.0):
+    def __init__(
+        self,
+        name,
+        Z_eff: int = 1,
+        I_mean_ev: float = 13.6,
+        speed_of_light: float = 299792458.0,
+    ):
+        """Stopping power for ions using the Bethe–Bloch formula.
 
-    """Stopping power for ions using the Bethe–Bloch formula.
-
-    The implementation neglects shell corrections and other high-order
-    effects and should be considered an order-of-magnitude estimate."""
-    def __init__(self, name, Z_eff=1, I_mean_ev=13.6):
-
+        The implementation neglects shell corrections and other high-order
+        effects and should be considered an order-of-magnitude estimate.
+        """
         self.name = name
         self.Z_eff = Z_eff
         self.I_mean = I_mean_ev * e_charge  # Convert eV to Joules

--- a/src/dpf2/simulation/diagnostics.py
+++ b/src/dpf2/simulation/diagnostics.py
@@ -7,7 +7,7 @@ from scipy.constants import c, m_n, m_e, mu_0, e, epsilon_0, k as k_B
 from scipy.interpolate import interp1d
 from pyevtk.hl import imageToVTK
 from dpf2.core.bases import DiagnosticsBase
-from utils import FieldManager, SimulationState  # Import FieldManager and SimulationState
+from .utils import FieldManager, SimulationState
 
 # Classical electron radius (m)
 r_e = e ** 2 / (4 * np.pi * epsilon_0 * m_e * c ** 2)

--- a/src/dpf2/simulation/dpf_simulation.py
+++ b/src/dpf2/simulation/dpf_simulation.py
@@ -14,57 +14,17 @@ import numpy as np
 import random
 from datetime import datetime
 
-try:
-    from .config_schema import SimulationConfig, FieldManagerConfig  # Import FieldManagerConfig
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from config_schema import SimulationConfig, FieldManagerConfig  # type: ignore
-
-try:
-    from .module_registry import ModuleRegistry
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from module_registry import ModuleRegistry  # type: ignore
-
-try:
-    from .collision_model import CollisionModel
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from collision_model import CollisionModel  # type: ignore
-
-try:
-    from .radiation_model import RadiationModel
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from radiation_model import RadiationModel  # type: ignore
-
-try:
-    from .hybrid_controller import HybridController
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from hybrid_controller import HybridController  # type: ignore
-
-try:
-    from .eos_selector import select_eos
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from eos_selector import select_eos  # type: ignore
-
-try:
-    from .solver_selector import select_solver
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from solver_selector import select_solver  # type: ignore
-
-try:
-    from .circuit import CircuitModel
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from circuit import CircuitModel  # type: ignore
-
-try:
-    from .utils import FieldManager, SimulationState  # Import FieldManager and SimulationState
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from utils import FieldManager, SimulationState  # type: ignore
-
-from dpf2.diagnostics import Diagnostics
-
-try:
-    from .pic_solver import PICSolver
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from pic_solver import PICSolver  # type: ignore
+from .config_schema import SimulationConfig, FieldManagerConfig  # Import FieldManagerConfig
+from .module_registry import ModuleRegistry
+from .collision_model import CollisionModel
+from .radiation_model import RadiationModel
+from .hybrid_controller import HybridController
+from .eos_selector import select_eos
+from .solver_selector import select_solver
+from .circuit import CircuitModel
+from .utils import FieldManager, SimulationState
+from ..diagnostics import Diagnostics
+from .pic_solver import PICSolver
 try:
     from ..exceptions import SimulationRuntimeError
 except Exception:  # pragma: no cover - fallback for standalone usage

--- a/src/dpf2/simulation/dpf_simulator_amrex_backend.py
+++ b/src/dpf2/simulation/dpf_simulator_amrex_backend.py
@@ -16,18 +16,18 @@ except Exception as e:  # pragma: no cover
     MPI = None
     logging.getLogger(__name__).warning("mpi4py not available: %s", e)
 from catalyst import CatalystPipeline
-from dpf_simulator_full_backend import DPFSimulatorBackend
-from fluid_solver_high_order import FluidSolver3DAMReX
-from warpx_wrapper import WarpXInterface
-from collision_model import CollisionModel
-from radiation_model import RadiationModel
-from circuit import CircuitModel
-from dpf2.diagnostics import Diagnostics
+from .dpf_simulator_full_backend import DPFSimulatorBackend
+from .fluid_solver_high_order import FluidSolver3DAMReX
+from .warpx_wrapper import WarpXInterface
+from .collision_model import CollisionModel
+from .radiation_model import RadiationModel
+from .circuit import CircuitModel
+from ..diagnostics import Diagnostics
 from .constants import mu0
-from sheath_model import PlasmaSheathFormation
-from load_balance_metrics import LoadBalanceMetrics
-from openpmd_io import OpenPMDWriter
-from utils import FieldManager, SimulationState  # Import FieldManager and SimulationState
+from .sheath_model import PlasmaSheathFormation
+from .load_balance_metrics import LoadBalanceMetrics
+from .openpmd_io import OpenPMDWriter
+from .utils import FieldManager, SimulationState
 
 logger = logging.getLogger(__name__)
 

--- a/src/dpf2/simulation/dpf_simulator_full_backend.py
+++ b/src/dpf2/simulation/dpf_simulator_full_backend.py
@@ -4,17 +4,17 @@ from mpi4py import MPI
 import logging
 import time
 
-from config_schema import SimulationConfig, SheathConfig
-from module_registry import ModuleRegistry
-from fluid_solver_high_order import FluidSolverHighOrder
-from circuit import CircuitModel
-from collision_model import CollisionModel
-from radiation_model import RadiationModel
-from pic_solver import PICSolver
-from hybrid_controller import HybridController
-from dpf2.diagnostics import Diagnostics
-from utils import FieldManager, SimulationState  # Import FieldManager and SimulationState
-from sheath_model import PlasmaSheathFormation
+from .config_schema import SimulationConfig, SheathConfig
+from .module_registry import ModuleRegistry
+from .fluid_solver_high_order import FluidSolverHighOrder
+from .circuit import CircuitModel
+from .collision_model import CollisionModel
+from .radiation_model import RadiationModel
+from .pic_solver import PICSolver
+from .hybrid_controller import HybridController
+from ..diagnostics import Diagnostics
+from .utils import FieldManager, SimulationState
+from .sheath_model import PlasmaSheathFormation
 from ..exceptions import SimulationRuntimeError
 
 logger = logging.getLogger(__name__)

--- a/src/dpf2/simulation/dpf_simulator_server.py
+++ b/src/dpf2/simulation/dpf_simulator_server.py
@@ -15,29 +15,17 @@ from flask_sock import Sock
 from werkzeug.security import generate_password_hash, check_password_hash
 from werkzeug.utils import secure_filename
 
-from dpf_simulation import DPFSimulation, ConfigurationError as SimConfigurationError
-from config_schema import ServerConfig, FieldManagerConfig  # Import FieldManagerConfig
-from utils import FieldManager  # Import FieldManager
+from .dpf_simulation import DPFSimulation, ConfigurationError as SimConfigurationError
+from .config_schema import ServerConfig, FieldManagerConfig  # Import FieldManagerConfig
+from .utils import FieldManager  # Import FieldManager
 
 # Import custom exception hierarchy
-try:  # pragma: no cover - handles execution as a module
-    from ..exceptions import (
-        ConfigurationError,
-        ExportError,
-        ServerError,
-        SimulationRuntimeError,
-    )
-except Exception:  # pragma: no cover - fallback for direct execution
-    import os
-    import sys
-
-    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-    from exceptions import (  # type: ignore
-        ConfigurationError,
-        ExportError,
-        ServerError,
-        SimulationRuntimeError,
-    )
+from ..exceptions import (
+    ConfigurationError,
+    ExportError,
+    ServerError,
+    SimulationRuntimeError,
+)
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")

--- a/src/dpf2/simulation/fluid_solver_high_order.py
+++ b/src/dpf2/simulation/fluid_solver_high_order.py
@@ -36,13 +36,13 @@ except ModuleNotFoundError as exc:  # pragma: no cover - import guard
     ) from exc
 import logging
 from numba import njit, prange
-from collision_model import braginskii_coeffs, CollisionModel  # Import CollisionModel
-from eos import TabulatedEOS
-from sheath_model import BohmSheath
-from radiation_model import RadiationModel # Import RadiationModel
-from turbulence_model import TurbulenceModel # Import TurbulenceModel
-from models import PhysicsModule
-from utils import FieldManager, SimulationState # Import FieldManager and SimulationState
+from .collision_model import braginskii_coeffs, CollisionModel
+from .eos import TabulatedEOS
+from .sheath_model import BohmSheath
+from .radiation_model import RadiationModel
+from .turbulence_model import TurbulenceModel
+from .models import PhysicsModule
+from .utils import FieldManager, SimulationState
 
 # Physical constants
 epsilon0 = 8.854187817e-12

--- a/src/dpf2/simulation/hybrid_controller.py
+++ b/src/dpf2/simulation/hybrid_controller.py
@@ -42,48 +42,16 @@ except Exception as e:  # pragma: no cover - fallback for test environment
 
     caliper = _CaliperStub()
 
-try:
-    from .sheath_model import PlasmaSheathFormation
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from sheath_model import PlasmaSheathFormation  # type: ignore
-
+from .sheath_model import PlasmaSheathFormation
 from scipy.ndimage import gaussian_filter, label
 from numba import njit, prange
-
-try:
-    from .fluid_solver_high_order import FluidSolverHighOrder
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from fluid_solver_high_order import FluidSolverHighOrder  # type: ignore
-
-try:
-    from .warpx_wrapper import WarpXWrapper
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from warpx_wrapper import WarpXWrapper  # type: ignore
-
-try:
-    from .radiation_model import RadiationModel
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from radiation_model import RadiationModel  # type: ignore
-
-try:
-    from .collision_model import CollisionModel
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from collision_model import CollisionModel  # type: ignore
-
-try:
-    from .config_schema import HybridConfig
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from config_schema import HybridConfig  # type: ignore
-
-try:
-    from .models import PhysicsModule, SimulationState
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from models import PhysicsModule, SimulationState  # type: ignore
-
-try:
-    from .utils import FieldManager
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from utils import FieldManager  # type: ignore
+from .fluid_solver_high_order import FluidSolverHighOrder
+from .warpx_wrapper import WarpXWrapper
+from .radiation_model import RadiationModel
+from .collision_model import CollisionModel
+from .config_schema import HybridConfig
+from .models import PhysicsModule, SimulationState
+from .utils import FieldManager
 
 # Physical constants
 mu0      = 4*np.pi*1e-7

--- a/src/dpf2/simulation/module_registry.py
+++ b/src/dpf2/simulation/module_registry.py
@@ -1,5 +1,5 @@
 # module_registry.py
-from Simulation.models import PhysicsModule  # Ensure plugin base class is available
+from .models import PhysicsModule  # Ensure plugin base class is available
 
 import importlib
 import inspect
@@ -8,7 +8,7 @@ import os
 from typing import Dict, Type, Any, List, Optional
 
 from pydantic import BaseModel, ValidationError
-from utils import FieldManager
+from .utils import FieldManager
 
 logger = logging.getLogger(__name__)
 

--- a/src/dpf2/simulation/pic_solver.py
+++ b/src/dpf2/simulation/pic_solver.py
@@ -11,44 +11,18 @@ import threading
 import math
 from numba import njit, prange
 from typing import List, Dict, Tuple, Optional
-try:
-    from .config_schema import PICConfig  # Assuming you have a PICConfig in config_schema.py
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from config_schema import PICConfig  # type: ignore
-
-try:
-    from .models import PhysicsModule  # Assuming you have a PhysicsModule in models.py
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from models import PhysicsModule  # type: ignore
-
-try:
-    from .utils import FieldManager, SimulationState  # Import FieldManager and SimulationState
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from utils import FieldManager, SimulationState  # type: ignore
-
-try:
-    from .warpx_wrapper import WarpXInterface  # Assuming you have a WarpXInterface in warpx_wrapper.py
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from warpx_wrapper import WarpXInterface  # type: ignore
-
-try:
-    from .collision_model import (
-        CollisionProcess,
-        BetheBlochStopping,
-        ElectronIonCollision,
-        ElectronNeutralCollision,
-        IonizationProcess,
-        RecombinationProcess,
-    )  # Assuming you have a CollisionProcess in collision_model.py
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from collision_model import (
-        CollisionProcess,
-        BetheBlochStopping,
-        ElectronIonCollision,
-        ElectronNeutralCollision,
-        IonizationProcess,
-        RecombinationProcess,
-    )  # type: ignore
+from .config_schema import PICConfig
+from .models import PhysicsModule
+from .utils import FieldManager, SimulationState
+from .warpx_wrapper import WarpXInterface
+from .collision_model import (
+    CollisionProcess,
+    BetheBlochStopping,
+    ElectronIonCollision,
+    ElectronNeutralCollision,
+    IonizationProcess,
+    RecombinationProcess,
+)
 
 # Configure logger
 logger = logging.getLogger('pic_solver')

--- a/src/dpf2/simulation/radiation_model.py
+++ b/src/dpf2/simulation/radiation_model.py
@@ -36,15 +36,13 @@ except ModuleNotFoundError as exc:  # pragma: no cover - import guard
 from scipy.interpolate import RegularGridInterpolator
 from numba import njit, prange
 import socket
-try:  # Prefer package-relative imports
-    from .models import PhysicsModule, SimulationState
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from models import PhysicsModule, SimulationState  # type: ignore
+from .models import PhysicsModule, SimulationState
 
 try:  # pragma: no cover - config schema may be optional
     from .config_schema import RadiationConfig
 except Exception:  # fallback when imported outside package
-    from config_schema import RadiationConfig  # type: ignore
+    from typing import Any
+    RadiationConfig = Any  # type: ignore
 from typing import Dict, Any
 
 # Physical constants

--- a/src/dpf2/simulation/sheath_model.py
+++ b/src/dpf2/simulation/sheath_model.py
@@ -31,18 +31,12 @@ except Exception:  # pragma: no cover - numba not available
 
 from typing import Dict, Any
 
-try:  # Prefer package-relative imports
-    from .models import PhysicsModule, SimulationState  # type: ignore
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from models import PhysicsModule, SimulationState  # type: ignore
+from .models import PhysicsModule, SimulationState  # type: ignore
 
 try:  # pragma: no cover - config schema depends on pydantic
     from .config_schema import SheathConfig  # type: ignore
 except Exception:  # pragma: no cover - when pydantic v2 not present
-    try:  # fallback for standalone import
-        from config_schema import SheathConfig  # type: ignore
-    except Exception:
-        SheathConfig = Any  # type: ignore
+    SheathConfig = Any  # type: ignore
 
 # Configure logger
 logger = logging.getLogger(__name__)

--- a/src/dpf2/simulation/solver_selector.py
+++ b/src/dpf2/simulation/solver_selector.py
@@ -1,28 +1,11 @@
 # solver_selector.py
-try:
-    from .fluid_solver_high_order import FluidSolverHighOrder
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from fluid_solver_high_order import FluidSolverHighOrder  # type: ignore
-
-try:
-    from .pic_solver import PICSolver
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from pic_solver import PICSolver  # type: ignore
-
+from .fluid_solver_high_order import FluidSolverHighOrder
+from .pic_solver import PICSolver
 # from .amrex_solver import FluidSolverAMReX  # Keep for potential future use, but comment out
-
-try:
-    from .utils import FieldManager  # Import FieldManager
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from utils import FieldManager  # type: ignore
-
+from .utils import FieldManager
 from typing import Dict, Any
 import logging
-
-try:
-    from .models import PhysicsModule
-except Exception:  # pragma: no cover - fallback for standalone usage
-    from models import PhysicsModule  # type: ignore
+from .models import PhysicsModule
 
 logger = logging.getLogger(__name__)
 

--- a/src/dpf2/simulation/turbulence_model.py
+++ b/src/dpf2/simulation/turbulence_model.py
@@ -6,7 +6,7 @@ from .models import PhysicsModule, SimulationState
 from typing import Dict, Any, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - only for type checking
-    from config_schema import TurbulenceConfig
+    from .config_schema import TurbulenceConfig
 
 logger = logging.getLogger(__name__)
 

--- a/src/dpf2/simulation/warpx_wrapper.py
+++ b/src/dpf2/simulation/warpx_wrapper.py
@@ -38,8 +38,8 @@ except ModuleNotFoundError as exc:  # pragma: no cover - import guard
     raise ImportError(
         "amrex is required for radiation features; install dpf2[radiation]"
     ) from exc
-from collision_model import CollisionModel  # Assuming you have this
-from utils import FieldManager # Import FieldManager
+from .collision_model import CollisionModel  # Assuming you have this
+from .utils import FieldManager
 
 # Configure logger
 logger = logging.getLogger('WarpXWrapper')


### PR DESCRIPTION
## Summary
- replace absolute intra-package imports with relative ones
- drop redundant fallback imports
- ensure simulation modules compile

## Testing
- `python -m py_compile src/dpf2/simulation/pic_solver.py src/dpf2/simulation/hybrid_controller.py src/dpf2/simulation/fluid_solver_high_order.py src/dpf2/simulation/collision_model.py src/dpf2/simulation/solver_selector.py src/dpf2/simulation/sheath_model.py src/dpf2/simulation/module_registry.py src/dpf2/simulation/radiation_model.py src/dpf2/simulation/dpf_simulator_amrex_backend.py src/dpf2/simulation/dpf_simulator_full_backend.py src/dpf2/simulation/dpf_simulator_server.py src/dpf2/simulation/dpf_simulation.py src/dpf2/simulation/diagnostics.py src/dpf2/simulation/warpx_wrapper.py src/dpf2/simulation/turbulence_model.py`
- `python -m py_compile src/dpf2/simulation/dpf_simulator_server.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae070c7ea0832a9277509f99f8ce55