### PR TITLE
Add MHD solver performance tests and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,5 @@ jobs:
         run: pytest
       - name: Validate pinch benchmarks
         run: python scripts/validate_pinch.py
-
-      - name: Validate pinch benchmarks
-        run: python scripts/validate_pinch.py
-
-
+      - name: MHD performance scaling
+        run: pytest tests/test_mhd_performance.py -q

--- a/tests/test_mhd_performance.py
+++ b/tests/test_mhd_performance.py
@@ -1,0 +1,30 @@
+import time
+import numpy as np
+
+from dpf2.hall_mhd_solver import HallMHDSolver, MHDState
+
+
+def _make_state(n: int) -> MHDState:
+    shape = (n, n, n)
+    rho = np.full(shape, 1.0)
+    mom = np.zeros(shape + (3,))
+    B = np.zeros(shape + (3,))
+    energy = np.full(shape, 1.0)
+    return MHDState(rho=rho, mom=mom, energy=energy, B=B)
+
+
+def _run_solver(n: int, steps: int = 5) -> float:
+    solver = HallMHDSolver()
+    state = _make_state(n)
+    start = time.perf_counter()
+    for _ in range(steps):
+        state = solver.step(state, 1e-6)
+    return time.perf_counter() - start
+
+
+def test_mhd_solver_scaling():
+    sizes = [4, 8, 16]
+    times = [_run_solver(n) for n in sizes]
+    # ensure larger grids take longer to compute
+    assert times[0] < times[-1]
+    assert times[1] < times[-1]


### PR DESCRIPTION
## Summary
- add performance scaling test for Hall MHD solver
- run pinch validation and performance test in CI workflow

## Testing
- `venv/bin/pytest tests/test_mhd_performance.py -q`
- `venv/bin/python scripts/validate_pinch.py --datasets data/benchmarks --out Validation` *(fails: AttributeError: type object 'GridResolution' has no attribute 'parse_obj')*
- `venv/bin/ruff check tests/test_mhd_performance.py .github/workflows/ci.yml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af7e981758832a859282930df3b1ab