### PR TITLE
Refactor circuit-plasma coupling to use typed state

### DIFF
--- a/examples/hybrid_feedback.py
+++ b/examples/hybrid_feedback.py
@@ -13,6 +13,7 @@ import numpy as np
 from dpf2.pinch_models import HybridPinchModel
 from dpf2.physics.pic_driver import PicDriver
 from dpf2.circuit_solver import CircuitSolver, RLCCircuit
+from dpf2.core.bases import CouplingState
 
 
 class MockPicDriver(PicDriver):
@@ -43,7 +44,9 @@ if __name__ == "__main__":
         radius, energy = pic.step(current, dt)
         # Simple feedback: plasma energy generates back EMF
         back_emf = energy * 1e-3
-        current, _ = circuit.step(current, back_emf, dt)
+        coupling = CouplingState(current=current, voltage=circuit.voltages[-1])
+        updated = circuit.step(coupling, back_emf, dt)
+        current = updated.current
 
     print(f"Final current: {current:.3e} A")
     print(f"Final radius:  {radius:.3e} m")

--- a/examples/plasma_circuit_coupling.py
+++ b/examples/plasma_circuit_coupling.py
@@ -32,6 +32,7 @@ core_mod = importlib.util.module_from_spec(core_spec)
 sys.modules["dpf2.core.circuit"] = core_mod
 core_spec.loader.exec_module(core_mod)  # type: ignore[misc]
 RLCCircuitSolver = core_mod.RLCCircuitSolver
+from dpf2.core.bases import CouplingState
 
 plasma_spec = importlib.util.spec_from_file_location(
     "dpf2.physics.simple_plasma", module_base / "physics/simple_plasma.py"
@@ -66,9 +67,15 @@ def main() -> None:
     plasma.step(None, 0.0, current, voltage)
 
     for _ in range(steps):
-        feedback = {"Lp": plasma.inductance, "emf": plasma.back_emf}
-        current, voltage = circuit.step(current, 0.0, dt, feedback)
-        plasma.step(None, dt, current, voltage)
+        feedback = CouplingState(
+            Lp=plasma.inductance,
+            emf=plasma.back_emf,
+            current=current,
+            voltage=voltage,
+        )
+        updated = circuit.step(feedback, 0.0, dt)
+        plasma.step(None, dt, updated.current, updated.voltage)
+        current, voltage = updated.current, updated.voltage
 
     Lp = plasma.inductance
     initial_energy = 0.5 * circuit.C_ext * circuit.V0 ** 2

--- a/src/dpf2/simulation/dpf_simulation.py
+++ b/src/dpf2/simulation/dpf_simulation.py
@@ -37,6 +37,7 @@ from .circuit import CircuitModel
 from .utils import FieldManager, SimulationState
 from ..diagnostics import Diagnostics
 from .pic_solver import PICSolver
+from ..core.bases import CouplingState
 try:
     from ..exceptions import SimulationRuntimeError
 except Exception:  # pragma: no cover - fallback for standalone usage
@@ -230,7 +231,28 @@ class DPFSimulation:
 
                     feedback = getattr(self.solver, "circuit_feedback", None)
 
-                    self.circuit.step(current, back_emf, self.dt, feedback)
+                    if isinstance(feedback, CouplingState):
+                        coupling = feedback
+                        coupling.current = current
+                        coupling.voltage = (
+                            self.circuit.get_voltage()
+                            if hasattr(self.circuit, "get_voltage")
+                            else 0.0
+                        )
+                    else:
+                        feedback = feedback or {}
+                        coupling = CouplingState(
+                            Lp=feedback.get("Lp", 0.0),
+                            emf=feedback.get("emf", 0.0),
+                            current=current,
+                            voltage=(
+                                self.circuit.get_voltage()
+                                if hasattr(self.circuit, "get_voltage")
+                                else 0.0
+                            ),
+                        )
+
+                    self.circuit.step(coupling, back_emf, self.dt)
                 except Exception as exc:
                     logger.error(f"Circuit step failed: {exc}")
 

--- a/src/dpf2/simulation/hybrid_controller.py
+++ b/src/dpf2/simulation/hybrid_controller.py
@@ -50,6 +50,7 @@ from .collision_model import CollisionModel
 from .config_schema import HybridConfig
 from .models import PhysicsModule, SimulationState
 from .utils import FieldManager
+from ..core.bases import CouplingState
 
 # Physical constants
 mu0      = 4*np.pi*1e-7
@@ -230,7 +231,13 @@ class HybridController(PhysicsModule):
             #I = self.fluid.compute_total_current()
             I = self.field_manager.get_J()
             # Pass the fluid current and zero back‑EMF to the circuit model.
-            self.circuit.step(I, 0.0, dt)
+            voltage = (
+                self.circuit.get_voltage()
+                if hasattr(self.circuit, "get_voltage")
+                else 0.0
+            )
+            state = CouplingState(current=I, voltage=voltage)
+            self.circuit.step(state, 0.0, dt)
 
             # 3. Radiation
             self.radiation.apply(state, dt)
@@ -259,7 +266,13 @@ class HybridController(PhysicsModule):
             self._apply_feedback(state, fb, regions)
 
             # 4. Circuit update
-            self.circuit.step(0.0, 0.0, dt)
+            voltage = (
+                self.circuit.get_voltage()
+                if hasattr(self.circuit, "get_voltage")
+                else 0.0
+            )
+            state = CouplingState(current=0.0, voltage=voltage)
+            self.circuit.step(state, 0.0, dt)
 
             # 5. Radiation effects
             self.radiation.apply(state, dt)

--- a/src/dpf2/simulation/warpx_wrapper.py
+++ b/src/dpf2/simulation/warpx_wrapper.py
@@ -49,6 +49,7 @@ except ModuleNotFoundError as exc:  # pragma: no cover - import guard
     ) from exc
 from .collision_model import CollisionModel  # Assuming you have this
 from .utils import FieldManager
