### PR TITLE
feat: integrate WarpX-style PIC collision handler

### DIFF
--- a/examples/pic_collision_example.py
+++ b/examples/pic_collision_example.py
@@ -1,0 +1,70 @@
+"""Minimal example demonstrating the :class:`PICCollisionHandler` API.
+
+The real WarpX runtime is not required for this example.  Instead a very small
+mock of the WarpX particle container interface is used so the example can be
+run as a standalone script::
+
+    $ python examples/pic_collision_example.py
+
+The script prints the electron velocities before and after a Monte Carlo
+collision step with ions.
+"""
+
+from __future__ import annotations
+
+import random
+
+from dpf2.simulation.warp_piclibrary import PICCollisionHandler
+
+
+class SimpleParticleContainer:
+    """Light‑weight stand in for a WarpX particle container."""
+
+    def __init__(self, velocities, mass=1.0):
+        self._vel = [list(v) for v in velocities]
+        self.mass = mass
+
+    def get_velocities(self):
+        return [v[:] for v in self._vel]
+
+    def set_velocities(self, v):
+        self._vel = [list(val) for val in v]
+
+
+class SimpleWarpX:
+    """Minimal subset of the WarpX API required by :class:`PICCollisionHandler`."""
+
+    def __init__(self):
+        self.volume = 1.0
+        self._species = {
+            "e": SimpleParticleContainer([[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], mass=1.0),
+            "i": SimpleParticleContainer([[0.0, 1.0, 0.0], [0.0, 1.0, 0.0]], mass=1836.0),
+        }
+
+    def get_particle_container(self, name):
+        return self._species[name]
+
+
+def constant_nu(ne, Te, **kwargs):
+    """Return a constant collision frequency for demonstration."""
+
+    return 100.0
+
+
+def main() -> None:
+    warp = SimpleWarpX()
+    handler = PICCollisionHandler(constant_nu, species_pairs=[("e", "i")])
+    dt = 0.1
+
+    print("electron velocities before:")
+    print(warp.get_particle_container("e").get_velocities())
+
+    handler.apply_collisions(warp, dt)
+
+    print("electron velocities after:")
+    print(warp.get_particle_container("e").get_velocities())
+
+
+if __name__ == "__main__":  # pragma: no cover - example script
+    random.seed(1)
+    main()

--- a/src/dpf2/simulation/warp_piclibrary.py
+++ b/src/dpf2/simulation/warp_piclibrary.py
@@ -8,71 +8,123 @@ and simulation loop.
 """
 
 import logging
-from typing import Callable, Any
-import numpy as np
+import math
+import random
+from statistics import mean
+from typing import Any, Callable, Sequence, Tuple
 
-# Assuming WarpX particle data might be accessible through objects passed here,
-# or this handler interacts with the WarpX Python API directly.
-# from pywarpx import picmi # Example import if directly using WarpX API
+# ``numpy`` is an optional dependency of the project.  The unit tests in this
+# kata run without the real package, therefore the implementation below relies
+# only on the Python standard library.  If ``numpy`` is available it can still
+# be used transparently as the container objects returned by WarpX often expose
+# list-like interfaces.
+try:  # pragma: no cover - optional dependency
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - fallback when numpy is absent
+    np = None  # type: ignore
+
+# We only import pywarpx lazily.  The real package is optional for the test
+# environment and is not required for the light-weight mocks used here.  If it
+# is available the handler will attempt to use the native MCC collision
+# routines instead of the simplified Python implementation below.
+try:  # pragma: no cover - optional dependency
+    from pywarpx import picmi  # type: ignore
+except Exception:  # pragma: no cover - the tests run without pywarpx installed
+    picmi = None
 
 logger = logging.getLogger(__name__)
 
 class PICCollisionHandler:
-    """
-    Handles the application of collision processes within the WarpX PIC solver.
+    """High level interface for Monte Carlo collisions in WarpX.
 
-    This class acts as an interface. Its methods would typically be called
-    by the main PIC solver loop (potentially within WarpXWrapper) to apply
-    collisions to WarpX particle data.
-
-    The exact implementation depends on the chosen collision algorithm
-    (e.g., Monte Carlo binary collisions) and how it interacts with WarpX's
-    particle storage and parallel decomposition.
+    The handler encapsulates logic for querying particle information from a
+    WarpX simulation object and applying Monte Carlo collision steps.  If a
+    native WarpX collision routine is available (e.g., through
+    ``pywarpx``/``picmi``) it will be used; otherwise a light‑weight Python
+    implementation is executed.  The latter is sufficient for unit testing and
+    simple examples.
     """
 
-    def __init__(self, collision_freq_func: Callable, **kwargs):
-        """
-        Initializes the PIC Collision Handler.
+    def __init__(
+        self,
+        collision_freq_func: Callable,
+        species_pairs: Sequence[Tuple[str, str]] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Create a new collision handler.
 
-        Args:
-            collision_freq_func (Callable): A function that takes plasma parameters
-                                             (e.g., ne, Te, Z) and returns a
-                                             collision frequency or related quantity needed
-                                             by the collision algorithm.
-            **kwargs: Additional parameters for the collision handler.
+        Parameters
+        ----------
+        collision_freq_func:
+            Callable returning a collision frequency given plasma properties.
+            The callable must accept at least ``ne`` and ``Te`` and may accept
+            the keyword arguments ``species1`` and ``species2``.
+        species_pairs:
+            Optional sequence of pairs of species names to collide when
+            :meth:`apply_collisions` is invoked without explicit pairs.
+        **kwargs:
+            Additional keyword arguments forwarded to ``collision_freq_func``.
         """
+
         self.collision_freq_func = collision_freq_func
         self.kwargs = kwargs
-        logger.info(f"PICCollisionHandler initialized with frequency function: {collision_freq_func}")
-        # Potential initialization of internal WarpX collision objects if using built-ins
-        # Example: picmi.MCCCollision(...) or similar
+        self.species_pairs = list(species_pairs or [])
 
-    def apply_collisions(self, species1_name: str, species2_name: str, warp_instance: Any, dt: float):
-        """
-        Applies collisions between two specified species within WarpX.
-
-        This is a placeholder method. The actual implementation would involve:
-        1. Getting particle data (positions, velocities, weights) for the
-           interacting species from the warp_instance (e.g., using WarpX API).
-        2. Getting relevant field data (density, temperature) potentially
-           averaged or interpolated to particle locations or grid cells.
-        3. Calculating collision probabilities using self.collision_freq_func
-           and the time step dt.
-        4. Performing the Monte Carlo collision algorithm (e.g., pairing particles,
-           scattering velocities based on probability and cross-sections).
-        5. Updating the particle velocities in the warp_instance.
-
-        Args:
-            species1_name (str): Name of the first interacting species.
-            species2_name (str): Name of the second interacting species.
-            warp_instance (Any): The WarpX simulation object (or relevant particle container).
-            dt (float): Simulation time step.
-        """
         logger.info(
-            f"Applying collisions between {species1_name} and {species2_name} with dt={dt}"
+            "PICCollisionHandler initialized with frequency function: %s",
+            collision_freq_func,
         )
 
-        # --- Retrieve particle containers -------------------------------------------------
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def apply_collisions(
+        self,
+        warp_instance: Any,
+        dt: float,
+        species_pairs: Sequence[Tuple[str, str]] | None = None,
+    ) -> None:
+        """Apply collisions for the configured species pairs.
+
+        Parameters
+        ----------
+        warp_instance:
+            WarpX simulation object exposing particle containers.
+        dt:
+            Time step over which to apply collisions.
+        species_pairs:
+            Optional explicit list of species pairs.  When omitted the pairs
+            supplied during initialisation are used.
+        """
+
+        pairs = list(species_pairs or self.species_pairs)
+        for sp1, sp2 in pairs:
+            self._apply_pair(sp1, sp2, warp_instance, dt)
+
+    # ------------------------------------------------------------------
+    # Implementation helpers
+    # ------------------------------------------------------------------
+    def _apply_pair(
+        self, species1_name: str, species2_name: str, warp_instance: Any, dt: float
+    ) -> None:
+        """Apply one collision step between two species."""
+
+        logger.info(
+            "Applying collisions between %s and %s with dt=%s",
+            species1_name,
+            species2_name,
+            dt,
+        )
+
+        # If the WarpX object exposes its own MCC collision routine we defer to
+        # it.  This mirrors the behaviour of ``picmi.MCCCollision``.
+        if hasattr(warp_instance, "do_mcc_collisions"):
+            warp_instance.do_mcc_collisions(
+                species1_name, species2_name, dt, self.collision_freq_func, **self.kwargs
+            )
+            return
+
+        # --- Retrieve particle containers ----------------------------------------------
         if not hasattr(warp_instance, "get_particle_container"):
             raise AttributeError("WarpX instance missing 'get_particle_container'")
 
@@ -85,32 +137,26 @@ class PICCollisionHandler:
                 f"Unknown species pair ({species1_name}, {species2_name})"
             ) from exc
 
