### PR TITLE
Add Monte Carlo variability sampling and ensemble statistics

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -24,3 +24,38 @@ repository. Benchmark definitions and expected diagnostic outputs are stored in
 To update or add a benchmark, edit or create the JSON files in
 `tests/benchmarks` and ensure the expected outputs match the new results. Commit
 these baseline files together with any code changes.
+
+## Uncertainty Propagation
+
+The validation workflow now supports Monte-Carlo exploration of experimental
+uncertainties. The `ExperimentalVariabilityModel` describes jitter in capacitor
+voltage, fill pressure, and geometric tolerances. The helper class
+`MonteCarloVariability` draws random realizations of these quantities and feeds
+them to the `SimulationEngine`. Statistics for current, pressure and neutron
+yield are aggregated (mean and standard deviation) across the ensemble.
+
+```python
+from dpf2.dpf_config import DPFConfig
+from dpf2.experimental_variability import ExperimentalVariabilityModel, MonteCarloVariability
+from dpf2.simulation_engine import SimulationEngine
+
+cfg = DPFConfig.with_defaults()
+var_cfg = ExperimentalVariabilityModel.with_defaults().model_copy(update={
+    "pressure_jitter_pct": 5,
+    "per_field_distribution_params": {
+        "capacitor_voltage": {"jitter_pct": 2.0},
+        "cathode_gap_degrees": {"jitter_pct": 1.0},
+    },
+    "stochastic_run_id": 42,
+})
+variability = MonteCarloVariability(var_cfg, realizations=50)
+engine = SimulationEngine(cfg)
+ensemble = engine.run(variability=variability)
+
+# ensemble.current_mean and ensemble.current_std bound the current trace
+```
+
+When plotting diagnostics, the mean trace may be surrounded with an uncertainty
+band using the ±1σ envelope from the ensemble statistics. The same approach
+applies to neutron yield time series, providing an intuitive visualization of
+expected experimental scatter.

--- a/src/dpf2/experimental_variability.py
+++ b/src/dpf2/experimental_variability.py
@@ -221,4 +221,110 @@ class ExperimentalVariabilityModel(ConfigSectionBase):
         return values
 
 