+from ..core.bases import CouplingState
 
 # Configure logger
 logger = logging.getLogger('WarpXWrapper')
@@ -354,11 +355,17 @@ class WarpXWrapper:
                 if self.circuit:
                     t_c = time.perf_counter()
                     I_pic = self.get_total_current()
-                    # The circuit interface expects the present current,
-                    # an applied back‑EMF and the timestep.  The stub circuit
-                    # used here does not provide a detailed model so we pass
-                    # the PIC current and zero EMF.
-                    self.circuit.step(I_pic, 0.0, dt)
+                    # The circuit interface expects the present state and an
+                    # applied back‑EMF.  The stub circuit used here does not
+                    # provide a detailed model so we pass the PIC current and
+                    # zero EMF/inductance.
+                    voltage = (
+                        self.circuit.get_voltage()
+                        if hasattr(self.circuit, "get_voltage")
+                        else 0.0
+                    )
+                    state = CouplingState(current=I_pic, voltage=voltage)
+                    self.circuit.step(state, 0.0, dt)
                     self.warp.applyBoundaryB(self.circuit.I)
                     timings['circuit'] += time.perf_counter() - t_c
             t_map = time.perf_counter()

--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -13,7 +13,7 @@ from .dpf_config import DPFConfig
 from .circuit_config import CircuitConfig
 
 from .circuit_solver import RLCCircuit, CircuitSolver, run_circuit_simulation
-from .core.bases import PlasmaSolverBase
+from .core.bases import PlasmaSolverBase, CouplingState
 from .pinch_models import (
     AnalyticPinchModel,
     SemiAnalyticPinchModel,
@@ -152,13 +152,11 @@ class SimulationEngine:
         )
 
         current = circuit.currents[-1]
+        voltage = circuit.voltages[-1]
         while circuit.time[-1] < t_end:
-            current, _ = circuit.step(
-                current,
-                0.0,
-                dt,
-                energy_tracker=tracker,
-            )
+            state = CouplingState(current=current, voltage=voltage)
+            updated = circuit.step(state, 0.0, dt, energy_tracker=tracker)
+            current, voltage = updated.current, updated.voltage
 
         t = np.array(circuit.time)
         current_arr = np.array(circuit.currents)

--- a/tests/integration/test_plasma_circuit_feedback.py
+++ b/tests/integration/test_plasma_circuit_feedback.py
@@ -28,14 +28,19 @@ def make_circuit():
     )
 
 
+from dpf2.core.bases import CouplingState
+
+
 def run_trace(inductances):
     circuit = make_circuit()
     dt = 1e-7
     trace = []
     for Lp in inductances:
         current = circuit.get_current()
-        circuit.step(current, 0.0, dt, {"Lp": Lp})
-        trace.append(circuit.get_current())
+        voltage = circuit.get_voltage()
+        coupling = CouplingState(Lp=Lp, emf=0.0, current=current, voltage=voltage)
+        updated = circuit.step(coupling, 0.0, dt)
+        trace.append(updated.current)
     return np.array(trace)
 
 

--- a/tests/test_dpf_simulation_run.py
+++ b/tests/test_dpf_simulation_run.py
@@ -16,15 +16,23 @@ class DummySolver:
 class DummyEOS:
     """Dummy EOS used by the selector."""
 
+from dpf2.core.bases import CouplingState
+
+
 class DummyCircuit:
     def __init__(self, collision_model=None, field_manager=None, **kwargs):
         self.current = 0.0
         self.voltage = kwargs.get("V0", 0.0)
 
-    def step(self, current, back_emf, dt, feedback=None):
+    def step(self, coupling: CouplingState, back_emf, dt):
         """Simple integrator incrementing current for testing."""
-        self.current += dt
-        return self.current, self.voltage
+        self.current = coupling.current + dt
+        return CouplingState(
+            Lp=coupling.Lp,
+            emf=coupling.emf,
+            current=self.current,
+            voltage=self.voltage,
+        )
 
     def get_current(self):
         return self.current

--- a/tests/test_hybrid_integration.py
+++ b/tests/test_hybrid_integration.py
@@ -103,12 +103,20 @@ def test_hybrid_step_combines_fluid_and_pic():
                 'pressure_density': pressure_density,
             }
 
+    from dpf2.core.bases import CouplingState
+
     class DummyCircuit:
         def __init__(self):
             self.step_calls = 0
-        def step(self, current, back_emf, dt, feedback=None):
+
+        def step(self, coupling: CouplingState, back_emf, dt):
             self.step_calls += 1
-            return current, 0.0
+            return CouplingState(
+                current=coupling.current,
+                voltage=0.0,
+                Lp=coupling.Lp,
+                emf=coupling.emf,
+            )
 
     class DummyRadiation:
         def __init__(self):


### PR DESCRIPTION
## Summary
- Introduce `CouplingState` dataclass for exchanging inductance, EMF, current, and voltage
- Update simulation engine and helpers to use `CouplingState` when stepping circuits
- Adjust tests and examples for the new typed coupling interface

## Testing
- `pytest tests/core/test_circuit_coupling.py tests/core/test_inductance_profile.py tests/integration/test_plasma_circuit_feedback.py tests/test_dpf_simulation_run.py -q`
- `pytest tests/test_hybrid_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0adf51b58832aa3b6be619b4ea87b