### PR TITLE
Integrate WarpX AMR controls and diagnostics

### DIFF
--- a/src/dpf2/simulation/adaptive_mesh_refinement.py
+++ b/src/dpf2/simulation/adaptive_mesh_refinement.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 import json
@@ -145,27 +147,32 @@ class AdvancedWarpXSimulation:
             raise
 
     def visualize_diagnostics(self):
-        """Placeholder for diagnostics visualization (extend as needed)."""
-        logger.info("Visualizing diagnostics is not yet implemented.")
+        """Dump refined meshes and tagging statistics."""
+        try:
+            # Write out the current mesh hierarchy
+            pywarpx.warpx.write_plotfile("diags/refined_mesh")
+
+            # Persist cell tagging statistics for post‑analysis
+            stats = pywarpx.amr.tagging_stats()
+            os.makedirs("diags", exist_ok=True)
+            with open("diags/tagging_stats.json", "w", encoding="utf-8") as fh:
+                json.dump(stats, fh)
+            logger.info("AMR diagnostics written to diags/ directory")
+        except Exception as e:  # pragma: no cover - depends on optional libs
+            logger.error(f"Failed to write AMR diagnostics: {e}")
 
     def refine_grid(self, state: SimulationState):
-        """Refines the grid based on particle density."""
+        """Refine the mesh where the density exceeds the threshold."""
         try:
             if not self.config["enable_amr"]:
                 return
 
-            rho = state.density  # Access density from SimulationState
-
-            # Implement AMR logic based on density
-            # Example: Refine where density exceeds a threshold
-            for level in range(self.config["amr_levels"]):
-                for i in range(self.config["ncell"][0]):
-                    for j in range(self.config["ncell"][1]):
-                        for k in range(self.config["ncell"][2]):
-                            if rho[i, j, k] > self.config["refinement_threshold"]:
-                                # Refine the grid at this location
-                                # (Implementation depends on your AMR library)
-                                logger.debug(f"Refining grid at ({i}, {j}, {k})")
+            rho = state.density
+            mask = rho > self.config["refinement_threshold"]
+            if np.any(mask):
+                # Tag cells for refinement and invoke WarpX to regrid
+                pywarpx.amr.tag_cells(mask.astype(np.int8))
+                pywarpx.warpx.regrid()
         except Exception as e:
             logger.error(f"Error during grid refinement: {e}")
 

--- a/src/dpf2/simulation/config_schema.py
+++ b/src/dpf2/simulation/config_schema.py
@@ -144,6 +144,19 @@ class FieldManagerConfig(BaseModel):
     field_smoothing_strength: float = Field(0.0, description="Strength of field smoothing")
     # Add other parameters as needed
 
+
+class AMRConfig(BaseModel):
+    """Configuration for adaptive mesh refinement."""
+
+    enable: bool = False
+    max_level: int = Field(1, ge=1, description="Maximum AMR level")
+    refinement_threshold: float = Field(
+        1.0, description="Density threshold triggering refinement"
+    )
+    diag_interval: int = Field(
+        10, ge=1, description="Interval for dumping AMR diagnostics"
+    )
+
 class SimulationConfig(BaseModel):
     """Main configuration for the DPF simulation."""
     grid_shape: List[int] = Field(..., min_items=3, max_items=3, description="Number of grid points (nx, ny, nz)")
@@ -161,6 +174,7 @@ class SimulationConfig(BaseModel):
     diagnostics: Optional[DiagnosticsConfig] = None
     geometry: Optional[GeometryConfig] = None
     field_manager: FieldManagerConfig = Field(default_factory=FieldManagerConfig, description="Configuration for the FieldManager.")
+    amr: AMRConfig = Field(default_factory=AMRConfig, description="Adaptive mesh refinement settings")
     provenance: Optional[Dict[str, Any]] = None
     telemetry: Optional[Dict[str, Any]] = None
     io: Optional[Dict[str, Any]] = None

--- a/src/dpf2/simulation/dpf_simulation.py
+++ b/src/dpf2/simulation/dpf_simulation.py
@@ -14,7 +14,19 @@ import numpy as np
 import random
 from datetime import datetime
 
-from .config_schema import SimulationConfig, FieldManagerConfig  # Import FieldManagerConfig
+try:  # Prefer package-local imports
+    from .config_schema import SimulationConfig, FieldManagerConfig, PICConfig, AMRConfig
+except Exception:  # pragma: no cover - fallback when loaded as a script
+    from config_schema import SimulationConfig, FieldManagerConfig  # type: ignore
+    class PICConfig:  # type: ignore
+        pass
+    class AMRConfig:  # type: ignore
+        enable: bool = False
+        max_level: int = 1
+        refinement_threshold: float = 1.0
+        diag_interval: int = 10
+
+_AMR = AMRConfig
 from .module_registry import ModuleRegistry
 from .collision_model import CollisionModel
 from .radiation_model import RadiationModel