-__all__ = ["ExperimentalVariabilityModel"]
+import numpy as np
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .dpf_config import DPFConfig
+
+
+class MonteCarloVariability:
+    """Utility for applying Monte-Carlo variations to a :class:`DPFConfig`.
+
+    The sampler draws perturbations for capacitor voltage, fill pressure and
+    selected geometric quantities using the distribution information stored in
+    :class:`ExperimentalVariabilityModel`.  The resulting configurations can be
+    fed to :class:`~dpf2.simulation_engine.SimulationEngine` to execute an
+    ensemble of runs.
+    """
+
+    def __init__(self, model: ExperimentalVariabilityModel, realizations: int) -> None:
+        self.model = model
+        self.realizations = realizations
+        self.rng = np.random.default_rng(model.stochastic_run_id)
+
+    # ------------------------------------------------------------------
+    def _distribution(self, field: str) -> tuple[str, float]:
+        """Return distribution type and relative jitter for ``field``."""
+
+        dist = (
+            self.model.per_field_distributions.get(field, self.model.distribution_model)
+            if self.model.per_field_distributions
+            else self.model.distribution_model
+        )
+        params = self.model.distribution_params or {}
+        if self.model.per_field_distribution_params and field in self.model.per_field_distribution_params:
+            params = self.model.per_field_distribution_params[field]
+
+        if field == "fill_pressure":
+            pct = self.model.pressure_jitter_pct / 100.0
+        else:
+            pct = params.get("jitter_pct", params.get("std_pct", 0.0)) / 100.0
+        return dist, pct
+
+    # ------------------------------------------------------------------
+    def _sample_scalar(self, field: str, nominal: float) -> np.ndarray:
+        dist, pct = self._distribution(field)
+        if pct == 0.0:
+            return np.full(self.realizations, nominal)
+        if dist == "uniform":
+            span = nominal * pct
+            return self.rng.uniform(nominal - span, nominal + span, self.realizations)
+        if dist == "normal":
+            sigma = nominal * pct
+            return self.rng.normal(nominal, sigma, self.realizations)
+        if dist == "lognormal":
+            sigma = pct
+            mu = np.log(nominal) - 0.5 * sigma**2
+            return self.rng.lognormal(mean=mu, sigma=sigma, size=self.realizations)
+        raise ValueError(f"Unknown distribution: {dist}")
+
+    # Public API -------------------------------------------------------
+    def sample_capacitor_voltage(self, nominal: float) -> np.ndarray:
+        return self._sample_scalar("capacitor_voltage", nominal)
+
+    def sample_fill_pressure(self, nominal: float) -> np.ndarray:
+        return self._sample_scalar("fill_pressure", nominal)
+
+    def sample_geometry_tolerances(self, geometry: Dict[str, float]) -> List[Dict[str, float]]:
+        samples: List[Dict[str, float]] = []
+        for _ in range(self.realizations):
+            g_sample: Dict[str, float] = {}
+            for name, value in geometry.items():
+                g_sample[name] = self._sample_scalar(name, value)[0]
+            samples.append(g_sample)
+        return samples
+
+    def generate_configurations(self, base_config: "DPFConfig") -> List["DPFConfig"]:
+        from .dpf_config import DPFConfig  # Local import to avoid circular ref
+
+        voltage_samples = self.sample_capacitor_voltage(base_config.circuit_config.V0)
+        pressure_samples = self.sample_fill_pressure(
+            base_config.initial_conditions.paschen_model.gas_pressure_torr
+        )
+        geom_samples = self.sample_geometry_tolerances(
+            {"cathode_gap_degrees": base_config.electrode_geometry.cathode_gap_degrees}
+        )
+
+        configs: List[DPFConfig] = []
+        for i in range(self.realizations):
+            cfg = base_config.model_copy(deep=True)
+            cfg = cfg.model_copy(
+                update={
+                    "circuit_config": cfg.circuit_config.model_copy(update={"V0": voltage_samples[i]}),
+                    "initial_conditions": cfg.initial_conditions.model_copy(
+                        update={
+                            "paschen_model": cfg.initial_conditions.paschen_model.model_copy(
+                                update={"gas_pressure_torr": pressure_samples[i]}
+                            )
+                        }
+                    ),
+                    "electrode_geometry": cfg.electrode_geometry.model_copy(update=geom_samples[i]),
+                }
+            )
+            configs.append(cfg)
+        return configs
+
+
+__all__ = ["ExperimentalVariabilityModel", "MonteCarloVariability"]
+

--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Dict
+from typing import Dict, List, Optional
 
 import numpy as np
 
@@ -17,8 +17,9 @@ from .pinch_models import (
     PinchModelBase,
     MHDPinchModel,
 )
+from .experimental_variability import MonteCarloVariability
 
-__all__ = ["SimulationEngine"]
+__all__ = ["SimulationEngine", "SimulationResults", "EnsembleResults"]
 
 
 @dataclass
@@ -43,6 +44,48 @@ class SimulationResults:
         }
 
 
