### PR TITLE
feat: add dynamic circuit-plasma coupling

### DIFF
--- a/src/dpf2/circuit_solver.py
+++ b/src/dpf2/circuit_solver.py
@@ -20,6 +20,7 @@ from scipy.integrate import solve_ivp
 from .circuit_config import CircuitConfig
 from .core.circuit import RLCCircuitSolver
 from .core.bases import PlasmaSolverBase
+from .geometry.inductance import loop_mutual_inductance
 
 __all__ = ["CircuitSolver", "RLCCircuit", "run_circuit_simulation"]
 
@@ -215,7 +216,16 @@ def run_circuit_simulation(
         voltage = circuit.voltages[-1]
         plasma_solver.step(plasma_state, 0.0, current, voltage)
         for _ in range(1, num_points):
-            feedback = {"Lp": plasma_solver.inductance, "emf": plasma_solver.back_emf}
+            feedback = plasma_solver.coupling_interface()
+            # Compute mutual inductance based on the instantaneous plasma radius
+            if hasattr(plasma_solver, "radius"):
+                M = loop_mutual_inductance(
+                    getattr(plasma_solver, "radius"),
+                    getattr(plasma_solver, "radius"),
+                    0.0,
+                )
+                feedback["M"] = M
+                feedback.setdefault("dIm_dt", 0.0)
             current, voltage = circuit.step(current, 0.0, dt, feedback)
             plasma_solver.step(plasma_state, dt, current, voltage)
 

--- a/src/dpf2/core/bases.py
+++ b/src/dpf2/core/bases.py
@@ -27,6 +27,18 @@ class PlasmaSolverBase(ABC):
         """
         raise NotImplementedError
 
+    # ------------------------------------------------------------------
+    def coupling_interface(self) -> dict[str, float]:
+        """Return circuit coupling terms for the current plasma state.
+
+        The mapping should contain at least the plasma inductance ``Lp`` in
+        Henries and the induced electromotive force ``emf`` in Volts.  Plasma
+        solvers that do not actively couple to the circuit may rely on this
+        default implementation which returns zero for both quantities.
+        """
+
+        return {"Lp": 0.0, "emf": 0.0}
+
 
 class CircuitSolverBase(ABC):
     """Interface for external circuit solvers."""

--- a/src/dpf2/geometry/__init__.py
+++ b/src/dpf2/geometry/__init__.py
@@ -1,0 +1,5 @@
+"""Geometry utilities for DPF simulations."""
+
+from .inductance import coaxial_inductance, loop_mutual_inductance
+
+__all__ = ["coaxial_inductance", "loop_mutual_inductance"]

--- a/src/dpf2/geometry/inductance.py
+++ b/src/dpf2/geometry/inductance.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Inductance calculations based on simple Biot–Savart integrations."""
+
+import math
+
+MU0 = 4e-7 * math.pi
+
+
+def coaxial_inductance(inner_radius: float, outer_radius: float, length: float, *, n: int = 1000) -> float:
+    """Return inductance of a straight coaxial plasma column."""
+
+    dr = (outer_radius - inner_radius) / max(n - 1, 1)
+    flux = 0.0
+    r = inner_radius
+    for _ in range(n):
+        B = MU0 / (2 * math.pi * r)
+        flux += B * dr
+        r += dr
+    return flux * length
+
+
+def loop_mutual_inductance(r1: float, r2: float, separation: float) -> float:
+    """Approximate mutual inductance between two coaxial circular loops.
+
+    Parameters
+    ----------
+    r1, r2:
+        Radii of the two loops in metres.
+    separation:
+        Axial separation between the loop centres in metres.
+    """
+
+    return MU0 * math.pi * r1 ** 2 * r2 ** 2 / (2 * (r1 ** 2 + separation ** 2) ** 1.5)
+
+
+__all__ = ["coaxial_inductance", "loop_mutual_inductance"]

--- a/src/dpf2/physics/simple_plasma.py
+++ b/src/dpf2/physics/simple_plasma.py
@@ -44,6 +44,12 @@ class ZeroDPlasma(PlasmaSolverBase):
         return state
 
     # ------------------------------------------------------------------
+    def coupling_interface(self) -> dict[str, float]:  # pragma: no cover - simple
+        """Expose the latest circuit coupling terms."""
+
+        return dict(self.circuit_feedback)
+
+    # ------------------------------------------------------------------
     # Radiation coupling
     # ------------------------------------------------------------------
     def apply_radiation(

--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -1,4 +1,3 @@
-"""Core driver for minimal DPF simulations."""
 from __future__ import annotations
 
 import json
@@ -10,7 +9,8 @@ import numpy as np
 from .dpf_config import DPFConfig
 from .circuit_config import CircuitConfig
 
-from .circuit_solver import RLCCircuit, CircuitSolver
+from .circuit_solver import RLCCircuit, CircuitSolver, run_circuit_simulation
+from .core.bases import PlasmaSolverBase
 from .pinch_models import (
     AnalyticPinchModel,
     SemiAnalyticPinchModel,
@@ -61,10 +61,33 @@ class SimulationEngine:
         return CircuitSolver(circuit)
 
     # ------------------------------------------------------------------
-    def run(self, method: str = "analytical", pinch_model: str = "analytic") -> SimulationResults:
+    def run(
+        self,
+        method: str = "analytical",
+        pinch_model: str = "analytic",
+        plasma_solver: PlasmaSolverBase | None = None,
+    ) -> SimulationResults:
         sc = self.config.simulation_control
         dt = sc.min_dt or 1e-9
         t_end = sc.time_end - sc.time_start
+
+        if plasma_solver is not None:
+            cc: CircuitConfig = self.config.circuit_config
+            num = int(t_end / dt) + 1
+            t, current, _, _, _ = run_circuit_simulation(
+                cc, t_end * 1e6, num_points=num, plasma_solver=plasma_solver, plasma_state=None
+            )
+            zeros = np.zeros_like(t)
+            return SimulationResults(
+                time=t,
+                current=current,
+                radius=zeros,
+                temperature=zeros,
+                pressure=zeros,
+                neutron_yield=0.0,
+                axial_position=None,
+            )
+
         circuit = self._setup_circuit()
         t, current = circuit.solve(t_end, dt, method=method)
 

--- a/tests/core/test_inductance_profile.py
+++ b/tests/core/test_inductance_profile.py
@@ -1,0 +1,50 @@
+import math
+
+from dpf2.core.circuit import RLCCircuitSolver
+from dpf2.core.bases import PlasmaSolverBase
+from dpf2.geometry.inductance import coaxial_inductance
+
+
+class AnalyticPlasma(PlasmaSolverBase):
+    def __init__(self, r0=0.01, drdt=-1.0, outer=0.02, length=0.1):
+        self.time = 0.0
+        self.radius = r0
+        self.r0 = r0
+        self.drdt = drdt
+        self.outer = outer
+        self.length = length
+        self.history: list[tuple[float, float]] = []
+
+    def step(self, state, dt, current, voltage):
+        self.time += dt
+        self.radius = self.r0 + self.drdt * self.time
+        return state
+
+    def coupling_interface(self):
+        Lp = coaxial_inductance(self.radius, self.outer, self.length)
+        self.history.append((self.time, Lp))
+        return {"Lp": Lp, "emf": 0.0}
+
+
+def test_inductance_profile_recovery():
+    plasma = AnalyticPlasma()
+    circuit = RLCCircuitSolver(L_ext=1.0, R_ext=0.0, C_ext=1.0, V0=1.0)
+    steps = 20
+    dt = 1e-6 / (steps - 1)
+
+    current = circuit.currents[-1]
+    voltage = circuit.voltages[-1]
+    plasma.step(None, 0.0, current, voltage)
+    for _ in range(1, steps):
+        feedback = plasma.coupling_interface()
+        current, voltage = circuit.step(current, 0.0, dt, feedback)
+        plasma.step(None, dt, current, voltage)
+
+    times = [t for t, _ in plasma.history]
+    Lp_vals = [Lp for _, Lp in plasma.history]
+    expected = [
+        coaxial_inductance(plasma.r0 + plasma.drdt * t, plasma.outer, plasma.length)
+        for t in times
+    ]
+    for a, b in zip(Lp_vals, expected):
+        assert math.isclose(a, b, rel_tol=1e-6)


### PR DESCRIPTION
## Summary
- expose `coupling_interface` on `PlasmaSolverBase` to supply plasma inductance and EMF
- compute geometry-based inductances via new `geometry.inductance` module
- enable bidirectional coupling in circuit solver and simulation engine
- cover dynamic inductance feedback with analytic test

## Testing
- `pytest tests/core/test_circuit_coupling.py::test_energy_conservation tests/core/test_inductance_profile.py::test_inductance_profile_recovery -q`

------
https://chatgpt.com/codex/tasks/task_e_68ae16c4c8a0832a928fd53ecb18bf52