### PR TITLE
Ensure radiation telemetry threads close cleanly

### DIFF
--- a/src/dpf2/simulation/hybrid_controller.py
+++ b/src/dpf2/simulation/hybrid_controller.py
@@ -436,6 +436,8 @@ class AsyncHybridController(HybridController):
             self._q.put(None)
             self._fth.join()
             self._pth.join()
+            self.circuit.finalize()
+            self.radiation.finalize()
             logger.info("AsyncHybridController finalized.")
         except Exception as e:
             logger.error(f"Error during asynchronous finalization: {e}")

--- a/src/dpf2/simulation/radiation_model.py
+++ b/src/dpf2/simulation/radiation_model.py
@@ -152,6 +152,7 @@ class RadiationModel(PhysicsModule):
 
         # Telemetry queue & thread (asynchronous)
         self._q = queue.Queue()
+        self._telemetry_conn = None
         try:
             self._t_thread = threading.Thread(target=self._telemetry_loop)
             self._t_thread.daemon = True
@@ -188,13 +189,12 @@ class RadiationModel(PhysicsModule):
 
     def _telemetry_loop(self):
         try:
-            conn = socket.create_connection(('localhost', self.telemetry_port))
+            self._telemetry_conn = socket.create_connection(('localhost', self.telemetry_port))
             while True:
                 msg = self._q.get()
                 if msg is None:
                     break
-                conn.sendall((str(msg) + "\n").encode())
-            conn.close()
+                self._telemetry_conn.sendall((str(msg) + "\n").encode())
         except Exception as e:
             logger.error(f"Error in telemetry thread: {e}")
 
@@ -512,8 +512,17 @@ class RadiationModel(PhysicsModule):
         """
         try:
             self._q.put(None)
-            self._t_thread.join()
-            self.writer.Close()
+            if getattr(self, "_t_thread", None):
+                self._t_thread.join()
+            if getattr(self, "_telemetry_conn", None):
+                try:
+                    self._telemetry_conn.shutdown(socket.SHUT_RDWR)
+                except Exception:
+                    pass
+                self._telemetry_conn.close()
+                self._telemetry_conn = None
+            if getattr(self, "writer", None):
+                self.writer.Close()
             logger.info("RadiationModel finalized.")
         except Exception as e:
             logger.error(f"Error during finalization: {e}")

--- a/tests/test_radiation_thread_cleanup.py
+++ b/tests/test_radiation_thread_cleanup.py
@@ -1,0 +1,72 @@
+import sys
+import types
+import threading
+import queue
+import time
+from unittest.mock import patch
+
+# Stub optional dependencies required for import
+sys.modules.setdefault("amrex", types.ModuleType("amrex"))
+sys.modules.setdefault("adios2", types.ModuleType("adios2"))
+import h5py_stub as h5py
+sys.modules.setdefault("h5py", h5py)
+
+numba_stub = types.ModuleType("numba")
+numba_stub.njit = lambda *a, **k: (lambda f: f)
+numba_stub.prange = range
+sys.modules.setdefault("numba", numba_stub)
+
+scipy_interp = types.ModuleType("scipy.interpolate")
+scipy_interp.RegularGridInterpolator = lambda *a, **k: None
+scipy_module = types.ModuleType("scipy")
+sys.modules.setdefault("scipy", scipy_module)
+sys.modules.setdefault("scipy.interpolate", scipy_interp)
+
+from dpf2.simulation.radiation_model import RadiationModel
+
+
+class DummyWriter:
+    def __init__(self):
+        self.closed = False
+
+    def Close(self):
+        self.closed = True
+
+
+class DummySocket:
+    def __init__(self):
+        self.closed = False
+
+    def sendall(self, data):
+        pass
+
+    def shutdown(self, how):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+def test_radiation_model_thread_cleanup():
+    pre_threads = set(threading.enumerate())
+    rm = RadiationModel.__new__(RadiationModel)
+    rm._q = queue.Queue()
+    rm.telemetry_port = 0
+    rm.writer = DummyWriter()
+
+    dummy_sock = DummySocket()
+    with patch("dpf2.simulation.radiation_model.socket.create_connection", return_value=dummy_sock):
+        rm._t_thread = threading.Thread(target=rm._telemetry_loop)
+        rm._t_thread.daemon = True
+        rm._t_thread.start()
+        for _ in range(100):
+            if getattr(rm, "_telemetry_conn", None):
+                break
+            time.sleep(0.01)
+        rm.finalize()
+
+    post_threads = set(threading.enumerate())
+    assert pre_threads == post_threads
+    assert dummy_sock.closed
+    assert rm.writer.closed
+    assert not rm._t_thread.is_alive()


### PR DESCRIPTION
## Summary
- Close telemetry socket and ADIOS2 writer during `RadiationModel.finalize`
- Guarantee `AsyncHybridController` invokes module finalization
- Add test asserting no leftover threads after radiation teardown

## Testing
- `pytest tests/test_radiation_thread_cleanup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae12b2e344832a87d10c8062ac8e28