### PR TITLE
Implement particle addition/removal for collisions

### DIFF
--- a/src/dpf2/simulation/collision_model.py
+++ b/src/dpf2/simulation/collision_model.py
@@ -278,8 +278,8 @@ class ElectronNeutralCollision(CollisionProcess):
 class IonizationProcess(CollisionProcess):
     """Ionization of neutrals by electron impact.
 
-    Particle creation is represented only by rate sampling; actual particle
-    insertion is left as a placeholder."""
+    Particle creation is represented by sampling from the ionization rate and
+    inserting new ions and electrons into the simulation state."""
     def __init__(self, ionization_energy=13.6, cross_section_file="ionization_cross_section.h5"):
         self.ionization_energy = ionization_energy * e_charge  # Convert eV to Joules
         self.cross_section_data = CrossSectionData(cross_section_file)
@@ -288,27 +288,42 @@ class IonizationProcess(CollisionProcess):
         try:
             if not hasattr(state, "species"):
                 return
-            for name, spc in state.species.items():
-                if spc['q'] < 0:  # Electrons
-                    ne = state.field_manager.ne
-                    Te = state.field_manager.Te
-                    nn = state.field_manager.nn
-                    # Use energy-dependent cross-section
-                    sigma_ion = self.cross_section_data(Te)
-                    # Ionization rate
-                    ionization_rate = ne * sigma_ion * np.sqrt(8 * kB * Te / (pi * m_e))
-                    # Create new ions and electrons
-                    num_new_ions = np.random.poisson(ionization_rate * nn * dt)
-                    # Add new particles (simplified - needs proper distribution)
-                    # ... (implementation for adding new particles) ...
+            if not hasattr(state, "field_manager"):
+                return
+            ne = state.field_manager.ne
+            Te = state.field_manager.Te
+            nn = getattr(state.field_manager, 'nn', 0.0)
+            sigma_ion = self.cross_section_data(Te)
+
+            ion_rate = ne * sigma_ion * np.sqrt(8 * kB * Te / (pi * m_e))
+
+            def _mean(val):
+                try:
+                    return float(np.mean(val))
+                except Exception:
+                    try:
+                        return float(sum(val) / len(val))
+                    except Exception:
+                        return float(val)
+
+            lam = _mean(ion_rate * nn) * dt
+            num_pairs = np.random.poisson(lam)
+            if num_pairs <= 0:
+                return
+            positions = state.sample_positions(num_pairs)
+            Te_mean = _mean(Te)
+            vel_e = state.sample_velocities(num_pairs, Te_mean, m_e)
+            vel_i = state.sample_velocities(num_pairs, Te_mean, m_p)
+            state.add_particles('e', -e_charge, m_e, positions, vel_e)
+            state.add_particles('ion', e_charge, m_p, positions, vel_i)
         except Exception as e:
             logger.error(f"Error applying ionization process: {e}")
 
 class RecombinationProcess(CollisionProcess):
     """Radiative recombination of ions and electrons.
 
-    Particle removal is not yet implemented and requires a proper selection
-    mechanism."""
+    Particle removal removes ion–electron pairs using a simple momentum
+    matching strategy to conserve charge and approximately conserve momentum."""
     def __init__(self, recombination_rate=1e-14):
         self.recombination_rate = recombination_rate
 
@@ -316,16 +331,45 @@ class RecombinationProcess(CollisionProcess):
         try:
             if not hasattr(state, "species"):
                 return
