### PR TITLE
Implement isotropic photon scattering

### DIFF
--- a/src/dpf2/simulation/radiation_model.py
+++ b/src/dpf2/simulation/radiation_model.py
@@ -80,16 +80,35 @@ class Photon:
         self.polarization = polarization if polarization is not None else np.array([1.0, 0.0, 0.0])  # Default: linear polarization along x-axis
 
     def scatter(self):
-        """Performs a Compton scattering event."""
+        """Perform a simplified isotropic Compton scattering event.
+
+        The scattering angle is sampled isotropically and the photon's
+        direction vector is rotated accordingly while remaining normalized.
+        """
         # Sample new energy
         x = self.energy / (m_e * c**2)
-        theta = np.arccos(1 - 2 * random.random())  # Isotropic scattering
-        y = x / (1 + x * (1 - np.cos(theta)))
+        mu = 1 - 2 * random.random()  # cos(theta) for isotropic scattering
+        theta = np.arccos(mu)
+        y = x / (1 + x * (1 - mu))
         self.energy = y * (m_e * c**2)
-        # Sample new direction
+
+        # Sample azimuthal angle
         phi = 2 * np.pi * random.random()
+
         # Rotate direction
-        # ... (implementation for rotating the direction vector) ...
+        n = self.dir
+        # Build an orthonormal basis {n, u, v}
+        if abs(n[0]) < 0.9:
+            tmp = np.array([1.0, 0.0, 0.0])
+        else:
+            tmp = np.array([0.0, 1.0, 0.0])
+        u = np.cross(n, tmp)
+        u /= np.linalg.norm(u)
+        v = np.cross(n, u)
+
+        sin_theta = np.sin(theta)
+        self.dir = mu * n + sin_theta * (np.cos(phi) * u + np.sin(phi) * v)
+        self.dir /= np.linalg.norm(self.dir)
 
 # --------------------------------------
 # Klein-Nishina Compton cross section

--- a/tests/test_photon_scatter.py
+++ b/tests/test_photon_scatter.py
@@ -1,0 +1,43 @@
+import random
+import sys
+import types
+
+# Stub optional heavy dependencies used by radiation_model
+sys.modules.setdefault("amrex", types.ModuleType("amrex"))
+sys.modules.setdefault("adios2", types.ModuleType("adios2"))
+sys.modules.setdefault("h5py", types.ModuleType("h5py"))
+scipy_stub = types.ModuleType("scipy")
+interpolate_stub = types.ModuleType("interpolate")
+interpolate_stub.RegularGridInterpolator = lambda *args, **kwargs: None
+scipy_stub.interpolate = interpolate_stub
+sys.modules.setdefault("scipy", scipy_stub)
+sys.modules.setdefault("scipy.interpolate", interpolate_stub)
+numba_stub = types.ModuleType("numba")
+numba_stub.njit = lambda *args, **kwargs: (lambda f: f)
+numba_stub.prange = range
+sys.modules.setdefault("numba", numba_stub)
+
+# Provide minimal numpy stub with required functions
+import math
+import numpy_stub
+numpy_stub.np.sin = math.sin
+numpy_stub.np.cos = math.cos
+numpy_stub.np.arccos = math.acos
+numpy_stub.np.linalg = types.SimpleNamespace(norm=lambda v: math.sqrt(sum(x * x for x in v)))
+sys.modules["numpy"] = numpy_stub.np
+
+from dpf2.simulation.radiation_model import Photon, m_e, c
+
+_norm = numpy_stub.np.linalg.norm
+
+
+def test_photon_scatter_rotates_direction():
+    random.seed(0)
+    p = Photon(pos=[0, 0, 0], dir=[1, 0, 0], energy=m_e * c**2, group=0)
+    initial_dir = p.dir.copy()
+    p.scatter()
+    changed = any(abs(a - b) > 1e-12 for a, b in zip(p.dir, initial_dir))
+    assert changed
+    norm = _norm(p.dir)
+    assert abs(norm - 1.0) < 1e-12
+


### PR DESCRIPTION
## Summary
- rotate photon direction vector using sampled polar and azimuthal angles for isotropic Compton scattering
- document simplification and ensure direction normalization
- add regression test covering photon scatter direction update

## Testing
- `pytest tests/test_photon_scatter.py`

------
https://chatgpt.com/codex/tasks/task_e_68ae12a8e5c4832aa7706f48cf7b5397