### PR TITLE
Add configuration templates, CLI wizard, and web dashboard

### DIFF
--- a/docs/config_templates/basic_simulation.yaml
+++ b/docs/config_templates/basic_simulation.yaml
@@ -1,0 +1,36 @@
+# Basic DPF simulation configuration template
+# Generated from DPFConfig schema with validation hints
+
+# --- Device size ---------------------------------------------------------
+# cathode_radius: meters, >0
+cathode_radius: 0.015
+# anode_radius: meters, must be > cathode_radius
+anode_radius: 0.025
+# electrode_length: meters
+electrode_length: 0.10
+
+# --- Capacitor bank ------------------------------------------------------
+# capacitance: Farads, >0
+capacitance: 3.0e-05
+# inductance: Henrys, >0
+inductance: 2.0e-08
+# resistance: Ohms, >=0
+resistance: 0.01
+# charging_voltage: Volts
+charging_voltage: 15000.0
+
+# --- Fill gas ------------------------------------------------------------
+# gas_type: deuterium | helium | neon | argon | xenon
+gas_type: deuterium
+# initial_pressure: Pascals, >0
+initial_pressure: 133.3
+
+# --- Mesh and runtime settings ------------------------------------------
+# nr_cells: integer >0
+nr_cells: 100
+# nz_cells: integer >0
+nz_cells: 200
+# cfl_number: 0 < value <= 1
+cfl_number: 0.5
+# end_time: seconds, >0
+end_time: 1.0e-05

--- a/docs/config_templates/capacitor_bank.yaml
+++ b/docs/config_templates/capacitor_bank.yaml
@@ -1,0 +1,7 @@
+# Capacitor bank configuration template
+# All values must be positive numbers (resistance >= 0)
+
+capacitance: 3.0e-05     # Farads
+inductance: 2.0e-08      # Henrys
+resistance: 0.01         # Ohms
+charging_voltage: 15000  # Volts

--- a/docs/config_templates/device_setup.yaml
+++ b/docs/config_templates/device_setup.yaml
@@ -1,0 +1,6 @@
+# Device geometry template with validation hints
+# Each length is in meters and must be positive.
+
+cathode_radius: 0.015      # Cathode radius > 0
+anode_radius: 0.025        # Anode radius > cathode_radius
+electrode_length: 0.10     # Electrode length > 0

--- a/docs/config_templates/fill_gas.yaml
+++ b/docs/config_templates/fill_gas.yaml
@@ -1,0 +1,6 @@
+# Fill gas configuration template
+# gas_type must be one of: deuterium, helium, neon, argon, xenon
+# initial_pressure in Pascals (>0)
+
+gas_type: deuterium
+initial_pressure: 133.3

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,5 +4,7 @@ Welcome to the DPF2 documentation. This site provides:
 
 - A comprehensive [User Guide](user_guide.md) covering installation, configuration, physics modules, examples, and server usage.
 - An [API Reference](api_reference.md) generated directly from the source code with links to examples.
+- Ready-to-use [configuration templates](config_templates/) with validation hints.
+- Step-by-step [tutorials](tutorials/) that mirror real experiments.
 
 Use the navigation to explore the simulator and learn how to extend it.

--- a/docs/tutorials/basic_experiment.md
+++ b/docs/tutorials/basic_experiment.md
@@ -1,0 +1,44 @@
+# Basic DPF Experiment Tutorial
+
+This tutorial mirrors a simple dense plasma focus experiment. It guides you through
+building a configuration, running a simulation, and inspecting results.
+
+## 1. Assemble configuration
+
+1. Copy the [basic simulation template](../config_templates/basic_simulation.yaml).
+2. Adjust **device size** and **capacitor bank** parameters to match your setup.
+3. Set the desired **fill gas** and pressure.
+
+## 2. Run the wizard
+
+You can also generate a configuration interactively:
+
+```bash
+python -m dpf2.cli.main wizard -o my_config.json
+```
+
+Answer the prompts for device dimensions, fill gas, and capacitor bank values.
+
+## 3. Start the simulation
+
+```bash
+python -m dpf2.cli.main simulate -c my_config.json -o output
+```
+
+The solver writes diagnostics to the `output` directory.
+
+## 4. Inspect diagnostics
+
+For a quick look in your browser, launch the web dashboard:
+
+```bash
+python -m dpf2.web.app
+```
+
+Then open `http://localhost:5000` to run simulations and browse generated files.
+
+## 5. Compare with experiment
+
+Use the diagnostic plots to compare peak current, voltage trace, or neutron yield
+with your lab measurements. Iteratively adjust the configuration until the
+simulated behavior matches the experiment.

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -1,5 +1,7 @@
 """Command line interface for DPF2."""
+import json
 import logging
+from dataclasses import asdict
 
 import click
 
@@ -33,6 +35,73 @@ def simulate(config: str | None, output: str) -> None:
     except Exception as e:
         logger.exception("Unexpected error running simulation")
         raise click.ClickException(f"Unexpected error: {e}")