-        if not (hasattr(species1, "get_velocities") and hasattr(species2, "get_velocities")):
+        if not (
+            hasattr(species1, "get_velocities") and hasattr(species2, "get_velocities")
+        ):
             raise AttributeError("Particle containers must implement get_velocities")
 
         # Work with explicit ``float`` copies so we can safely modify the arrays
-        v1 = np.asarray(species1.get_velocities(), dtype=float)
-        v2 = np.asarray(species2.get_velocities(), dtype=float)
+        v1 = [list(v) for v in species1.get_velocities()]
+        v2 = [list(v) for v in species2.get_velocities()]
 
         # Optional: retrieve particle weights if WarpX exposes them
-        w1 = (
-            np.asarray(species1.get_weights())
-            if hasattr(species1, "get_weights")
-            else None
-        )
-        w2 = (
-            np.asarray(species2.get_weights())
-            if hasattr(species2, "get_weights")
-            else None
-        )
+        w1 = list(species1.get_weights()) if hasattr(species1, "get_weights") else None
+        w2 = list(species2.get_weights()) if hasattr(species2, "get_weights") else None
 
-        if v1.size == 0 or v2.size == 0:
+        if len(v1) == 0 or len(v2) == 0:
             logger.debug("One of the species has no particles; skipping collisions")
             return
 
