### PR TITLE
feat: expand CLI with validation and plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ to the scientific community to further explore.
 
 ## Documentation
 
-Full documentation, including a user guide and API reference, lives in the [docs/](docs/index.md) directory and is available as a MkDocs site. Build and view it locally with:
+Full documentation, including a user guide, CLI reference, and API reference, lives in the [docs/](docs/index.md) directory and is available as a MkDocs site. Build and view it locally with:
 
 ```bash
 pip install -r docs/requirements.txt
 mkdocs serve
 ```
+
+For details on the command line interface, see [docs/cli.md](docs/cli.md).
 
 ## Installation
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,49 @@
+# Command Line Interface
+
+The `dpf2` executable exposes several subcommands for running
+simulations and inspecting results.
+
+## simulate
+
+```
+dpf2 simulate -c config.json -o output_dir
+```
+
+Run a simulation using a configuration file. Results are written to the
+specified output directory.
+
+## wizard
+
+```
+dpf2 wizard -o my_config.json
+```
+
+Interactive flow that guides users through building a configuration.
+Advanced mesh and timing options are available when requested.
+
+## validate
+
+```
+dpf2 validate --config config.json --dataset PF1000
+```
+
+Execute a simulation and compare the output with bundled validation
+traces. Overlay plots are written to the `validation` directory by
+default.
+
+## plot
+
+```
+dpf2 plot --input output_dir --output plot.png
+```
+
+Generate a quick plot of current and voltage from simulation output
+files.
+
+## schema
+
+```
+dpf2 schema
+```
+
+Print a JSON description of the configuration schema and default values.

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -1,6 +1,8 @@
 """Command line interface for DPF2."""
 import json
 import logging
+import dataclasses
+from pathlib import Path
 from dataclasses import asdict
 
 import click
@@ -8,6 +10,7 @@ import click
 from dpf2.core.config import DPFConfig
 from dpf2.core.simulation import DPFSimulation
 from dpf2.exceptions import ConfigurationError, SimulationRuntimeError
+from .validate import run_validation
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +41,68 @@ def simulate(config: str | None, output: str) -> None:
 
 
 @main.command()
