### PR TITLE
refactor: move distributed circuit models

### DIFF
--- a/src/dpf2/circuit/__init__.py
+++ b/src/dpf2/circuit/__init__.py
@@ -1,0 +1,3 @@
+"""Circuit-related utilities and models."""
+
+__all__ = ["distributed"]

--- a/src/dpf2/circuit/distributed.py
+++ b/src/dpf2/circuit/distributed.py
@@ -1,0 +1,124 @@
+"""Models for distributed RLC circuits used in DPF simulations.
+
+This module provides dataclasses describing transmission line segments,
+triggered switches and parasitic elements. It also exposes helper routines
+that assemble R, L and C matrices for a network that can be used with a
+state–space integrator.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, Sequence
+
+import numpy as np
+
+__all__ = [
+    "TransmissionLineSegment",
+    "TriggeredSwitch",
+    "ShuntCapacitance",
+    "StrayInductance",
+    "assemble_matrices",
+]
+
+
+class Parasitic(Protocol):
+    """Protocol for parasitic elements attachable to a segment."""
+
+    def totals(self) -> tuple[float, float, float]:
+        """Return contributions to ``L``, ``R`` and ``C``."""
+
+
+@dataclass
+class ShuntCapacitance:
+    """Simple shunt capacitance parasitic."""
+
+    C: float
+
+    def totals(self) -> tuple[float, float, float]:
+        return 0.0, 0.0, self.C
+
+
+@dataclass
+class StrayInductance:
+    """Simple stray inductance parasitic."""
+
+    L: float
+
+    def totals(self) -> tuple[float, float, float]:
+        return self.L, 0.0, 0.0
+
+
+@dataclass
+class TransmissionLineSegment:
+    """RLC transmission line segment with optional parasitics.
+
+    Parameters are specified per unit length. ``length`` is measured in
+    metres while ``L_per_m``, ``R_per_m`` and ``C_per_m`` are the inductance,
+    resistance and capacitance per metre respectively.  Parasitic elements
+    can be attached and are included when computing the total values.
+    """
+
+    length: float
+    L_per_m: float
+    R_per_m: float
+    C_per_m: float
+    parasitics: Sequence[Parasitic] = field(default_factory=tuple)
+
+    def totals(self) -> tuple[float, float, float]:
+        """Return the total ``L``, ``R`` and ``C`` for this segment."""
+
+        L = self.L_per_m * self.length
+        R = self.R_per_m * self.length
+        C = self.C_per_m * self.length
+        for p in self.parasitics:
+            pL, pR, pC = p.totals()
+            L += pL
+            R += pR
+            C += pC
+        return L, R, C
+
+
+@dataclass
+class TriggeredSwitch:
+    """Switch that closes at a specified trigger time."""
+
+    trigger_time: float
+    R_on: float = 1e-3
+    R_off: float = 1e6
+
+    def resistance(self, time: float) -> float:
+        """Return the instantaneous resistance at ``time``."""
+
+        return self.R_on if time >= self.trigger_time else self.R_off
+
+
+def assemble_matrices(
+    segments: Sequence[TransmissionLineSegment],
+    switches: Sequence[TriggeredSwitch] | None = None,
+    time: float = 0.0,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Assemble diagonal ``R``, ``L`` and ``C`` matrices for a network.
+
+    Each segment contributes its total ``R``, ``L`` and ``C`` (including
+    parasitic elements) to the diagonal of the returned matrices.  If
+    ``switches`` are provided their resistances at ``time`` are added in
+    series with the corresponding segments.
+    """
+
+    n = len(segments)
+    R = np.zeros((n, n))
+    L = np.zeros((n, n))
+    C = np.zeros((n, n))
+
+    for i, seg in enumerate(segments):
+        L_tot, R_tot, C_tot = seg.totals()
+        L[i, i] = L_tot
+        R[i, i] = R_tot
+        C[i, i] = C_tot
+
+    if switches is not None:
+        for i, sw in enumerate(switches):
+            if i < n:
+                R[i, i] += sw.resistance(time)
+
+    return R, L, C

--- a/src/dpf2/circuit_config.py
+++ b/src/dpf2/circuit_config.py
@@ -246,15 +246,15 @@ class CircuitConfig(ConfigSectionBase):
 
     # ------------------------------------------------------------------
     def build_distributed_model(self):
-        """Return ``TransmissionLineSegment`` and ``Switch`` objects.
+        """Return ``TransmissionLineSegment`` and ``TriggeredSwitch`` objects.
 
         This helper constructs runtime objects used by the distributed
         circuit solver.  Values are converted from the configuration
         units (μH, mΩ, μF) into SI units per metre as required by
-        :class:`dpf2.distributed_circuit.TransmissionLineSegment`.
+        :class:`dpf2.circuit.distributed.TransmissionLineSegment`.
         """
 
-        from .distributed_circuit import TransmissionLineSegment, Switch
+        from .circuit.distributed import TransmissionLineSegment, TriggeredSwitch
 
         segments: List[TransmissionLineSegment] = []
         if self.segments:
@@ -274,12 +274,13 @@ class CircuitConfig(ConfigSectionBase):
                     )
                 )
 
-        switches: List[Switch] = []
+        switches: List[TriggeredSwitch] = []
         if self.switches:
             for sw in self.switches:
+                trigger = 0.0 if sw.closed else float("inf")
                 switches.append(
-                    Switch(
-                        closed=sw.closed,
+                    TriggeredSwitch(
+                        trigger_time=trigger,
                         R_on=sw.r_on * 1e-3,
                         R_off=sw.r_off * 1e-3,
                     )

--- a/src/dpf2/distributed_circuit.py
+++ b/src/dpf2/distributed_circuit.py
@@ -1,104 +1,24 @@
-"""Models for distributed RLC circuits used in DPF simulations.
+"""Backward compatibility wrapper for distributed circuit models.
 
-This module provides simple dataclasses describing transmission line
-segments and switches.  It also exposes helper routines to assemble
-R, L and C matrices for a network of segments that can be used with a
-state–space integrator.
-
-The implementation is intentionally lightweight – it is not a full
-featured circuit simulator but rather a minimal tool to enable unit
-testing and examples of distributed networks within the DPF code base.
+The implementations have moved to :mod:`dpf2.circuit.distributed`.
 """
