### PR TITLE
Add validation CLI and reproducibility script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,6 @@ jobs:
         run: mypy .
       - name: Test
         run: pytest
+      - name: Validation benchmark
+        run: python -m dpf2.cli.validate --config examples/config.json --dataset PF1000
 

--- a/scripts/reproduce_published.py
+++ b/scripts/reproduce_published.py
@@ -1,0 +1,43 @@
+"""Reproduce published device benchmarks using bundled data.
+
+This helper script loads a DPF configuration, runs the
+:class:`~dpf2.simulation_engine.SimulationEngine`, and overlays the
+resulting observables with experimental traces. Validation scores are
+printed to standard output.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from dpf2.cli.validate import run_validation
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        required=True,
+        help="Path to DPF configuration file",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default="PF1000",
+        help="Dataset identifier (default: PF1000)",
+    )
+    parser.add_argument(
+        "--outdir",
+        type=Path,
+        default=Path("validation"),
+        help="Directory to store overlay plots",
+    )
+    args = parser.parse_args()
+    run_validation(args.config, args.dataset, outdir=args.outdir)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/src/dpf2/cli/__init__.py
+++ b/src/dpf2/cli/__init__.py
@@ -1,1 +1,1 @@
-from .main import main
+"""Command line interfaces for DPF2."""

--- a/src/dpf2/cli/validate.py
+++ b/src/dpf2/cli/validate.py
@@ -1,0 +1,195 @@
+"""Validation command line interface for DPF2.
+
+This module provides a small entry point to run a simulation and compare
+its output against simple experimental traces using the
+``ValidationSuite`` configuration. It is intentionally lightweight and
+only supports the minimal data used in the tests and CI workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from ..dpf_config import DPFConfig
+from ..simulation_engine import SimulationEngine, SimulationResults
+from ..validation_suite import ValidationSuite
+
+
+# ---------------------------------------------------------------------------
+# Data handling helpers
+
+def _build_validation_suite(dataset: str) -> ValidationSuite:
+    """Create a :class:`ValidationSuite` for the bundled example data.
+
+    Parameters
+    ----------
+    dataset:
+        Identifier of the dataset. Currently only ``"PF1000"`` is
+        supported and is mapped to the CSV files in the top level
+        ``Validation`` directory.
+    """
+    root = Path(__file__).resolve().parents[3]
+    data_dir = root / "Validation"
+    return ValidationSuite(
+        experiment_device_id=dataset,
+        experiment_campaign_id="demo",
+        dataset_directory=data_dir,
+        dataset_format="csv",
+        observable_file_map={"I(t)": Path("current_profile.csv")},
+        observable_format_spec={
+            "I(t)": {"time": "time_us", "value": "current_kA"}
+        },
+        observable_tolerances={"I(t)": 0.1},
+    )
+
+
+def _load_experimental(vsuite: ValidationSuite) -> Dict[str, Tuple[np.ndarray, np.ndarray]]:
+    """Load experimental observables from disk."""
+    data: Dict[str, Tuple[np.ndarray, np.ndarray]] = {}
+    for name, rel in vsuite.observable_file_map.items():
+        path = vsuite.dataset_directory / rel
+        arr = np.genfromtxt(path, delimiter=",", names=True)
+        spec = vsuite.observable_format_spec.get(name, {}) if vsuite.observable_format_spec else {}
+        t_col = spec.get("time", arr.dtype.names[0])
+        v_col = spec.get("value", arr.dtype.names[1])
+        data[name] = (arr[t_col], arr[v_col])
+    return data
+
+
+def _simulation_observables(res: SimulationResults) -> Dict[str, Tuple[np.ndarray, np.ndarray]]:
+    """Extract observables from the simulation results."""
+    return {"I(t)": (res.time * 1e6, res.current / 1e3)}
+
+
+def _score_observable(
+    sim: Tuple[np.ndarray, np.ndarray],
+    exp: Tuple[np.ndarray, np.ndarray],
+    tolerance: float,
+) -> float:
+    """Compute a simple normalized RMSE score for a single observable."""
+    exp_t, exp_v = exp
+    sim_t, sim_v = sim
+    sim_interp = np.interp(exp_t, sim_t, sim_v)
+    rmse = float(np.sqrt(np.mean((sim_interp - exp_v) ** 2)))
+    norm = np.max(np.abs(exp_v)) or 1.0
+    return max(0.0, 1.0 - rmse / (norm * tolerance))
+
+
+def _compute_scores(
+    res: SimulationResults,
+    vsuite: ValidationSuite,
+    exp: Dict[str, Tuple[np.ndarray, np.ndarray]],
+) -> Tuple[Dict[str, float], float, bool]:
+    """Calculate per-observable and aggregate scores."""
+    sim = _simulation_observables(res)
+    scores: Dict[str, float] = {}
+    for obs in vsuite.validation_targets:
+        if obs not in exp or obs not in sim:
+            continue
+        tol = vsuite.observable_tolerances.get(obs, 1.0)
+        scores[obs] = _score_observable(sim[obs], exp[obs], tol)
+    weights = vsuite.observable_weighting or {k: 1.0 for k in scores}
+    total = sum(weights.values()) or 1.0
+    overall = (
+        sum(scores.get(k, 0.0) * weights.get(k, 0.0) for k in scores) / total
+    )
+    passed = overall >= vsuite.score_pass_threshold
+    return scores, overall, passed
+
+
+def _plot_overlays(
+    res: SimulationResults,
+    exp: Dict[str, Tuple[np.ndarray, np.ndarray]],
+    output_dir: Path,
+) -> None:
+    """Generate overlay plots of simulation vs. experiment."""
+    sim = _simulation_observables(res)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for name, (t_exp, v_exp) in exp.items():
+        if name not in sim:
+            continue
+        t_sim, v_sim = sim[name]
+        plt.figure()
+        plt.plot(t_exp, v_exp, label="experiment")
+        plt.plot(t_sim, v_sim, label="simulation")
+        plt.xlabel("time [us]")
+        plt.title(name)
+        plt.legend()
+        plt.tight_layout()
+        plt.savefig(output_dir / f"{name.replace('/', '_')}_overlay.png")
+        plt.close()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+
+def run_validation(config: Path, dataset: str, *, outdir: Path = Path("validation")) -> bool:
+    """Execute a simulation and validate against experimental data.
+
+    Parameters
+    ----------
+    config:
+        Path to a JSON/YAML :class:`DPFConfig` file.
+    dataset:
+        Identifier of the experimental dataset to use.
+    outdir:
+        Directory where overlay plots will be written.
+
+    Returns
+    -------
+    bool
+        ``True`` if the validation passed according to the
+        :class:`ValidationSuite` specification.
+    """
+    cfg = DPFConfig.from_file(config)
+    engine = SimulationEngine(cfg)
+    results = engine.run()
+
+    vsuite = _build_validation_suite(dataset)
+    exp = _load_experimental(vsuite)
+    scores, overall, passed = _compute_scores(results, vsuite, exp)
+    _plot_overlays(results, exp, outdir)
+
+    for name, score in scores.items():
+        print(f"{name}: {score:.3f}")
+        
+    print(f"Overall score: {overall:.3f}")
+    print("Validation passed" if passed else "Validation failed")
+    return passed
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate simulation against experimental data"
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        required=True,
+        help="Path to DPF configuration file",
+    )
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        required=True,
+        help="Dataset identifier (e.g. PF1000)",
+    )
+    parser.add_argument(
+        "--outdir",
+        type=Path,
+        default=Path("validation"),
+        help="Directory to store overlay plots",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    run_validation(args.config, args.dataset, outdir=args.outdir)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/reproduce_published.py` script for reproducing published benchmarks
- introduce `dpf2.cli.validate` to run simulations and compute validation scores
- run lightweight validation benchmark in CI

## Testing
- `ruff check .` *(fails: many style issues)*
- `flake8 .` *(fails: command not found, installation error)*
- `mypy .` *(fails: Unterminated triple-quoted string literal in src/dpf2/simulation/eos.py)*
- `pytest` *(fails: multiple import errors due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16ca4678832a9c5eb7ba6c9e5089