+@dataclass
+class EnsembleResults:
+    """Statistics aggregated from multiple realizations."""
+
+    time: np.ndarray
+    current_mean: np.ndarray
+    current_std: np.ndarray
+    radius_mean: np.ndarray
+    radius_std: np.ndarray
+    temperature_mean: np.ndarray
+    temperature_std: np.ndarray
+    pressure_mean: np.ndarray
+    pressure_std: np.ndarray
+    neutron_yield_mean: float
+    neutron_yield_std: float
+    axial_position_mean: Optional[np.ndarray] | None = None
+    axial_position_std: Optional[np.ndarray] | None = None
+
+    def to_dict(self) -> Dict[str, object]:
+        data: Dict[str, object] = {
+            "time": self.time.tolist(),
+            "current_mean": self.current_mean.tolist(),
+            "current_std": self.current_std.tolist(),
+            "pinch_radius_mean": self.radius_mean.tolist(),
+            "pinch_radius_std": self.radius_std.tolist(),
+            "temperature_mean": self.temperature_mean.tolist(),
+            "temperature_std": self.temperature_std.tolist(),
+            "pressure_mean": self.pressure_mean.tolist(),
+            "pressure_std": self.pressure_std.tolist(),
+            "neutron_yield_mean": self.neutron_yield_mean,
+            "neutron_yield_std": self.neutron_yield_std,
+        }
+        if self.axial_position_mean is not None and self.axial_position_std is not None:
+            data.update(
+                {
+                    "axial_position_mean": self.axial_position_mean.tolist(),
+                    "axial_position_std": self.axial_position_std.tolist(),
+                }
+            )
+        return data
+
+
 class SimulationEngine:
     """Execute a minimal Dense Plasma Focus simulation."""
 
@@ -61,31 +104,76 @@ class SimulationEngine:
         return CircuitSolver(circuit)
 
     # ------------------------------------------------------------------
-    def run(self, method: str = "analytical", pinch_model: str = "analytic") -> SimulationResults:
-        sc = self.config.simulation_control
-        dt = sc.min_dt or 1e-9
-        t_end = sc.time_end - sc.time_start
-        circuit = self._setup_circuit()
-        t, current = circuit.solve(t_end, dt, method=method)
+    def run(
+        self,
+        method: str = "analytical",
+        pinch_model: str = "analytic",
+        variability: Optional[MonteCarloVariability] = None,
+    ) -> SimulationResults | EnsembleResults:
+        if variability is None:
+            sc = self.config.simulation_control
+            dt = sc.min_dt or 1e-9
+            t_end = sc.time_end - sc.time_start
+            circuit = self._setup_circuit()
+            t, current = circuit.solve(t_end, dt, method=method)
 
