### PR TITLE
Add ideal gas EOS backend and mixture parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,34 @@ result = simulation.run()
 
 Configuration files use the `DPFConfig` schema defined in this repository. See `examples/quickstart.ipynb` for a walk-through in a Jupyter notebook.
 
+### Equation of State Backends
+
+The simulator supports both tabulated and ideal–gas equations of state. The
+backend is selected via the ``eos_model`` entry in the configuration.  For a
+simple ideal gas:
+
+```json
+{
+  "physics_models": {
+    "eos_model": "ideal_gas",
+    "gamma": 1.4,
+    "mu": 2.0
+  }
+}
+```
+
+A tabulated EOS with a two–species mixture can be configured as:
+
+```json
+{
+  "physics": {
+    "eosModel": "tabulated",
+    "eosTablePath": "tests/data/sesame_dummy.csv",
+    "mixtureFractions": "Ar:0.9,He:0.1"
+  }
+}
+```
+
 ## Server Mode (Experimental)
 
 A lightweight Flask server is provided for remote execution and basic job management. The implementation is not production ready and exposes only minimal endpoints. Install the `[server]` extra and launch with `python -m dpf2.simulation.dpf_simulator_server`. See [`src/dpf2/simulation/dpf_simulator_server.py`](src/dpf2/simulation/dpf_simulator_server.py) and [`tests/test_api_endpoints.py`](tests/test_api_endpoints.py) for the current interface.

