### PR TITLE
Add parasitic and trigger options to distributed circuit configs

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -26,6 +26,20 @@ pip install -e .[diagnostics]
 
 Simulations are configured with the `DPFConfig` data class. Configuration files are written in JSON and validated against this schema. See `dpf_config.py` and related `*config.py` modules for field descriptions and default values.
 
+### Distributed Circuit Configuration
+
+The circuit section now supports a distributed representation composed of
+segments and switches.  Each `SegmentConfig` connects two nodes using the
+`from_node` and `to_node` fields and may include fixed parasitic
+inductance, resistance and capacitance values as well as optional
+time-dependent profiles for these quantities
+(`l_profile`, `r_profile`, `c_profile`).  `SwitchConfig` definitions have
+gained a `trigger_times` list in nanoseconds along with corresponding
+parasitic `l_parasitic`, `r_parasitic` and `c_parasitic` parameters.  The
+`CircuitConfig.build_distributed_model()` helper translates these
+configurations into `TransmissionLineSegment` and `Switch` instances from
+`dpf2.circuit.distributed` for use by network solvers.
+
 ## Physics Modules
 
 The core simulation is composed of modular physics components. Key modules include:

--- a/src/dpf2/circuit/distributed.py
+++ b/src/dpf2/circuit/distributed.py
@@ -68,11 +68,15 @@ class TransmissionLineSegment:
 @dataclass
 
 class Switch:
-    """Idealised switch model with optional trigger times.
+    """Idealised switch model with optional trigger times and parasitics.
 
     ``from_node`` and ``to_node`` identify the nodes bridged by the
     switch.  ``trigger_times`` is an optional sequence of times in
-    seconds when the switch state should toggle.
+    seconds when the switch state should toggle.  ``L_parasitic`` and
+    ``C_parasitic`` provide fixed inductive and capacitive contributions
+    irrespective of the switch state while ``R_parasitic`` is a series
+    resistance always present in addition to the state-dependent value
+    returned by :meth:`resistance`.
     """
 
     from_node: int
@@ -81,11 +85,15 @@ class Switch:
     R_on: float = 1e-3
     R_off: float = 1e6
     trigger_times: Sequence[float] | None = None
+    L_parasitic: float = 0.0
+    R_parasitic: float = 0.0
+    C_parasitic: float = 0.0
 
     def resistance(self, t: float | None = None) -> float:
         """Return the instantaneous resistance of the switch."""
 
-        return self.R_on if self.closed else self.R_off
+        base = self.R_on if self.closed else self.R_off
+        return base + self.R_parasitic
 
 
 def assemble_matrices(
@@ -117,8 +125,9 @@ def assemble_matrices(
     if switches is not None:
         for i, sw in enumerate(switches):
             if i < n:
-
                 R[i, i] += sw.resistance()
+                L[i, i] += sw.L_parasitic
+                C[i, i] += sw.C_parasitic
 
 
     return R, L, C

--- a/src/dpf2/circuit_config.py
+++ b/src/dpf2/circuit_config.py
@@ -163,6 +163,21 @@ class SwitchConfig(BaseModel):
         alias="rOff",
         metadata={"units": "mΩ", "category": "Circuit", "group": "Distributed"},
     )
+    L_parasitic: float = Field(
+        0.0,
+        alias="lParasitic",
+        metadata={"units": "μH", "category": "Circuit", "group": "Distributed"},
+    )
+    R_parasitic: float = Field(
+        0.0,
+        alias="rParasitic",
+        metadata={"units": "mΩ", "category": "Circuit", "group": "Distributed"},
+    )
+    C_parasitic: float = Field(
+        0.0,
+        alias="cParasitic",
+        metadata={"units": "μF", "category": "Circuit", "group": "Distributed"},
+    )
     trigger_times: Optional[List[float]] = Field(
         None,
         alias="triggerTimes",
@@ -368,6 +383,9 @@ class CircuitConfig(ConfigSectionBase):
 
                         R_on=sw.r_on * 1e-3,
                         R_off=sw.r_off * 1e-3,
+                        L_parasitic=sw.L_parasitic * 1e-6,
+                        R_parasitic=sw.R_parasitic * 1e-3,
+                        C_parasitic=sw.C_parasitic * 1e-6,
                         trigger_times=trig,
                     )
                 )

--- a/tests/test_distributed_config.py
+++ b/tests/test_distributed_config.py
@@ -16,6 +16,8 @@ def test_build_distributed_model_parses_connections():
                     R_parasitic=0.2,
                     C_parasitic=0.3,
                     L_profile=[(0.0, 1.0)],
+                    R_profile=[(0.0, 0.2)],
+                    C_profile=[(0.0, 0.3)],
                 )
             ],
             "switches": [
@@ -26,6 +28,9 @@ def test_build_distributed_model_parses_connections():
                     r_on=1.0,
                     r_off=1000.0,
                     trigger_times=[10.0],
+                    L_parasitic=0.5,
+                    R_parasitic=0.6,
+                    C_parasitic=0.7,
                 )
             ],
         }
@@ -35,6 +40,11 @@ def test_build_distributed_model_parses_connections():
     assert seg.from_node == 0 and seg.to_node == 1
     assert seg.L_parasitic == 0.1e-6
     assert seg.L_profile == [(0.0, 1.0e-6)]
+    assert seg.R_profile == [(0.0, 0.2e-3)]
+    assert seg.C_profile == [(0.0, 0.3e-6)]
     sw = switches[0]
     assert sw.from_node == 1 and sw.to_node == 2
     assert sw.trigger_times == [10.0e-9]
+    assert sw.L_parasitic == 0.5e-6
+    assert sw.R_parasitic == 0.6e-3
+    assert sw.C_parasitic == 0.7e-6


### PR DESCRIPTION
## Summary
- extend `SwitchConfig` with parasitic L/R/C fields and trigger times
- translate new switch options and segment profiles into `circuit.distributed` objects
- update distributed circuit docs and tests

## Testing
- `pytest tests/test_distributed_config.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'HallMHD' from 'dpf2.physics'; ModuleNotFoundError: No module named 'werkzeug'; ModuleNotFoundError: No module named 'adios2'; ImportError: cannot import name 'ValidationError' from 'pydantic'; ModuleNotFoundError: No module named 'scipy.constants'; ImportError: cannot import name 'PicDriver' from 'dpf2.physics'; FileNotFoundError: No such file or directory: '/workspace/dpf2/dpf2/ionization.py'; ImportError: cannot import name 'ResistiveMHD' from 'dpf2.physics'; ImportError: cannot import name 'AnalyticPinchModel' from 'dpf2.pinch_models'; NameError: name 'types' is not defined; ModuleNotFoundError: No module named 'scipy.ndimage'; ImportError: cannot import name 'c' from '<unknown module name>' )*


------
https://chatgpt.com/codex/tasks/task_e_68b0adf3bc8c832aa40e7d6015e443d6