### PR TITLE
Add training utilities and lifecycle methods for surrogate models

### DIFF
--- a/examples/ai_training.ipynb
+++ b/examples/ai_training.ipynb
@@ -1,0 +1,46 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import torch\n",
+    "from dpf2.ai.training import load_numpy_dataset, train_torch_model\n",
+    "from dpf2.ai import TorchSurrogateModel\n",
+    "from dpf2.metadata import Metadata\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = np.linspace(-1, 1, 100, dtype=np.float32).reshape(-1, 1)\n",
+    "y = 3 * x + 1\n",
+    "loader = load_numpy_dataset(x, y, batch_size=10)\n",
+    "net = torch.nn.Sequential(torch.nn.Linear(1, 1))\n",
+    "meta = Metadata.with_defaults()\n",
+    "train_torch_model(net, loader, epochs=50, lr=0.1, metadata=meta)\n",
+    "torch.jit.script(net).save('linear.pt')\n",
+    "sur = TorchSurrogateModel.load('linear.pt')\n",
+    "sur.predict(x[:5])\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dpf2/ai/__init__.py
+++ b/src/dpf2/ai/__init__.py
@@ -1,9 +1,12 @@
 """Surrogate model interfaces for AI integration."""
 
 from .surrogate import SurrogateModel, TorchSurrogateModel, ONNXSurrogateModel
+from .training import load_numpy_dataset, train_torch_model
 
 __all__ = [
     "SurrogateModel",
     "TorchSurrogateModel",
     "ONNXSurrogateModel",
+    "load_numpy_dataset",
+    "train_torch_model",
 ]

--- a/src/dpf2/ai/surrogate.py
+++ b/src/dpf2/ai/surrogate.py
@@ -20,6 +20,39 @@ class SurrogateModel(ABC):
         """Return model prediction for ``inputs``."""
         raise NotImplementedError
 
+    # ------------------------------------------------------------------
+    # Optional lifecycle helpers
+    def train(self, *args: Any, **kwargs: Any) -> dict[str, float]:
+        """Train the surrogate model.
+
+        Parameters and return values are model-specific. Sub-classes may
+        override this method to provide training capabilities. The default
+        implementation raises :class:`NotImplementedError`.
+        """
+
+        raise NotImplementedError("Training not implemented for this model")
+
+    def save(self, path: str | Path | None = None) -> Path:
+        """Persist the model to ``path``.
+
+        Parameters
+        ----------
+        path:
+            Destination for the serialized model. Implementations may fall
+            back to ``self.model_path`` when ``path`` is ``None``.
+        """
+
+        raise NotImplementedError("Save not implemented for this model")
+
+    @classmethod
+    def load(cls, model_path: str | Path, *args: Any, **kwargs: Any) -> "SurrogateModel":
+        """Load a serialized model from ``model_path``.
+
+        Sub-classes should override this to return an initialized instance.
+        """
+
+        raise NotImplementedError("Load not implemented for this model")
+
 
 class TorchSurrogateModel(SurrogateModel):
     """Surrogate model backed by a PyTorch ``ScriptModule``."""
@@ -42,6 +75,49 @@ class TorchSurrogateModel(SurrogateModel):
             out = self.model(tensor).cpu().numpy()
         return out
 
+    # ------------------------------------------------------------------
+    def train(
+        self,
+        dataloader: Any,
+        epochs: int = 10,
+        lr: float = 1e-3,
+        metadata: Any | None = None,
+    ) -> dict[str, float]:
+        """Train the underlying ``torch.nn.Module``.
+
+        Parameters
+        ----------
+        dataloader:
+            Iterable yielding ``(inputs, targets)`` tensors.
+        epochs:
+            Number of passes through the dataset.
+        lr:
+            Learning rate for the Adam optimizer.
+        metadata:
+            Optional :class:`~dpf2.metadata.Metadata` instance updated with
+            ``ml_metadata`` and ``ml_result``.
+        """
+
+        try:
+            from .training import train_torch_model
+        except Exception as exc:  # pragma: no cover - optional
+            raise ImportError("Training utilities require PyTorch") from exc
+
+        self.model, metrics = train_torch_model(
+            self.model, dataloader, epochs=epochs, lr=lr, metadata=metadata
+        )
+        return metrics
+
+    def save(self, path: str | Path | None = None) -> Path:
+        dest = Path(path or self.model_path)
+        scripted = self._torch.jit.script(self.model)
+        scripted.save(str(dest))
+        return dest
+
+    @classmethod
+    def load(cls, model_path: str | Path, device: str = "cpu") -> "TorchSurrogateModel":
+        return cls(model_path, device=device)
+
 
 class ONNXSurrogateModel(SurrogateModel):
     """Surrogate model using ``onnxruntime`` for inference."""
@@ -58,6 +134,24 @@ class ONNXSurrogateModel(SurrogateModel):
         input_name = self.session.get_inputs()[0].name
         outputs = self.session.run(None, {input_name: inputs})
         return outputs[0]
+
+    # ------------------------------------------------------------------
+    def train(self, *args: Any, **kwargs: Any) -> dict[str, float]:  # pragma: no cover - thin wrapper
+        """ONNX models are inference-only and cannot be trained."""
+
+        raise NotImplementedError("ONNX models do not support in-place training")
+
+    def save(self, path: str | Path | None = None) -> Path:
+        dest = Path(path or self.model_path)
+        if dest != self.model_path:
+            import shutil
+
+            shutil.copy(self.model_path, dest)
+        return dest
+
+    @classmethod
+    def load(cls, model_path: str | Path) -> "ONNXSurrogateModel":
+        return cls(model_path)
 
 
 __all__ = ["SurrogateModel", "TorchSurrogateModel", "ONNXSurrogateModel"]