+
+
+@main.command()
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(),
+    default="config_generated.json",
+    help="File to write generated configuration",
+)
+def wizard(output: str) -> None:
+    """Interactive wizard for building a configuration."""
+
+    click.echo("DPF2 configuration wizard\n")
+    defaults = DPFConfig()
+
+    # --- Device size -------------------------------------------------
+    cathode_radius = click.prompt(
+        "Cathode radius [m]", type=float, default=defaults.cathode_radius
+    )
+    anode_radius = click.prompt(
+        "Anode radius [m]", type=float, default=defaults.anode_radius
+    )
+    electrode_length = click.prompt(
+        "Electrode length [m]", type=float, default=defaults.electrode_length
+    )
+
+    # --- Fill gas ----------------------------------------------------
+    gas_type = click.prompt("Fill gas", type=str, default=defaults.gas_type)
+    initial_pressure = click.prompt(
+        "Initial pressure [Pa]", type=float, default=defaults.initial_pressure
+    )
+
+    # --- Capacitor bank ---------------------------------------------
+    capacitance = click.prompt(
+        "Capacitance [F]", type=float, default=defaults.capacitance
+    )
+    inductance = click.prompt(
+        "Inductance [H]", type=float, default=defaults.inductance
+    )
+    resistance = click.prompt(
+        "Resistance [Ohm]", type=float, default=defaults.resistance
+    )
+    charging_voltage = click.prompt(
+        "Charging voltage [V]", type=float, default=defaults.charging_voltage
+    )
+
+    cfg_dict = asdict(defaults)
+    cfg_dict.update(
+        {
+            "cathode_radius": cathode_radius,
+            "anode_radius": anode_radius,
+            "electrode_length": electrode_length,
+            "gas_type": gas_type,
+            "initial_pressure": initial_pressure,
+            "capacitance": capacitance,
+            "inductance": inductance,
+            "resistance": resistance,
+            "charging_voltage": charging_voltage,
+        }
+    )
+    cfg = DPFConfig(**cfg_dict)
+
+    with open(output, "w") as fh:
+        json.dump(asdict(cfg), fh, indent=2)
+
+    click.echo(f"Configuration saved to {output}")
 
 
 if __name__ == "__main__":

--- a/src/dpf2/web/__init__.py
+++ b/src/dpf2/web/__init__.py
@@ -1,0 +1,5 @@
+"""Lightweight web dashboard for running simulations."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/src/dpf2/web/app.py
+++ b/src/dpf2/web/app.py
@@ -1,0 +1,67 @@
+"""Minimal Flask application for running DPF simulations."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from flask import Flask, redirect, render_template_string, request, url_for
+
+from ..core.config import DPFConfig
+from ..core.simulation import DPFSimulation
+from ..exceptions import ConfigurationError, SimulationRuntimeError
+
+INDEX_HTML = """
+<!doctype html>
+<title>DPF2 Dashboard</title>
+<h1>Run Simulation</h1>
+<form method=post>
+  Config file path: <input name=config><br>
+  Output directory: <input name=output value="output"><br>
+  <input type=submit value="Run">
+</form>
+<p><a href="{{ url_for('diagnostics') }}">View diagnostics</a></p>
+"""
+
+DIAG_HTML = """
+<!doctype html>
+<title>Diagnostics</title>
+<h1>Diagnostics</h1>
+<ul>
+{% for f in files %}<li>{{ f }}</li>{% endfor %}
+</ul>
+<p><a href="{{ url_for('index') }}">Back</a></p>
+"""
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.route("/", methods=["GET", "POST"])
+    def index():
+        if request.method == "POST":
+            cfg_path = request.form.get("config")
+            output = request.form.get("output", "output")
+            try:
+                cfg = DPFConfig.from_file(cfg_path) if cfg_path else DPFConfig()
+                sim = DPFSimulation(cfg)
+                sim.run(output_dir=output)
+                return redirect(url_for("diagnostics", output=output))
+            except (ConfigurationError, SimulationRuntimeError, Exception) as exc:  # pragma: no cover - UI path
+                return render_template_string(INDEX_HTML + f"<p>Error: {exc}</p>")
+        return render_template_string(INDEX_HTML)
+
+    @app.route("/diagnostics")
+    def diagnostics():
+        output = request.args.get("output", "output")
+        try:
+            files = sorted(os.listdir(output))
+        except FileNotFoundError:
+            files = []
+        return render_template_string(DIAG_HTML, files=files)
+
+    return app
+
+
+if __name__ == "__main__":  # pragma: no cover
+    create_app().run(debug=True)


### PR DESCRIPTION
## Summary
- add schema-driven YAML config templates with validation hints
- introduce interactive `wizard` command for building configs
- provide lightweight Flask dashboard for running simulations
- expand docs with experiment-style tutorial

## Testing
- `pytest` *(fails: FileNotFoundError, NameError and other missing assets)*

------
https://chatgpt.com/codex/tasks/task_e_68af7e98f17c832a839280ae66d34925