-            for name, spc in state.species.items():
-                if spc['q'] > 0:  # Ions
-                    ne = state.field_manager.ne
-                    ni = state.field_manager.ni
-                    # Recombination rate
-                    recombination_rate = self.recombination_rate * ne * ni
-                    # Remove ions and electrons
-                    num_removed_ions = np.random.poisson(recombination_rate * dt)
-                    # Remove particles (simplified - needs proper selection)
-                    # ... (implementation for removing particles) ...
+            if not hasattr(state, 'field_manager'):
+                return
+            ne = state.field_manager.ne
+            ni = getattr(state.field_manager, 'ni', ne)
+
+            def _mean(val):
+                try:
+                    return float(np.mean(val))
+                except Exception:
+                    try:
+                        return float(sum(val) / len(val))
+                    except Exception:
+                        return float(val)
+
+            lam = _mean(self.recombination_rate * ne * ni) * dt
+            num_pairs = np.random.poisson(lam)
+            # identify electron and ion species
+            e_name = next((n for n, sp in state.species.items() if sp.get('q', 0.0) < 0), None)
+            i_name = next((n for n, sp in state.species.items() if sp.get('q', 0.0) > 0), None)
+            if e_name is None or i_name is None:
+                return
+            sp_e = state.species[e_name]
+            sp_i = state.species[i_name]
+            num_pairs = min(num_pairs, sp_e['pos'].shape[0], sp_i['pos'].shape[0])
+            for _ in range(num_pairs):
+                if sp_e['pos'].shape[0] == 0 or sp_i['pos'].shape[0] == 0:
+                    break
+                if hasattr(np.random, 'randint'):
+                    idx_e = int(np.random.randint(0, sp_e['pos'].shape[0]))
+                else:
+                    idx_e = 0
+                p_e = sp_e['m'] * sp_e['vel'][idx_e]
+                ion_mom = sp_i['m'] * sp_i['vel']
+                try:
+                    idx_i = int(np.argmin(np.sum((ion_mom + p_e)**2, axis=1)))
+                except Exception:
+                    idx_i = 0
+                state.remove_particles(e_name, [idx_e])
+                state.remove_particles(i_name, [idx_i])
         except Exception as e:
             logger.error(f"Error applying recombination process: {e}")
 

--- a/src/dpf2/simulation/utils.py
+++ b/src/dpf2/simulation/utils.py
@@ -1,4 +1,6 @@
 # utils.py
+from __future__ import annotations
+
 import numpy as np
 from typing import Dict, Any, Optional, Tuple
 import logging
@@ -464,3 +466,98 @@ class SimulationState:
     def __repr__(self):
         """Returns a string representation of the SimulationState."""
         return self.__str__()
+
+    # ------------------------------------------------------------------
+    # Particle helper routines
+    # ------------------------------------------------------------------
+    def _ensure_species(self):
+        """Ensure the ``species`` dictionary exists."""
+        if not hasattr(self, "species"):
+            self.species = {}
+
+    def add_particles(self, name: str, q: float, m: float,
+                      pos: np.ndarray, vel: np.ndarray):
+        """Safely add particles to the state.
+
+        If ``name`` already exists, the particle arrays are appended.  The
+        charge and mass are only set when the species is first created.
+        """
+        self._ensure_species()
+        try:
+            pos = np.array(pos)
+            if len(getattr(pos, 'shape', ())) == 1:
+                pos = np.array([pos])
+        except Exception:
+            pass
+        try:
+            vel = np.array(vel)
+            if len(getattr(vel, 'shape', ())) == 1:
+                vel = np.array([vel])
+        except Exception:
+            pass
+        if name in self.species:
+            sp = self.species[name]
+            sp['pos'] = np.vstack([sp.get('pos', np.zeros((0, 3))), pos])
+            sp['vel'] = np.vstack([sp.get('vel', np.zeros((0, 3))), vel])
+            sp.setdefault('q', q)
+            sp.setdefault('m', m)
+        else:
+            self.species[name] = {'q': q, 'm': m,
+                                  'pos': pos.copy(), 'vel': vel.copy()}
+
+    def remove_particles(self, name: str, indices):
+        """Remove particles specified by ``indices`` from ``name`` species."""
+        self._ensure_species()
+        sp = self.species.get(name)
+        if sp is None or 'pos' not in sp:
+            return
+        if isinstance(indices, (list, tuple)):
+            idx = [int(i) for i in indices]
+        else:
+            idx = [int(indices)]
+        if not idx:
+            return
+        mask = [True] * len(sp['pos'])
+        for i in idx:
+            if 0 <= i < len(mask):
+                mask[i] = False
+        sp['pos'] = np.array([p for m, p in zip(mask, sp['pos']) if m])
+        sp['vel'] = np.array([v for m, v in zip(mask, sp['vel']) if m])
+
+    # --- Sampling utilities -------------------------------------------------
+    kB = 1.380649e-23  # Boltzmann constant [J/K]
+
+    def sample_positions(self, n: int) -> np.ndarray:
+        """Sample ``n`` positions uniformly in the simulation domain."""
+        self._ensure_species()
+        rand = getattr(np.random, 'random', None) or getattr(np.random, 'rand', None)
+        if rand is None:
+            return np.zeros((n, 3))
+        try:
+            x = rand(n)
+            y = rand(n)
+            z = rand(n)
+        except TypeError:
+            x = rand(size=n)
+            y = rand(size=n)
+            z = rand(size=n)
+        Lx = self.grid_shape[0] * self.dx
+        Ly = self.grid_shape[1] * self.dy
+        Lz = self.grid_shape[2] * self.dz
+        x0, y0, z0 = self.domain_lo
+        pts = [
+            (x0 + x[i] * Lx, y0 + y[i] * Ly, z0 + z[i] * Lz)
+            for i in range(n)
+        ]
+        return np.array(pts)
+
+    def sample_velocities(self, n: int, temperature: float, mass: float) -> np.ndarray:
+        """Sample Maxwellian velocities for ``temperature`` and ``mass``."""
+        normal = getattr(np.random, 'normal', None)
+        if normal is None:
+            return np.zeros((n, 3))
+        vth = np.sqrt(self.kB * float(temperature) / mass)
+        try:
+            return normal(0.0, vth, size=(n, 3))
+        except TypeError:
+            return normal(size=(n, 3)) * vth

