### PR TITLE
Handle optional WarpX dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ version = "0.1.0"
 description = "Minimal Dense Plasma Focus simulator"
 requires-python = ">=3.10"
 dependencies = [
-    "h5py",
     "matplotlib",
     "numba",
     "numpy",
@@ -25,7 +24,11 @@ server = [
 ]
 warpx = [
     "pywarpx",
-    "amrex_solver"
+    "amrex_solver",
+    "amrex",
+    "adios2",
+    "picmi",
+    "h5py>=3.7.0"
 ]
 telemetry = [
     "opencensus"

--- a/src/dpf2/simulation/adaptive_mesh_refinement.py
+++ b/src/dpf2/simulation/adaptive_mesh_refinement.py
@@ -5,8 +5,13 @@ import time
 import logging
 from typing import List, Optional
 import numpy as np
-import pywarpx
-from pywarpx import picmi
+try:  # optional dependency
+    import pywarpx
+    from pywarpx import picmi
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ImportError(
+        "WarpX dependencies missing; install dpf2[warpx]"
+    ) from exc
 
 # Setup logging
 logging.basicConfig(level=logging.INFO,

--- a/src/dpf2/simulation/collision_model.py
+++ b/src/dpf2/simulation/collision_model.py
@@ -18,12 +18,17 @@ Future Work
 """
 
 import numpy as np
-import h5py
 import math
 from scipy.interpolate import interp1d, RegularGridInterpolator
 from numba import njit, prange, cuda
 import logging
 import types
+try:  # optional dependency
+    import h5py
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ImportError(
+        "h5py is required; install dpf2[warpx]"
+    ) from exc
 
 
 from typing import List, Dict, Tuple, Optional

--- a/src/dpf2/simulation/diagnostics.py
+++ b/src/dpf2/simulation/diagnostics.py
@@ -1,8 +1,13 @@
 import numpy as np
-import h5py
 import json
 import logging
 import time
+try:  # optional dependency
+    import h5py
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ImportError(
+        "h5py is required; install dpf2[warpx]"
+    ) from exc
 from scipy.constants import c, m_n, m_e, mu_0, e, epsilon_0, k as k_B
 from scipy.interpolate import interp1d
 from pyevtk.hl import imageToVTK

--- a/src/dpf2/simulation/dpf_simulator_amrex_backend.py
+++ b/src/dpf2/simulation/dpf_simulator_amrex_backend.py
@@ -3,7 +3,7 @@ try:  # optional dependency
     import adios2
 except ModuleNotFoundError as exc:  # pragma: no cover - import guard
     raise ImportError(
-        "adios2 is required for radiation features; install dpf2[radiation]"
+        "adios2 is required; install dpf2[warpx]"
     ) from exc
 import resource
 import logging

--- a/src/dpf2/simulation/eos.py
+++ b/src/dpf2/simulation/eos.py
@@ -2,9 +2,14 @@ import logging
 from pathlib import Path
 from typing import Dict, Optional, Union
 
-import h5py
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator
+try:  # optional dependency
+    import h5py
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ImportError(
+        "h5py is required; install dpf2[warpx]"
+    ) from exc
 
 logger = logging.getLogger(__name__)
 

--- a/src/dpf2/simulation/fluid_solver_high_order.py
+++ b/src/dpf2/simulation/fluid_solver_high_order.py
@@ -25,13 +25,13 @@ try:  # optional dependency
     from amrex import EBIndexSpace, MultiFab, MultiFabLaplacian, MLMG
 except ModuleNotFoundError as exc:  # pragma: no cover - import guard
     raise ImportError(
-        "amrex is required for the high-order fluid solver; install it via `pip install dpf2[radiation]`"
+        "amrex is required; install dpf2[warpx]"
     ) from exc
 try:  # optional dependency
     import adios2
 except ModuleNotFoundError as exc:  # pragma: no cover - import guard
     raise ImportError(
-        "adios2 is required for the high-order fluid solver; install it via `pip install dpf2[radiation]`"
+        "adios2 is required; install dpf2[warpx]"
     ) from exc
 import logging
 from numba import njit, prange

--- a/src/dpf2/simulation/openpmd_io.py
+++ b/src/dpf2/simulation/openpmd_io.py
@@ -1,4 +1,9 @@
-import h5py
+try:  # optional dependency
+    import h5py
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ImportError(
+        "h5py is required; install dpf2[warpx]"
+    ) from exc
 import numpy as np
 from typing import Dict, Any
 

--- a/src/dpf2/simulation/radiation_model.py
+++ b/src/dpf2/simulation/radiation_model.py
@@ -19,19 +19,24 @@ import numpy as np
 import random
 import threading
 import queue
-import h5py
 import logging
+try:  # optional dependency
+    import h5py
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ImportError(
+        "h5py is required; install dpf2[warpx]"
+    ) from exc
 try:  # optional dependency
     import amrex
 except ModuleNotFoundError as exc:  # pragma: no cover - import guard
     raise ImportError(
-        "amrex is required for radiation features; install dpf2[radiation]"
+        "amrex is required; install dpf2[warpx]"
     ) from exc
 try:  # optional dependency
     import adios2
 except ModuleNotFoundError as exc:  # pragma: no cover - import guard
     raise ImportError(
-        "adios2 is required for radiation features; install dpf2[radiation]"
+        "adios2 is required; install dpf2[warpx]"
     ) from exc
 from scipy.interpolate import RegularGridInterpolator
 from numba import njit, prange

--- a/src/dpf2/simulation/warpx_wrapper.py
+++ b/src/dpf2/simulation/warpx_wrapper.py
@@ -22,21 +22,31 @@ import queue
 import socket
 import json
 import numpy as np
-import h5py
 import logging
-import picmi
+try:  # optional dependency
+    import h5py
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ImportError(
+        "h5py is required; install dpf2[warpx]"
+    ) from exc
+try:  # optional dependency
+    import picmi
+except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+    raise ImportError(
+        "picmi is required; install dpf2[warpx]"
+    ) from exc
 try:  # optional dependency
     import adios2
 except ModuleNotFoundError as exc:  # pragma: no cover - import guard
     raise ImportError(
-        "adios2 is required for radiation features; install dpf2[radiation]"
+        "adios2 is required; install dpf2[warpx]"
     ) from exc
 try:  # optional dependency
     import amrex
     from amrex import EBIndexSpace
 except ModuleNotFoundError as exc:  # pragma: no cover - import guard
     raise ImportError(
-        "amrex is required for radiation features; install dpf2[radiation]"
+        "amrex is required; install dpf2[warpx]"
     ) from exc
 from .collision_model import CollisionModel  # Assuming you have this
 from .utils import FieldManager

--- a/tests/test_warpx_smoke.py
+++ b/tests/test_warpx_smoke.py
@@ -1,0 +1,14 @@
+"""Smoke test for WarpX wrapper optional dependencies."""
+
+import pytest
+
+
+def test_warpx_wrapper_import():
+    """Import the WarpX wrapper when dependencies are present."""
+    pytest.importorskip("adios2")
+    pytest.importorskip("amrex")
+    pytest.importorskip("picmi")
+    pytest.importorskip("h5py")
+
+    from dpf2.simulation.warpx_wrapper import WarpXWrapper  # noqa: F401
+


### PR DESCRIPTION
## Summary
- Wrap optional adios2, amrex, picmi, and h5py imports with guidance to install `dpf2[warpx]`
- Expand `warpx` extra to include amrex, adios2, picmi, and h5py
- Add smoke test that skips when WarpX dependencies are unavailable

## Testing
- `pytest -q` *(fails: No module named 'pydantic')*
- `pytest tests/test_warpx_smoke.py -q`
- `pip install pydantic` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae12aac750832aa71e2d1246267983