@@ -48,6 +60,7 @@ class DPFSimulation:
         self.step_count = 0
         self.current_time = 0.0
         self.dt = self.config.dt_init
+        self.amr_config = getattr(self.config, "amr", _AMR())
 
         # Initialize modules
         self.registry = ModuleRegistry()
@@ -85,7 +98,8 @@ class DPFSimulation:
                 dz=self.config.dz,
                 domain_lo=self.config.domain_lo,
                 boundary_conditions=self.config.field_manager.boundary_conditions,
-                field_manager=self.field_manager  # Pass FieldManager to SimulationState
+                field_manager=self.field_manager,
+                amr_config=self.amr_config,
             )
 
             self.solver = select_solver(
@@ -99,11 +113,18 @@ class DPFSimulation:
                 field_manager=self.field_manager,
             )
 
-            self.pic_solver = (
-                PICSolver(config=self.config.pic.dict(), field_manager=self.field_manager)
-                if self.config.pic
-                else None
-            )
+            self.pic_solver = None
+            if self.config.pic:
+                pic_cfg = self.config.pic.dict()
+                pic_cfg.update(
+                    {
+                        "amr": self.amr_config.enable,
+                        "density_threshold": self.amr_config.refinement_threshold,
+                    }
+                )
+                self.pic_solver = PICSolver(
+                    config=PICConfig(**pic_cfg), field_manager=self.field_manager
+                )
 
             if self.config.collision:
                 self.modules["collision"] = self.registry.create(

--- a/tests/test_amr_refinement.py
+++ b/tests/test_amr_refinement.py
@@ -1,0 +1,91 @@
+import sys
+import types
+
+
+class _NP:
+    """Minimal numpy-like helper for AMR tests."""
+
+    int8 = int
+
+    @staticmethod
+    def any(arr):
+        data = getattr(arr, "data", arr)
+        return any(any(any(v for v in row) for row in plane) for plane in data)
+
+
+class Density:
+    def __init__(self, shape):
+        nx, ny, nz = shape
+        self.data = [[[0 for _ in range(nz)] for _ in range(ny)] for _ in range(nx)]
+
+    def __gt__(self, thresh):
+        mask = [[[1 if v > thresh else 0 for v in row2] for row2 in row1] for row1 in self.data]
+        return Mask(mask)
+
+
+class Mask:
+    def __init__(self, data):
+        self.data = data
+
+    def astype(self, _):
+        return self.data
+
+
+class DummyState:
+    def __init__(self, shape):
+        self.density = Density(shape)
+
+
+def _install_pywarpx_stub():
+    warpx_api = types.SimpleNamespace(regrid=lambda: None, write_plotfile=lambda *_: None)
+    amr_state = {"tagged": None}
+
+    def tag_cells(mask):
+        amr_state["tagged"] = mask
+
+    def tagging_stats():
+        data = amr_state["tagged"]
+        total = sum(v for plane in data for row in plane for v in row) if data else 0
+        return {"tagged_cells": total}
+
+    amr_api = types.SimpleNamespace(tag_cells=tag_cells, tagging_stats=tagging_stats)
+    mod = types.ModuleType("pywarpx")
+    mod.warpx = warpx_api
+    mod.amr = amr_api
+    picmi_mod = types.ModuleType("pywarpx.picmi")
+    mod.picmi = picmi_mod
+    sys.modules["pywarpx"] = mod
+    sys.modules["pywarpx.picmi"] = picmi_mod
+    return mod, amr_state
+
+
+def test_refinement_triggers(monkeypatch):
+    pyw, amr_state = _install_pywarpx_stub()
+    from dpf2.simulation import adaptive_mesh_refinement as amr_mod
+
+    # Replace numpy dependency with minimal helper
+    amr_mod.np = _NP
+
+    sim = amr_mod.AdvancedWarpXSimulation.__new__(amr_mod.AdvancedWarpXSimulation)
+    sim.config = {
+        "enable_amr": True,
+        "refinement_threshold": 0.1,
+        "ncell": [2, 2, 2],
+        "amr_levels": 1,
+    }
+
+    state = DummyState((2, 2, 2))
+    state.density.data[0][0][0] = 1.0
+
+    called = {}
+
+    def fake_regrid():
+        called["regrid"] = True
+
+    pyw.warpx.regrid = fake_regrid
+
+    sim.refine_grid(state)
+
+    assert called.get("regrid")
+    assert amr_state["tagged"] is not None
+    assert amr_state["tagged"][0][0][0] == 1


### PR DESCRIPTION
## Summary
- hook WarpX AMR tagging and regrid into adaptive mesh refinement driver
- expose AMR settings via SimulationConfig and flow them to DPFSimulation
- add diagnostics dumps and regression test for AMR triggering

## Testing
- `pytest tests/test_amr_refinement.py -q`
- `pytest tests/test_dpf_simulation_run.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af798aee98832abff02d799e8d4d6e