--- a/examples/config.json
+++ b/examples/config.json
@@ -70,6 +70,7 @@
   "physics_models": {
     "eos_model": "ideal_gas",
     "gamma": 1.4,
+    "mu": 2.0,
     "two_temperature_model_enabled": false,
     "neutral_fluid_enabled": false,
     "initial_neutral_pressure_torr": null,

--- a/examples/physics_models.json
+++ b/examples/physics_models.json
@@ -1,10 +1,11 @@
 {
-  "physics": {
-    "eosModel": "tabulated",
-    "eosTablePath": "tests/data/sesame_dummy.csv",
-    "ionizationModel": "FLYCHK",
-    "ionizationTablePath": "tests/data/flychk_dummy.csv",
-    "radiationModel": "Bremsstrahlung",
+    "physics": {
+      "eosModel": "tabulated",
+      "eosTablePath": "tests/data/sesame_dummy.csv",
+      "mixtureFractions": "Ar:0.9,He:0.1",
+      "ionizationModel": "FLYCHK",
+      "ionizationTablePath": "tests/data/flychk_dummy.csv",
+      "radiationModel": "Bremsstrahlung",
     "radiationTransportModel": "MonteCarlo",
     "gamma": 1.6666666667
   }

--- a/src/dpf2/eos/ideal_gas.py
+++ b/src/dpf2/eos/ideal_gas.py
@@ -1,0 +1,65 @@
+"""Ideal gas equation of state backend.
+
+This lightweight implementation provides ion and electron pressure and
+internal energy for a fully ionised or partially ionised ideal gas.  The
+model assumes a constant adiabatic index ``gamma`` and mean molecular
+weight ``mu`` (in arbitrary units).  When ``ionization`` is non-zero the
+same amount of pressure and energy is attributed to the electron fluid.
+
+The calculations intentionally avoid physical constants in order to keep
+unit tests self contained.  The specific gas constant is taken as
+``1 / mu`` so that pressure is given by ``p = rho * R * T`` and the
+specific internal energy follows from ``e = R * T / (gamma - 1)``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+
+@dataclass
+class IdealGasEOS:
+    """Ideal‑gas equation of state with optional electron component."""
+
+    gamma: float = 5.0 / 3.0
+    mu: float = 1.0
+    ionization: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    @property
+    def R(self) -> float:
+        """Return the specific gas constant used by the model."""
+
+        return 1.0 / self.mu
+
+    # ------------------------------------------------------------------
+    # EOS interface
+    # ------------------------------------------------------------------
+    def ion_pressure(self, rho: np.ndarray, T: np.ndarray) -> np.ndarray:
+        """Ion pressure for density ``rho`` and temperature ``T``."""
+
+        return rho * self.R * T
+
+    def electron_pressure(self, rho: np.ndarray, T: np.ndarray) -> np.ndarray:
+        """Electron pressure contribution for density ``rho`` and temperature ``T``."""
+
+        if self.ionization == 0.0:
+            return np.zeros_like(rho)
+        return self.ionization * rho * self.R * T
+
+    def ion_energy(self, rho: np.ndarray, T: np.ndarray) -> np.ndarray:  # noqa: ARG002
+        """Ion specific internal energy for density ``rho`` and temperature ``T``."""
+
+        cv = self.R / (self.gamma - 1.0)
+        return cv * T
+
+    def electron_energy(self, rho: np.ndarray, T: np.ndarray) -> np.ndarray:  # noqa: ARG002
+        """Electron specific internal energy for density ``rho`` and temperature ``T``."""
+
+        if self.ionization == 0.0:
+            return np.zeros_like(rho)
+        cv = self.R / (self.gamma - 1.0)
+        return self.ionization * cv * T

--- a/src/dpf2/simulation/eos.py
+++ b/src/dpf2/simulation/eos.py
@@ -3,7 +3,39 @@ from pathlib import Path
 from typing import Dict, Optional, Union
 
 import numpy as np
-from scipy.interpolate import RegularGridInterpolator
+try:  # pragma: no cover - optional SciPy dependency
+    from scipy.interpolate import RegularGridInterpolator
+except ModuleNotFoundError:  # pragma: no cover
+    class RegularGridInterpolator:  # type: ignore[misc]
+        """Very small fallback interpolator when SciPy is unavailable."""
+
+        def __init__(self, points, values):
+            self.x, self.y = [np.array(p) for p in points]
+            self.values = np.array(values)
+
+        def __call__(self, pts):  # noqa: D401 - behave like SciPy callable
+            result = []
+            for x, y in pts:
+                i = np.searchsorted(self.x, x, side="right") - 1
+                j = np.searchsorted(self.y, y, side="right") - 1
+                i = max(min(i, len(self.x) - 2), 0)
+                j = max(min(j, len(self.y) - 2), 0)
+                x0, x1 = self.x[i], self.x[i + 1]
+                y0, y1 = self.y[j], self.y[j + 1]
+                tx = 0.0 if x1 == x0 else (x - x0) / (x1 - x0)
+                ty = 0.0 if y1 == y0 else (y - y0) / (y1 - y0)
+                f00 = self.values[i, j]
+                f01 = self.values[i, j + 1]
+                f10 = self.values[i + 1, j]
+                f11 = self.values[i + 1, j + 1]
+                val = (
+                    f00 * (1 - tx) * (1 - ty)
+                    + f01 * (1 - tx) * ty
+                    + f10 * tx * (1 - ty)
+                    + f11 * tx * ty
+                )
+                result.append(val)
+            return np.array(result)
 try:  # optional dependency
     import h5py
 except ModuleNotFoundError as exc:  # pragma: no cover - import guard
@@ -246,29 +278,7 @@ class TabulatedEOS:
             raise
 
     def electron_energy(self, rho, T):
-
-        """Return electron internal energy for the given density and temperature.
-
-        Parameters
-        ----------
-        rho: np.ndarray
-            Mass density (kg/m^3).
-        T: np.ndarray
-            Temperature (K).
-
-        """
-        Returns the electron internal energy at a given density and temperature.
-
-        Args:
-            rho (np.ndarray): Mass density (kg/m^3).
-            T (np.ndarray): Temperature (K).
-
-
-        Returns
-        -------
-        np.ndarray
-            Electron specific internal energy (J/kg).
-        """
+        """Return electron internal energy for the given density and temperature."""
         try:
             return self.e_interp(np.stack([rho, T], axis=-1))
         except Exception as e:
@@ -277,7 +287,11 @@ class TabulatedEOS:
 
     def __str__(self):
         """Returns a string representation of the TabulatedEOS object."""
-        return f"TabulatedEOS(rho_grid={self.rho_grid.shape}, T_grid={self.T_grid.shape}, p_table={self.p_table.shape}, e_table={self.e_table.shape})"
+        return (
+            f"TabulatedEOS(rho_grid={self.rho_grid.shape}, "
+            f"T_grid={self.T_grid.shape}, "
+            f"p_table={self.p_table.shape}, e_table={self.e_table.shape})"
+        )
 
     def __repr__(self):
         """Returns a string representation of the TabulatedEOS object."""

--- a/src/dpf2/simulation/eos_selector.py
+++ b/src/dpf2/simulation/eos_selector.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Optional, Union
 
 from .eos import TabulatedEOS, parse_mixture_fractions
+from dpf2.eos.ideal_gas import IdealGasEOS
 
 logger = logging.getLogger(__name__)
 
@@ -35,13 +36,14 @@ def select_eos(
     """
     logger.info(f"Selecting EOS backend: {backend}")
 
+    fractions = None
+    if mixture_fractions is not None:
+        fractions = parse_mixture_fractions(mixture_fractions)
+
     if backend == 'tabulated':
         if table_file is None:
             logger.error("Tabulated EOS backend selected, but 'table_file' not provided.")
             raise ValueError("Missing 'table_file' for tabulated EOS backend.")
-        fractions = None
-        if mixture_fractions is not None:
-            fractions = parse_mixture_fractions(mixture_fractions)
 
         try:
             eos_instance = TabulatedEOS(
@@ -57,19 +59,14 @@ def select_eos(
             logger.error(f"Failed to instantiate TabulatedEOS: {e}")
             raise
 
-    # Add other EOS backends here if needed
-    # elif backend == 'ideal_gas':
-    #     try:
-    #         from ideal_gas_eos import IdealGasEOS # Example
-    #         eos_instance = IdealGasEOS(**kwargs)
-    #         logger.info("Instantiated IdealGasEOS")
-    #         return eos_instance
-    #     except ImportError:
-    #         logger.error("IdealGasEOS module not found.")
-    #         raise ValueError("IdealGasEOS module required but not found.")
-    #     except Exception as e:
-    #         logger.error(f"Failed to instantiate IdealGasEOS: {e}")
-    #         raise
+    elif backend == 'ideal_gas':
+        try:
+            eos_instance = IdealGasEOS(**kwargs)
+            logger.info("Instantiated IdealGasEOS")
+            return eos_instance
+        except Exception as e:
+            logger.error(f"Failed to instantiate IdealGasEOS: {e}")
+            raise
 
     else:
         logger.error(f"Unknown EOS backend specified: {backend}")

--- a/tests/numpy_stub.py
+++ b/tests/numpy_stub.py
@@ -87,6 +87,11 @@ class Array:
             return (len(self.data),)
         return ()
 
+    @property
+    def ndim(self) -> int:
+        """Return the number of array dimensions."""
+        return len(self.shape)
+
     # ------------------------------------------------------------------
     # arithmetic operations
     def _binary(self, other, op):
@@ -255,6 +260,11 @@ def allclose(a, b, rtol=1.0e-8, atol=1.0e-8):
     return bool(comp)
 
 
+def array_equal(a, b) -> bool:
+    """Return ``True`` if two arrays are exactly equal."""
+    return bool(allclose(a, b))
+
+
 sqrt = math.sqrt
 
 
@@ -281,13 +291,14 @@ np = types.SimpleNamespace(
     cross=cross,
     clip=clip,
     sqrt=sqrt,
-    gradient=gradient,
-    isclose=isclose,
-    allclose=allclose,
-    Array=Array,
-    inf=float("inf"),
-    pi=math.pi,
-)
+      gradient=gradient,
+      isclose=isclose,
+      allclose=allclose,
+      array_equal=array_equal,
+      Array=Array,
+      inf=float("inf"),
+      pi=math.pi,
+  )
 
 sys.modules.setdefault("numpy", np)
 

--- a/tests/test_eos_selector.py
+++ b/tests/test_eos_selector.py
@@ -10,6 +10,7 @@ import pytest
 
 from dpf2.simulation.eos_selector import select_eos  # type: ignore
 from dpf2.simulation.eos import TabulatedEOS  # type: ignore
+from dpf2.eos.ideal_gas import IdealGasEOS
 
 
 def _create_species_eos_file(tmp_path: Path, species: str, p_val: float = 1.0, e_val: float = 1.0) -> Path:
@@ -84,4 +85,39 @@ def test_select_eos_negative_fraction(tmp_path):
             "tabulated",
             table_file=str(tmp_path),
             mixture_fractions="A:-0.1,B:1.1",
+        )
+
+
+def test_select_eos_ideal_gas():
+    eos = select_eos("ideal_gas", gamma=1.4, mu=2.0)
+    assert isinstance(eos, IdealGasEOS)
+
+
+def test_select_eos_ideal_gas_mixture_str():
+    eos = select_eos(
+        "ideal_gas",
+        gamma=1.4,
+        mu=2.0,
+        mixture_fractions="A:1.0",
+    )
+    assert isinstance(eos, IdealGasEOS)
+
+
+def test_select_eos_ideal_gas_mixture_dict():
+    eos = select_eos(
+        "ideal_gas",
+        gamma=1.4,
+        mu=2.0,
+        mixture_fractions={"A": 1.0},
+    )
+    assert isinstance(eos, IdealGasEOS)
+
+
+def test_select_eos_ideal_gas_invalid_mixture():
+    with pytest.raises(ValueError):
+        select_eos(
+            "ideal_gas",
+            gamma=1.4,
+            mu=2.0,
+            mixture_fractions="A:0.5,B:0.4",
         )

--- a/tests/test_ideal_gas_eos.py
+++ b/tests/test_ideal_gas_eos.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from dpf2.eos.ideal_gas import IdealGasEOS
+
+
+def test_ideal_gas_basic_relations():
+    eos = IdealGasEOS(gamma=1.4, mu=2.0, ionization=1.0)
+    rho = np.array([1.0])
+    T = np.array([3.0])
+    R = 1.0 / 2.0
+    p_i = eos.ion_pressure(rho, T)
+    p_e = eos.electron_pressure(rho, T)
+    e_i = eos.ion_energy(rho, T)
+    e_e = eos.electron_energy(rho, T)
+    assert np.allclose(p_i, rho * R * T)
+    assert np.allclose(p_e, rho * R * T)
+    expected_e = R * T / (1.4 - 1.0)
+    assert np.allclose(e_i, expected_e)
+    assert np.allclose(e_e, expected_e)


### PR DESCRIPTION
## Summary
- implement lightweight IdealGasEOS backend with optional electron component
- allow `select_eos` to parse mixture fractions and instantiate IdealGasEOS
- add unit tests for ideal gas and tabulated backends and document EOS selection

## Testing
- `pytest tests/test_eos_selector.py tests/test_ideal_gas_eos.py`
- `pytest` *(fails: ModuleNotFoundError: 'types.SimpleNamespace' object has no attribute 'ndarray', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68af7989de68832a9e8bcef8543ee8d8