-from __future__ import annotations
+from .circuit.distributed import (
+    TransmissionLineSegment,
+    TriggeredSwitch,
+    ShuntCapacitance,
+    StrayInductance,
+    assemble_matrices,
+)
 
-from dataclasses import dataclass
-from typing import Iterable, Sequence
-
-import numpy as np
+# ``Switch`` was renamed to ``TriggeredSwitch``; provide an alias for
+# existing callers.
+Switch = TriggeredSwitch
 
 __all__ = [
     "TransmissionLineSegment",
-    "Switch",
+    "TriggeredSwitch",
+    "ShuntCapacitance",
+    "StrayInductance",
     "assemble_matrices",
+    "Switch",
 ]
-
-
-@dataclass
-class TransmissionLineSegment:
-    """Simple RLC transmission line segment.
-
-    Parameters are specified per unit length.  ``length`` is measured
-    in metres while ``L_per_m``, ``R_per_m`` and ``C_per_m`` are the
-    inductance, resistance and capacitance per metre respectively.
-    All quantities are converted to total values when building the
-    circuit matrices.
-    """
-
-    length: float
-    L_per_m: float
-    R_per_m: float
-    C_per_m: float
-
-    def totals(self) -> tuple[float, float, float]:
-        """Return the total ``L``, ``R`` and ``C`` for this segment."""
-
-        L = self.L_per_m * self.length
-        R = self.R_per_m * self.length
-        C = self.C_per_m * self.length
-        return L, R, C
-
-
-@dataclass
-class Switch:
-    """Idealised switch model.
-
-    The switch is represented only by an on and off resistance.  The
-    state of the switch is toggled by setting ``closed`` to ``True`` or
-    ``False``.
-    """
-
-    closed: bool = True
-    R_on: float = 1e-3
-    R_off: float = 1e6
-
-    def resistance(self) -> float:
-        """Return the instantaneous resistance of the switch."""
-
-        return self.R_on if self.closed else self.R_off
-
-
-def assemble_matrices(
-    segments: Sequence[TransmissionLineSegment],
-    switches: Sequence[Switch] | None = None,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Assemble diagonal ``R``, ``L`` and ``C`` matrices for a network.
-
-    Each segment contributes its total ``R``, ``L`` and ``C`` to the
-    diagonal of the returned matrices.  If ``switches`` are provided
-    their resistances are added in series with the corresponding
-    segments.
-
-    The matrices are primarily intended for use with the simple
-    state–space integrator implemented in :mod:`dpf2.circuit_solver`.
-    They are not intended to cover all possible circuit topologies but
-    are sufficient for modelling a linear chain of segments and
-    switches.
-    """
-
-    n = len(segments)
-    R = np.zeros((n, n), dtype=float)
-    L = np.zeros((n, n), dtype=float)
-    C = np.zeros((n, n), dtype=float)
-
-    for i, seg in enumerate(segments):
-        L_tot, R_tot, C_tot = seg.totals()
-        L[i, i] = L_tot
-        R[i, i] = R_tot
-        C[i, i] = C_tot
-
-    if switches is not None:
-        for i, sw in enumerate(switches):
-            if i < n:
-                R[i, i] += sw.resistance()
-
-    return R, L, C

--- a/tests/test_distributed_circuit.py
+++ b/tests/test_distributed_circuit.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+
+from dpf2.circuit.distributed import (
+    TransmissionLineSegment,
+    TriggeredSwitch,
+    ShuntCapacitance,
+    StrayInductance,
+    assemble_matrices,
+)
+
+
+def test_assemble_matrices_with_trigger_and_parasitics():
+    seg = TransmissionLineSegment(
+        length=1.0,
+        L_per_m=2.0,
+        R_per_m=3.0,
+        C_per_m=4.0,
+        parasitics=[ShuntCapacitance(1.0), StrayInductance(0.5)],
+    )
+    sw = TriggeredSwitch(trigger_time=1.0, R_on=0.1, R_off=10.0)
+
+    R0, L0, C0 = assemble_matrices([seg], [sw], time=0.0)
+    assert R0[0, 0] == 3.0 + 10.0
+    assert L0[0, 0] == 2.0 + 0.5
+    assert C0[0, 0] == 4.0 + 1.0
+
+    R1, L1, C1 = assemble_matrices([seg], [sw], time=2.0)
+    assert R1[0, 0] == 3.0 + 0.1
+    assert L0[0, 0] == L1[0, 0]
+    assert C0[0, 0] == C1[0, 0]


### PR DESCRIPTION
## Summary
- move distributed circuit utilities into `dpf2.circuit.distributed`
- add triggered switch and parasitic element support for assembly helpers
- update circuit config to build new triggered switch models
- add tests for assembling matrices with triggers and parasitics

## Testing
- `pytest tests/test_distributed_circuit.py -q`
- `pytest tests/test_circuit_model.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0897bf04c832a9eabfeb6255769a0