-        # --- Estimate plasma parameters ---------------------------------------------------
-        n1 = int(np.sum(w1)) if w1 is not None else int(v1.shape[0])
-        n2 = int(np.sum(w2)) if w2 is not None else int(v2.shape[0])
+        # --- Estimate plasma parameters -------------------------------------------------
+        n1 = int(sum(w1)) if w1 is not None else len(v1)
+        n2 = int(sum(w2)) if w2 is not None else len(v2)
 
         volume = None
         if hasattr(warp_instance, "get_volume"):
@@ -124,49 +170,73 @@ class PICCollisionHandler:
         if volume and volume > 0.0:
             ne = max(n1, n2) / volume
         else:  # pragma: no cover - logging path
-            logger.warning("WarpX instance missing volume; using particle count for density")
+            logger.warning(
+                "WarpX instance missing volume; using particle count for density"
+            )
             ne = float(max(n1, n2))
 
         k_B = 1.380649e-23  # Boltzmann constant
         m1 = getattr(species1, "mass", 1.0)
-        speeds1 = np.linalg.norm(v1, axis=1)
-        Te = m1 * np.mean(speeds1**2) / (3.0 * k_B)
+        def norm(vec):
+            return math.sqrt(sum(comp * comp for comp in vec))
+
+        speeds1 = [norm(v) for v in v1]
+        Te = m1 * mean(s * s for s in speeds1) / (3.0 * k_B)
 
         # Collision frequency and probability
-        freq = float(self.collision_freq_func(ne, Te, **self.kwargs))
+        freq = float(
+            self.collision_freq_func(
+                ne,
+                Te,
+                species1=species1_name,
+                species2=species2_name,
+                **self.kwargs,
+            )
+        )
         if freq < 0:
             raise ValueError("Collision frequency must be non-negative")
-        prob = np.clip(1.0 - np.exp(-freq * dt), 0.0, 1.0)
+        prob = max(0.0, min(1.0, 1.0 - math.exp(-freq * dt)))
         if prob <= 0.0:
             logger.debug("Zero collision probability; skipping")
             return
 
-        # --- Determine colliding pairs ----------------------------------------------------
+        # --- Determine colliding pairs --------------------------------------------------
         num_pairs = int(min(n1, n2))
         if num_pairs == 0:
             return
-        rand = np.random.random(num_pairs)
-        colliding = np.where(rand < prob)[0]
+        rand = [random.random() for _ in range(num_pairs)]
+        colliding = [i for i, r in enumerate(rand) if r < prob]
 
-        if colliding.size:
-            def random_dirs(count: int) -> np.ndarray:
-                vec = np.random.normal(size=(count, 3))
-                norms = np.linalg.norm(vec, axis=1, keepdims=True)
-                norms[norms == 0] = 1.0
-                return vec / norms
-
+        if colliding:
             m2 = getattr(species2, "mass", 1.0)