-        if pinch_model == "analytic":
-            plasma: PinchModelBase = AnalyticPinchModel()
-        elif pinch_model == "semi-analytic":
-            plasma = SemiAnalyticPinchModel()
-        elif pinch_model == "mhd":
-            plasma = MHDPinchModel()
-        else:
-            raise ValueError(
-                "pinch_model must be 'analytic', 'semi-analytic', or 'mhd'"
+            if pinch_model == "analytic":
+                plasma: PinchModelBase = AnalyticPinchModel()
+            elif pinch_model == "semi-analytic":
+                plasma = SemiAnalyticPinchModel()
+            elif pinch_model == "mhd":
+                plasma = MHDPinchModel()
+            else:
+                raise ValueError(
+                    "pinch_model must be 'analytic', 'semi-analytic', or 'mhd'",
+                )
+            pres = plasma.run(t, current)
+
+            return SimulationResults(
+                time=pres.time,
+                current=current,
+                radius=pres.radius,
+                temperature=pres.temperature,
+                pressure=pres.pressure,
+                neutron_yield=pres.neutron_yield,
+                axial_position=pres.axial_position,
             )
-        pres = plasma.run(t, current)
 
-        return SimulationResults(
-            time=pres.time,
-            current=current,
-            radius=pres.radius,
-            temperature=pres.temperature,
-            pressure=pres.pressure,
-            neutron_yield=pres.neutron_yield,
-            axial_position=pres.axial_position,
+        configs = variability.generate_configurations(self.config)
+        results: List[SimulationResults] = []
+        for cfg in configs:
+            engine = SimulationEngine(cfg)
+            results.append(engine.run(method=method, pinch_model=pinch_model))
+
+        time = results[0].time
+        stack = lambda attr: np.vstack([getattr(r, attr) for r in results])
+        current = stack("current")
+        radius = stack("radius")
+        temp = stack("temperature")
+        pres = stack("pressure")
+
+        axial_mean: Optional[np.ndarray] = None
+        axial_std: Optional[np.ndarray] = None
+        if all(r.axial_position is not None for r in results):
+            ax = stack("axial_position")
+            axial_mean = ax.mean(axis=0)
+            axial_std = ax.std(axis=0)
+
+        yields = np.array([r.neutron_yield for r in results])
+
+        return EnsembleResults(
+            time=time,
+            current_mean=current.mean(axis=0),
+            current_std=current.std(axis=0),
+            radius_mean=radius.mean(axis=0),
+            radius_std=radius.std(axis=0),
+            temperature_mean=temp.mean(axis=0),
+            temperature_std=temp.std(axis=0),
+            pressure_mean=pres.mean(axis=0),
+            pressure_std=pres.std(axis=0),
+            neutron_yield_mean=float(yields.mean()),
+            neutron_yield_std=float(yields.std()),
+            axial_position_mean=axial_mean,
+            axial_position_std=axial_std,
         )
+

--- a/src/dpf2/validation_suite.py
+++ b/src/dpf2/validation_suite.py
@@ -66,6 +66,9 @@ class ValidationSuite(ConfigSectionBase):
     observable_uncertainties: Optional[Dict[str, float]] = Field(
         None, alias="observableUncertainties"
     )
+    observable_uncertainty_ranges: Optional[Dict[str, Tuple[float, float]]] = Field(
+        None, alias="observableUncertaintyRanges"
+    )
 
     # Validation target configuration
     validation_targets: List[str] = Field(
@@ -183,13 +186,26 @@ class ValidationSuite(ConfigSectionBase):
         update: Dict[str, Any] = {}
         if values.observable_weighting:
             update["observable_weighting"] = norm_weights
-        if values.observable_uncertainties and values.validation_score_model == "weighted":
+
+        # Combine uncertainties from ranges and scalars ----------------
+        uncertainties = dict(values.observable_uncertainties or {})
+        if values.observable_uncertainty_ranges:
+            for obs, rng in values.observable_uncertainty_ranges.items():
+                if len(rng) != 2:
+                    raise ValueError("uncertainty ranges must have two entries")
+                lo, hi = rng
+                if lo > hi:
+                    raise ValueError("uncertainty range lower bound must be <= upper bound")
+                uncertainties[obs] = (hi - lo) / 2.0
+
+        if uncertainties and values.validation_score_model == "weighted":
             score = 1.0
             for t in values.validation_targets:
-                u = values.observable_uncertainties.get(t, 0.0) if values.observable_uncertainties else 0.0
+                u = uncertainties.get(t, 0.0)
                 w = norm_weights.get(t, 0.0)
                 score -= u * w
             update["computed_validation_score"] = score
+            update["observable_uncertainties"] = uncertainties
         score = update.get("computed_validation_score", values.computed_validation_score)
         if score is not None:
             update["validation_passed"] = score >= values.score_pass_threshold

--- a/tests/test_experimental_variability.py
+++ b/tests/test_experimental_variability.py
@@ -2,6 +2,9 @@ import pytest
 from pathlib import Path
 
 from dpf2.experimental_variability import ExperimentalVariabilityModel
+from dpf2.experimental_variability import MonteCarloVariability
+from dpf2.dpf_config import DPFConfig
+import numpy as np
 
 
 def test_invalid_jitter_values():
@@ -62,3 +65,26 @@ def test_config_hash_changes_on_seed():
     cfg2 = ExperimentalVariabilityModel.model_validate(d2)
 
     assert cfg1.variability_config_hash != cfg2.variability_config_hash
+
+
+def test_monte_carlo_sampling(tmp_path):
+    base_cfg = DPFConfig.with_defaults()
+    var_cfg = ExperimentalVariabilityModel.with_defaults().model_copy(
+        update={
+            "pressure_jitter_pct": 5.0,
+            "stochastic_run_id": 123,
+            "per_field_distribution_params": {
+                "capacitor_voltage": {"jitter_pct": 1.0},
+                "cathode_gap_degrees": {"jitter_pct": 0.5},
+            },
+        }
+    )
+    sampler1 = MonteCarloVariability(var_cfg, realizations=4)
+    sampler2 = MonteCarloVariability(var_cfg, realizations=4)
+    v1 = sampler1.sample_capacitor_voltage(20e3)
+    v2 = sampler2.sample_capacitor_voltage(20e3)
+    assert np.allclose(v1, v2)
+    pressures = sampler1.sample_fill_pressure(10.0)
+    assert pressures.size == 4
+    geom = sampler1.sample_geometry_tolerances({"cathode_gap_degrees": 36.0})
+    assert len(geom) == 4 and "cathode_gap_degrees" in geom[0]

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 from dpf2.dpf_config import DPFConfig
-from dpf2.simulation_engine import SimulationEngine
+from dpf2.simulation_engine import SimulationEngine, EnsembleResults
+from dpf2.experimental_variability import ExperimentalVariabilityModel, MonteCarloVariability
 
 
 def test_engine_runs():
@@ -37,3 +38,24 @@ def test_engine_runs():
     as_dict = results.to_dict()
     for key in ["time", "current", "pinch_radius", "temperature", "pressure", "neutron_yield"]:
         assert key in as_dict
+
+
+def test_engine_ensemble_statistics():
+    cfg = DPFConfig.with_defaults()
+    cfg = cfg.model_copy(update={"simulation_control": cfg.simulation_control.model_copy(update={"time_end": 1e-6})})
+    var_cfg = ExperimentalVariabilityModel.with_defaults().model_copy(
+        update={
+            "pressure_jitter_pct": 5.0,
+            "stochastic_run_id": 1,
+            "per_field_distribution_params": {
+                "capacitor_voltage": {"jitter_pct": 1.0},
+                "cathode_gap_degrees": {"jitter_pct": 0.5},
+            },
+        }
+    )
+    variability = MonteCarloVariability(var_cfg, realizations=2)
+    engine = SimulationEngine(cfg)
+    results = engine.run(variability=variability)
+    assert isinstance(results, EnsembleResults)
+    assert results.current_mean.shape == results.time.shape
+    assert results.current_std.shape == results.time.shape

--- a/tests/test_validation_suite.py
+++ b/tests/test_validation_suite.py
@@ -87,6 +87,21 @@ def test_uncertainty_and_weighting_combined_score(tmp_path: Path):
     assert cfg.validation_passed
 
 
+def test_uncertainty_range_influences_score(tmp_path: Path):
+    data = base_data(tmp_path)
+    data["observableUncertaintyRanges"] = {"I(t)": (-0.05, 0.05), "Yn": (-0.1, 0.1)}
+    data["validationScoreModel"] = "weighted"
+    cfg = ValidationSuite.model_validate(data)
+    assert cfg.computed_validation_score == pytest.approx(0.925)
+
+
+def test_invalid_uncertainty_range_raises(tmp_path: Path):
+    data = base_data(tmp_path)
+    data["observableUncertaintyRanges"] = {"I(t)": (0.1, -0.1)}
+    with pytest.raises(ValueError):
+        ValidationSuite.model_validate(data)
+
+
 def test_hash_changes_with_score_model_or_dataset(tmp_path: Path):
     data = base_data(tmp_path)
     cfg1 = ValidationSuite.model_validate(data)


### PR DESCRIPTION
## Summary
- add MonteCarloVariability for capacitor voltage, fill pressure and geometry sampling
- run ensembles in SimulationEngine with mean/std aggregation
- propagate uncertainty ranges through ValidationSuite and document workflow

## Testing
- `pytest tests/test_experimental_variability.py tests/test_simulation_engine.py tests/test_validation_suite.py` *(fails: DPFConfig model rebuild failed due to missing pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16cb7e14832a84d95873a039829a