### PR TITLE
Clarify fluid solver dependency guidance

### DIFF
--- a/src/dpf2/simulation/fluid_solver_high_order.py
+++ b/src/dpf2/simulation/fluid_solver_high_order.py
@@ -26,13 +26,13 @@ try:  # optional dependency
     from amrex import EBIndexSpace, MultiFab, MultiFabLaplacian, MLMG
 except ModuleNotFoundError as exc:  # pragma: no cover - import guard
     raise ImportError(
-        "amrex is required for radiation features; install dpf2[radiation]"
+        "amrex is required for the high-order fluid solver; install it via `pip install dpf2[radiation]`"
     ) from exc
 try:  # optional dependency
     import adios2
 except ModuleNotFoundError as exc:  # pragma: no cover - import guard
     raise ImportError(
-        "adios2 is required for radiation features; install dpf2[radiation]"
+        "adios2 is required for the high-order fluid solver; install it via `pip install dpf2[radiation]`"
     ) from exc
 import logging
 from numba import njit, prange


### PR DESCRIPTION
## Summary
- Clarify `ImportError` guidance for amrex and adios2 in `fluid_solver_high_order`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_68ae071974c8832a8f7ff5b25db36f6b