+@click.option("--config", type=click.Path(exists=True, dir_okay=False), required=True)
+@click.option("--dataset", type=str, required=True)
+@click.option("--outdir", type=click.Path(file_okay=False), default="validation")
+def validate(config: str, dataset: str, outdir: str) -> None:
+    """Run a validation simulation and compare with experimental data."""
+    try:
+        ok = run_validation(Path(config), dataset, outdir=Path(outdir))
+        if not ok:
+            raise click.ClickException("Validation failed")
+    except Exception as e:  # pragma: no cover - defensive
+        raise click.ClickException(str(e))
+
+
+@main.command()
+@click.option("--input", type=click.Path(file_okay=False), required=True)
+@click.option("--output", type=click.Path(), default="plot.png")
+def plot(input: str, output: str) -> None:
+    """Plot current and voltage from simulation outputs."""
+    import h5py
+    import matplotlib.pyplot as plt
+
+    files = sorted(Path(input).glob("data_*.h5"))
+    if not files:
+        raise click.ClickException(f"No HDF5 files found in {input}")
+
+    times, currents, voltages = [], [], []
+    for fname in files:
+        with h5py.File(fname, "r") as fh:
+            times.append(float(fh["time"][()]))
+            if "current" in fh:
+                currents.append(float(fh["current"][()]))
+            if "voltage" in fh:
+                voltages.append(float(fh["voltage"][()]))
+
+    if not currents:
+        raise click.ClickException("No current data available")
+
+    plt.figure()
+    plt.plot(times, currents, label="current")
+    if voltages:
+        plt.plot(times, voltages, label="voltage")
+    plt.xlabel("time [s]")
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(output)
+    click.echo(f"Plot written to {output}")
+
+
+@main.command()
+def schema() -> None:
+    """Print the configuration schema."""
+    fields = {
+        f.name: {
+            "type": getattr(f.type, "__name__", str(f.type)),
+            "default": f.default,
+        }
+        for f in dataclasses.fields(DPFConfig)
+    }
+    click.echo(json.dumps(fields, indent=2))
+
+
+@main.command()
 @click.option(
     "-o",
     "--output",
@@ -52,35 +117,83 @@ def wizard(output: str) -> None:
     defaults = DPFConfig()
 
     # --- Device size -------------------------------------------------
+    click.echo("Device geometry:")
     cathode_radius = click.prompt(
-        "Cathode radius [m]", type=float, default=defaults.cathode_radius
+        "Cathode radius [m]", type=float, default=defaults.cathode_radius, show_default=True
     )
     anode_radius = click.prompt(
-        "Anode radius [m]", type=float, default=defaults.anode_radius
+        "Anode radius [m]", type=float, default=defaults.anode_radius, show_default=True
     )
     electrode_length = click.prompt(
-        "Electrode length [m]", type=float, default=defaults.electrode_length
+        "Electrode length [m]", type=float, default=defaults.electrode_length, show_default=True
     )
 
     # --- Fill gas ----------------------------------------------------
-    gas_type = click.prompt("Fill gas", type=str, default=defaults.gas_type)
+    click.echo("\nPlasma fill parameters:")
+    gas_type = click.prompt("Fill gas", type=str, default=defaults.gas_type, show_default=True)
     initial_pressure = click.prompt(
-        "Initial pressure [Pa]", type=float, default=defaults.initial_pressure
+        "Initial pressure [Pa]",
+        type=float,
+        default=defaults.initial_pressure,
+        show_default=True,
     )
 
     # --- Capacitor bank ---------------------------------------------
+    click.echo("\nExternal circuit:")
+    click.echo("Capacitor bank and wiring values influence current rise.")
     capacitance = click.prompt(
-        "Capacitance [F]", type=float, default=defaults.capacitance
+        "Capacitance [F]",
+        type=float,
+        default=defaults.capacitance,
+        show_default=True,
     )
     inductance = click.prompt(
-        "Inductance [H]", type=float, default=defaults.inductance
+        "Inductance [H]",
+        type=float,
+        default=defaults.inductance,
+        show_default=True,
     )
     resistance = click.prompt(
-        "Resistance [Ohm]", type=float, default=defaults.resistance
+        "Resistance [Ohm]",
+        type=float,
+        default=defaults.resistance,
+        show_default=True,
     )
     charging_voltage = click.prompt(
-        "Charging voltage [V]", type=float, default=defaults.charging_voltage
+        "Charging voltage [V]",
+        type=float,
+        default=defaults.charging_voltage,
+        show_default=True,
     )
+
+    # --- Advanced options -------------------------------------------
+    advanced_cfg: dict[str, float | int] = {}
+    if click.confirm("Configure advanced mesh and timing options?", default=False):
+        click.echo("\nMesh and solver controls:")
+        advanced_cfg["nr_cells"] = click.prompt(
+            "Radial cells",
+            type=int,
+            default=defaults.nr_cells,
+            show_default=True,
+        )
+        advanced_cfg["nz_cells"] = click.prompt(
+            "Axial cells",
+            type=int,
+            default=defaults.nz_cells,
+            show_default=True,
+        )
+        advanced_cfg["cfl_number"] = click.prompt(
+            "CFL number",
+            type=float,
+            default=defaults.cfl_number,
+            show_default=True,
+        )
+        advanced_cfg["end_time"] = click.prompt(
+            "Simulation end time [s]",
+            type=float,
+            default=defaults.end_time,
+            show_default=True,
+        )
 
     cfg_dict = asdict(defaults)
     cfg_dict.update(
@@ -96,6 +209,7 @@ def wizard(output: str) -> None:
             "charging_voltage": charging_voltage,
         }
     )
+    cfg_dict.update(advanced_cfg)
     cfg = DPFConfig(**cfg_dict)
 
     with open(output, "w") as fh:


### PR DESCRIPTION
## Summary
- add validation, plotting, and schema inspection subcommands to CLI
- extend interactive wizard with advanced options and help text
- document CLI usage and link from README

## Testing
- `pytest` *(fails: missing optional dependencies and modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bb660d68832a9c34c97d589620ee