--- a/src/dpf2/ai/training.py
+++ b/src/dpf2/ai/training.py
@@ -1,0 +1,83 @@
+"""Utilities for training surrogate models."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Tuple
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import torch
+    from torch.utils.data import DataLoader, TensorDataset
+except Exception:  # pragma: no cover - optional dependency
+    torch = None  # type: ignore
+
+from ..metadata import MLMetadata, MLResult, Metadata
+
+
+def load_numpy_dataset(
+    x: np.ndarray, y: np.ndarray, batch_size: int = 32
+) -> "DataLoader":
+    """Create a torch ``DataLoader`` from numpy arrays."""
+
+    if torch is None:  # pragma: no cover - environment w/out torch
+        raise ImportError("PyTorch is required for dataset loading")
+
+    inputs = torch.as_tensor(x, dtype=torch.float32)
+    targets = torch.as_tensor(y, dtype=torch.float32)
+    dataset = TensorDataset(inputs, targets)
+    return DataLoader(dataset, batch_size=batch_size, shuffle=True)
+
+
+def train_torch_model(
+    model: "torch.nn.Module",
+    dataloader: Iterable,
+    *,
+    epochs: int = 10,
+    lr: float = 1e-3,
+    metadata: Metadata | None = None,
+) -> Tuple["torch.nn.Module", Dict[str, float]]:
+    """Train ``model`` using data from ``dataloader``.
+
+    The model is optimized with Adam and mean squared error loss. Evaluation
+    metrics are returned as a dictionary. When ``metadata`` is supplied, its
+    ``ml_metadata`` and ``ml_result`` fields are populated accordingly.
+    """
+
+    if torch is None:  # pragma: no cover - environment w/out torch
+        raise ImportError("PyTorch is required for training")
+
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    loss_fn = torch.nn.MSELoss()
+
+    for _ in range(epochs):
+        for xb, yb in dataloader:
+            optimizer.zero_grad()
+            pred = model(xb)
+            loss = loss_fn(pred, yb)
+            loss.backward()
+            optimizer.step()
+
+    # Evaluation ---------------------------------------------------------
+    total_loss = 0.0
+    count = 0
+    with torch.no_grad():
+        for xb, yb in dataloader:
+            pred = model(xb)
+            total_loss += loss_fn(pred, yb).item() * len(xb)
+            count += len(xb)
+    mse = total_loss / max(count, 1)
+
+    if metadata is not None:
+        metadata.ml_metadata = MLMetadata(
+            model=type(model).__name__,
+            version=torch.__version__,
+            engine="torch",
+            optimizer="Adam",
+        )
+        metadata.ml_result = MLResult(model_error=mse)
+
+    return model, {"mse": mse}
+
+
+__all__ = ["load_numpy_dataset", "train_torch_model"]

--- a/tests/test_ai_surrogate.py
+++ b/tests/test_ai_surrogate.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from typing import Any
 
 from dpf2.ai import SurrogateModel, TorchSurrogateModel, ONNXSurrogateModel
 
@@ -8,7 +9,7 @@ class DummySurrogate(SurrogateModel):
     def __init__(self):
         super().__init__("/tmp/model")
 
-    def predict(self, inputs: np.ndarray) -> np.ndarray:
+    def predict(self, inputs: Any) -> Any:
         return inputs * 2
 
 

--- a/tests/test_ai_training.py
+++ b/tests/test_ai_training.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from dpf2.ai import ONNXSurrogateModel, TorchSurrogateModel
+from dpf2.ai.training import load_numpy_dataset, train_torch_model
+from dpf2.metadata import Metadata
+
+
+def _train_linear(tmp_path):
+    x = np.linspace(-1, 1, 20, dtype=np.float32).reshape(-1, 1)
+    y = 3 * x + 1
+    loader = load_numpy_dataset(x, y, batch_size=5)
+    net = torch.nn.Sequential(torch.nn.Linear(1, 1))
+    meta = Metadata.with_defaults()
+    train_torch_model(net, loader, epochs=200, lr=0.1, metadata=meta)
+    model_path = tmp_path / "linear.pt"
+    torch.jit.script(net).save(model_path)
+    return x, y, model_path, meta, net
+
+
+def test_torch_training_inference(tmp_path):
+    x, y, path, meta, _ = _train_linear(tmp_path)
+    sm = TorchSurrogateModel.load(path)
+    preds = sm.predict(x)
+    np.testing.assert_allclose(preds, y, atol=1e-1)
+    assert meta.ml_metadata is not None
+    assert meta.ml_result is not None
+
+
+def test_onnx_inference(tmp_path):
+    pytest.importorskip("onnxruntime")
+    x, y, _, _, net = _train_linear(tmp_path)
+    onnx_path = tmp_path / "linear.onnx"
+    net.eval()
+    torch.onnx.export(net, torch.as_tensor(x), onnx_path)
+    sm = ONNXSurrogateModel.load(onnx_path)
+    preds = sm.predict(x)
+    np.testing.assert_allclose(preds, y, atol=1e-1)


### PR DESCRIPTION
## Summary
- extend `SurrogateModel` with optional `train`, `save`, and `load` helpers
- implement lifecycle methods for Torch and ONNX surrogate models
- add `training` module for dataset loading, optimizer loops, and metadata capture
- supply example notebook and tests for training/inference on a toy dataset

## Testing
- `pytest tests/test_ai_surrogate.py tests/test_ai_training.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68af798d6828832a8d3fad4401dc85ec