### PR TITLE
feat: add openpmd diagnostics schema

### DIFF
--- a/src/dpf2/simulation/diagnostics.py
+++ b/src/dpf2/simulation/diagnostics.py
@@ -79,7 +79,13 @@ class Diagnostic(DiagnosticsBase):
                 payload = callback()
             if payload is None:
                 return
-            self.data.append({"time": float(t), **payload})
+            # Attach simulation time and wall-clock timestamp for provenance
+            record = {
+                "time": float(t),
+                "wall_time": float(time.time()),
+            }
+            record.update(payload)
+            self.data.append(record)
         except Exception:  # pragma: no cover - error path
             logger.exception("diagnostic %s failed to record", self.name)
 
@@ -91,12 +97,24 @@ class Diagnostic(DiagnosticsBase):
         """
 
         grp = hdf5_group.require_group(self.name)
+        # Minimal openPMD-like identifiers
+        grp.attrs.setdefault("openPMD", "1.1.0")
+        grp.attrs.setdefault("openPMDextension", 0)
+
         try:
             if self.data:
-                grp.create_dataset("time", data=[d["time"] for d in self.data])
-                keys = [k for k in self.data[0] if k != "time"]
+                times = [d["time"] for d in self.data]
+                wtimes = [d.get("wall_time", float("nan")) for d in self.data]
+                t_ds = grp.create_dataset("time", data=times)
+                t_ds.attrs["unitSI"] = 1.0
+                wt_ds = grp.create_dataset("wall_time", data=wtimes)
+                wt_ds.attrs["unitSI"] = 1.0
+
+                keys = [k for k in self.data[0] if k not in ("time", "wall_time")]
                 for k in keys:
-                    grp.create_dataset(k, data=np.array([d[k] for d in self.data]))
+                    arr = np.array([d[k] for d in self.data])
+                    ds = grp.create_dataset(k, data=arr)
+                    ds.attrs["unitSI"] = 1.0
         except Exception:  # pragma: no cover - error path
             logger.exception("diagnostic %s failed to serialise", self.name)
         return grp
@@ -423,17 +441,21 @@ class Diagnostics:
         """Write diagnostics to HDF5."""
         try:
             with h5py.File(self.hdf5_filename, 'w') as f:
-                # Provenance / config
-                cfggrp = f.create_group('config')
-                for k,v in self.config.items():
-                    cfggrp.attrs[k] = json.dumps(v)
+                f.attrs.update({"openPMD": "1.1.0", "openPMDextension": 0})
+                # Provenance / config snapshot
+                prov = f.create_group('provenance')
+                prov.attrs['created'] = time.time()
+                prov.attrs['software'] = 'dpf2'
+                prov.create_dataset('config', data=np.string_(json.dumps(self.config)))
 
                 # Time series
                 ts = f.create_group('time_series')
+                ts.attrs.update({"openPMD": "1.1.0", "openPMDextension": 0})
                 keys = list(self.summary[0].keys())
                 for key in keys:
                     data = [rec[key] for rec in self.summary]
-                    ts.create_dataset(key, data=data, compression='gzip')
+                    ds = ts.create_dataset(key, data=data, compression='gzip')
+                    ds.attrs['unitSI'] = 1.0
 
                 # Snapshots
                 snaps = f.create_group('snapshots')
@@ -448,6 +470,7 @@ class Diagnostics:
 
                 # Diagnostic-specific data
                 diag_grp = f.create_group('diagnostics')
+                diag_grp.attrs.update({"openPMD": "1.1.0", "openPMDextension": 0})
                 for diagnostic in self.diagnostics:
                     diagnostic.to_hdf5(diag_grp)
         except Exception as e:

--- a/tests/test_diagnostic_serialization.py
+++ b/tests/test_diagnostic_serialization.py
@@ -71,14 +71,20 @@ def test_interferometry_serialisation(tmp_path):
     state = types.SimpleNamespace(density=np.full((1, 1, 1), 1.0), dx=1.0, domain_lo=(0, 0, 0))
 
     diag.record(0.0, None, None, state=state)
+    expected = diag.data[0]["phase_shift"]
+    wall = diag.data[0]["wall_time"]
 
     with h5py.File(tmp_path / "out.h5", "w") as h5:
         diag.to_hdf5(h5)
 
     with h5py.File(tmp_path / "out.h5", "r") as h5:
         grp = h5["int"]
+        assert grp.attrs["openPMD"] == "1.1.0"
         assert np.allclose(grp["time"].data, [0.0])
-        assert "phase_shift" in grp
+        assert np.allclose(grp["wall_time"].data, [wall])
+        assert np.allclose(grp["phase_shift"].data, [expected])
+        assert grp["time"].attrs["unitSI"] == 1.0
+        assert grp["phase_shift"].attrs["unitSI"] == 1.0
 
 
 def test_xray_detector_serialisation(tmp_path):
@@ -95,15 +101,20 @@ def test_xray_detector_serialisation(tmp_path):
     )
 
     diag.record(0.0, None, None, radiation=radiation, state=state)
+    expected = diag.data[0]["signal"]
+    wall = diag.data[0]["wall_time"]
 
     with h5py.File(tmp_path / "out.h5", "w") as h5:
         diag.to_hdf5(h5)
 
     with h5py.File(tmp_path / "out.h5", "r") as h5:
         grp = h5["xray"]
+        assert grp.attrs["openPMD"] == "1.1.0"
         assert np.allclose(grp["time"].data, [0.0])
-        assert "signal" in grp
+        assert np.allclose(grp["wall_time"].data, [wall])
+        assert np.allclose(grp["signal"].data, [expected])
         assert grp["energy_bins"].data == diag.energy_bins
+        assert grp["signal"].attrs["unitSI"] == 1.0
 
 
 def test_neutron_detector_serialisation(tmp_path):
@@ -117,14 +128,20 @@ def test_neutron_detector_serialisation(tmp_path):
     )
 
     diag.record(0.0, None, None, pic=pic)
+    expected = diag.data[0]["histogram"]
+    wall = diag.data[0]["wall_time"]
 
     with h5py.File(tmp_path / "out.h5", "w") as h5:
         diag.to_hdf5(h5)
 
     with h5py.File(tmp_path / "out.h5", "r") as h5:
         grp = h5["nd"]
+        assert grp.attrs["openPMD"] == "1.1.0"
         assert np.allclose(grp["time"].data, [0.0])
+        assert np.allclose(grp["wall_time"].data, [wall])
         assert np.array(grp["histogram"].data).shape == (1, len(bins) - 1)
+        assert np.allclose(grp["histogram"].data[0], expected)
         assert np.allclose(grp["time_bins"].data, bins)
+        assert grp["histogram"].attrs["unitSI"] == 1.0
         assert grp.attrs["reaction"] == "DD"
 


### PR DESCRIPTION
## Summary
- add time-stamped diagnostic recording with OpenPMD-like schema
- write provenance metadata and config snapshots to diagnostic outputs
- test serialization/deserialization for interferometry, x-ray, and neutron diagnostics

## Testing
- `pytest tests/test_diagnostic_serialization.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'HallMHD' from 'dpf2.physics' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68af7e970d24832aa6d06a0430d9c032