-            dir_rel = random_dirs(colliding.size)
-            rel_v = v1[colliding] - v2[colliding]
-            rel_speed = np.linalg.norm(rel_v, axis=1)
 
-            v_cm = (m1 * v1[colliding] + m2 * v2[colliding]) / (m1 + m2)
-            new_rel = dir_rel * rel_speed[:, None]
-            v1[colliding] = v_cm + (m2 / (m1 + m2)) * new_rel
-            v2[colliding] = v_cm - (m1 / (m1 + m2)) * new_rel
+            def random_dir() -> list[float]:
+                while True:
+                    vec = [random.gauss(0.0, 1.0) for _ in range(3)]
+                    n = norm(vec)
+                    if n > 0:
+                        return [c / n for c in vec]
 
-        # --- Write updated velocities back ------------------------------------------------
-        if not hasattr(species1, "set_velocities") or not hasattr(species2, "set_velocities"):
+            for idx in colliding:
+                dir_rel = random_dir()
+                rel_v = [v1[idx][j] - v2[idx][j] for j in range(3)]
+                rel_speed = norm(rel_v)
+                v_cm = [
+                    (m1 * v1[idx][j] + m2 * v2[idx][j]) / (m1 + m2)
+                    for j in range(3)
+                ]
+                new_rel = [dir_rel[j] * rel_speed for j in range(3)]
+                v1[idx] = [
+                    v_cm[j] + (m2 / (m1 + m2)) * new_rel[j] for j in range(3)
+                ]
+                v2[idx] = [
+                    v_cm[j] - (m1 / (m1 + m2)) * new_rel[j] for j in range(3)
+                ]
+
+        # --- Write updated velocities back ----------------------------------------------
+        if not (
+            hasattr(species1, "set_velocities") and hasattr(species2, "set_velocities")
+        ):
             raise AttributeError("Particle containers must implement set_velocities")
 
         species1.set_velocities(v1)