--- a/tests/test_number_density_changes.py
+++ b/tests/test_number_density_changes.py
@@ -1,0 +1,75 @@
+import numpy as np
+import types
+import sys
+
+
+class DummyFieldManager:
+    def __init__(self, ne, Te, nn, ni):
+        self.ne = ne
+        self.Te = Te
+        self.nn = nn
+        self.ni = ni
+
+    def get_J(self):
+        return np.zeros((3,))
+
+
+class DeterministicRandom:
+    def poisson(self, lam):
+        try:
+            _ = len(lam)  # array-like
+            return np.zeros_like(lam, dtype=int) + 1
+        except Exception:
+            return 1
+
+    def normal(self, loc=0.0, scale=1.0, size=None):
+        return np.zeros(size)
+
+    def random(self, size=None):
+        return np.zeros(size)
+
+    def randint(self, low, high=None):
+        return 0
+
+
+def test_number_density_changes_over_time(monkeypatch):
+    # Stub heavy dependencies before import
+    monkeypatch.setitem(sys.modules, "h5py", types.SimpleNamespace(File=lambda *a, **k: (_ for _ in ()).throw(OSError())))
+    scipy_interp = types.SimpleNamespace(
+        interp1d=lambda *a, **k: (lambda x: np.zeros_like(x)),
+        RegularGridInterpolator=lambda *a, **k: (lambda x: np.zeros(1)),
+    )
+    monkeypatch.setitem(sys.modules, "scipy", types.SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "scipy.interpolate", scipy_interp)
+    numba_stub = types.SimpleNamespace(
+        njit=lambda f=None, *a, **k: (lambda *args, **kwargs: f(*args, **kwargs) if f else None),
+        prange=range,
+        cuda=types.SimpleNamespace(),
+    )
+    monkeypatch.setitem(sys.modules, "numba", numba_stub)
+
+    from dpf2.simulation.collision_model import IonizationProcess, RecombinationProcess, e_charge, m_e, m_p
+    from dpf2.simulation.utils import SimulationState
+
+    dr = DeterministicRandom()
+    monkeypatch.setattr(np, "random", dr, raising=False)
+
+    fm = DummyFieldManager(ne=1e18, Te=1e3, nn=1e20, ni=1e18)
+    state = SimulationState((1, 1, 1), 1.0, 1.0, 1.0, (0.0, 0.0, 0.0), {})
+    state.field_manager = fm
+    state.species = {
+        "e": {"q": -e_charge, "m": m_e, "pos": np.zeros((0, 3)), "vel": np.zeros((0, 3))},
+        "ion": {"q": e_charge, "m": m_p, "pos": np.zeros((0, 3)), "vel": np.zeros((0, 3))},
+    }
+
+    ion = IonizationProcess()
+    ion.cross_section_data = lambda T: 1e-20
+    for _ in range(2):
+        ion.apply(state, 1.0)
+    assert state.species["e"]["pos"].shape[0] == 2
+    assert state.species["ion"]["pos"].shape[0] == 2
+
+    rec = RecombinationProcess(recombination_rate=1e-20)
+    rec.apply(state, 1.0)
+    assert state.species["e"]["pos"].shape[0] == 1
+    assert state.species["ion"]["pos"].shape[0] == 1


### PR DESCRIPTION
## Summary
- add helper methods in `SimulationState` for particle management and sampling
- implement particle creation in `IonizationProcess` and pair removal in `RecombinationProcess`
- add regression test covering ionization and recombination number density evolution

## Testing
- `pytest tests/test_collision_processes.py -q`
- `pytest tests/test_collision_model_restart.py -q`
- `pytest tests/test_number_density_changes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af75844864832aa1b2eb381f59e804