--- a/tests/test_pic_collisions.py
+++ b/tests/test_pic_collisions.py
@@ -10,7 +10,9 @@ the collision logic without requiring a full WarpX installation.
 """
 
 
-import numpy as np
+import math
+import random
+
 import pytest
 
 module_path = Path(__file__).resolve().parent.parent / "src/dpf2/simulation/warp_piclibrary.py"
@@ -22,14 +24,14 @@ PICCollisionHandler = warp_pic.PICCollisionHandler
 
 class SimpleParticleContainer:
     def __init__(self, velocities, mass=1.0):
-        self._vel = np.array(velocities, dtype=float)
+        self._vel = [list(vec) for vec in velocities]
         self.mass = mass
 
     def get_velocities(self):
-        return self._vel.copy()
+        return [vec[:] for vec in self._vel]
 
     def set_velocities(self, v):
-        self._vel = np.array(v, dtype=float)
+        self._vel = [list(vec) for vec in v]
 
 
 class SimpleWarpX:
@@ -48,47 +50,59 @@ class SimpleWarpX:
         self.registered_ops.append((s1, s2, freq_func, kwargs))
 
 
+def _vec_sum(vs):
+    return [sum(comp) for comp in zip(*vs)]
+
+
+def _arrays_close(a, b, tol=1e-12):
+    for va, vb in zip(a, b):
+        for xa, xb in zip(va, vb):
+            if not math.isclose(xa, xb, rel_tol=1e-9, abs_tol=tol):
+                return False
+    return True
+
+
 def test_apply_collisions_scatter_velocities():
-    np.random.seed(1)
+    random.seed(1)
     warp = SimpleWarpX()
-    handler = PICCollisionHandler(lambda ne, Te, Z=1.0: 100.0)
+    handler = PICCollisionHandler(lambda ne, Te, Z=1.0, **k: 100.0, species_pairs=[("e", "i")])
 
     v_e_before = warp.get_particle_container("e").get_velocities()
     v_i_before = warp.get_particle_container("i").get_velocities()
 
-    handler.apply_collisions("e", "i", warp, dt=0.1)
+    handler.apply_collisions(warp, dt=0.1)
 
     v_e_after = warp.get_particle_container("e").get_velocities()
     v_i_after = warp.get_particle_container("i").get_velocities()
 
-    assert not np.allclose(v_e_before, v_e_after)
-    assert not np.allclose(v_i_before, v_i_after)
+    assert not _arrays_close(v_e_before, v_e_after)
+    assert not _arrays_close(v_i_before, v_i_after)
 
-    before_total = v_e_before.sum(axis=0) + v_i_before.sum(axis=0)
-    after_total = v_e_after.sum(axis=0) + v_i_after.sum(axis=0)
-    assert np.allclose(before_total, after_total)
+    before_total = [a + b for a, b in zip(_vec_sum(v_e_before), _vec_sum(v_i_before))]
+    after_total = [a + b for a, b in zip(_vec_sum(v_e_after), _vec_sum(v_i_after))]
+    assert _arrays_close([before_total], [after_total])
 
 
 def test_no_collisions_when_zero_probability():
     """Collisions should leave velocities unchanged when the rate is zero."""
-    np.random.seed(1)
+    random.seed(1)
     warp = SimpleWarpX()
-    handler = PICCollisionHandler(lambda ne, Te, Z=1.0: 0.0)
+    handler = PICCollisionHandler(lambda ne, Te, Z=1.0, **k: 0.0, species_pairs=[("e", "i")])
 
     v_e_before = warp.get_particle_container("e").get_velocities()
     v_i_before = warp.get_particle_container("i").get_velocities()
 
-    handler.apply_collisions("e", "i", warp, dt=0.1)
+    handler.apply_collisions(warp, dt=0.1)
 
-    assert np.allclose(v_e_before, warp.get_particle_container("e").get_velocities())
-    assert np.allclose(v_i_before, warp.get_particle_container("i").get_velocities())
+    assert _arrays_close(v_e_before, warp.get_particle_container("e").get_velocities())
+    assert _arrays_close(v_i_before, warp.get_particle_container("i").get_velocities())
 
 
 def test_apply_collisions_unknown_species():
     warp = SimpleWarpX()
-    handler = PICCollisionHandler(lambda ne, Te: 1.0)
+    handler = PICCollisionHandler(lambda ne, Te, **k: 1.0, species_pairs=[("e", "x")])
     with pytest.raises(ValueError):
-        handler.apply_collisions("e", "x", warp, dt=0.1)
+        handler.apply_collisions(warp, dt=0.1)
 
 
 def test_apply_collisions_missing_hook():
@@ -96,14 +110,29 @@ def test_apply_collisions_missing_hook():
         """WarpX-like object missing required collision interface."""
 
     warp = BrokenWarp()
-    handler = PICCollisionHandler(lambda ne, Te: 1.0)
+    handler = PICCollisionHandler(lambda ne, Te, **k: 1.0, species_pairs=[("e", "i")])
     with pytest.raises(AttributeError):
-        handler.apply_collisions("e", "i", warp, dt=0.1)
+        handler.apply_collisions(warp, dt=0.1)
+
+
+def test_uses_native_warp_api_when_available():
+    class NativeWarp(SimpleWarpX):
+        def __init__(self):
+            super().__init__()
+            self.called = []
+
+        def do_mcc_collisions(self, s1, s2, dt, freq, **kwargs):
+            self.called.append((s1, s2, dt))
+
+    warp = NativeWarp()
+    handler = PICCollisionHandler(lambda ne, Te, **k: 1.0, species_pairs=[("e", "i")])
+    handler.apply_collisions(warp, dt=0.1)
+    assert warp.called == [("e", "i", 0.1)]
 
 
 def test_setup_warpx_collisions_registers_ops():
     warp = SimpleWarpX()
-    freq = lambda ne, Te, Z=1.0: 1.0
+    freq = lambda ne, Te, Z=1.0, **k: 1.0
     handler = PICCollisionHandler(freq)
     handler.setup_warpx_collisions(warp, [("e", "i")])
     assert warp.registered_ops[0][0:2] == ("e", "i")


### PR DESCRIPTION
## Summary
- implement configurable Monte Carlo collision handler with species pair support
- include usage example showing electron/ion collisions
- add tests with mocked WarpX containers verifying velocity scattering and conservation

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'HallMHD' from 'dpf2.physics', ModuleNotFoundError: No module named 'werkzeug', ModuleNotFoundError: No module named 'scipy', ImportError: adios2 is required; install dpf2[warpx])* 
- `pytest tests/test_pic_collisions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7588f71c832a9bc5a9c5156510e8