### PR TITLE
feat: unify solver coupling and add synthetic diagnostics

### DIFF
--- a/src/dpf2/circuit_solver.py
+++ b/src/dpf2/circuit_solver.py
@@ -310,10 +310,11 @@ def run_circuit_simulation(
         voltage = circuit.voltages[-1]
         plasma_solver.step(plasma_state, 0.0, current, voltage)
         for _ in range(1, num_points):
-            feedback = plasma_solver.coupling_interface()
-            feedback.current = current
-            feedback.voltage = voltage
-            updated = circuit.step(feedback, 0.0, dt)
+            fb = plasma_solver.coupling_interface()
+            coupling = CouplingState(
+                Lp=fb.Lp, emf=fb.emf, current=current, voltage=voltage
+            )
+            updated = circuit.step(coupling, 0.0, dt)
             current, voltage = updated.current, updated.voltage
             plasma_solver.step(plasma_state, dt, current, voltage)
 

--- a/src/dpf2/core/bases.py
+++ b/src/dpf2/core/bases.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Tuple
 
 
 @dataclass
@@ -27,6 +27,17 @@ class CouplingState:
     emf: float = 0.0
     current: float = 0.0
     voltage: float = 0.0
+
+    def as_tuple(self) -> Tuple[float, float, float, float]:
+        """Return the state as ``(Lp, emf, current, voltage)`` tuple.
+
+        This helper simplifies unpacking when a solver prefers positional
+        access.  The method is intentionally lightweight to keep the
+        ``CouplingState`` dataclass as a minimal container for exchanged
+        quantities.
+        """
+
+        return self.Lp, self.emf, self.current, self.voltage
 
 
 class PlasmaSolverBase(ABC):

--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -10,11 +10,21 @@ from pydantic import BaseModel, ConfigDict, Field, root_validator
 from .neutron_yield import compute_neutron_yield
 from .xray_spectra import compute_xray_spectrum
 from .scope_trace import compute_scope_trace
+from .synthetic_signals import (
+    current_waveform,
+    voltage_waveform,
+    rogowski_signal,
+    bdot_signal,
+)
 
 __all__ = [
     "compute_neutron_yield",
     "compute_xray_spectrum",
     "compute_scope_trace",
+    "current_waveform",
+    "voltage_waveform",
+    "rogowski_signal",
+    "bdot_signal",
 ]
 
 # Compatibility helpers -------------------------------------------------------

--- a/src/dpf2/diagnostics/synthetic_signals.py
+++ b/src/dpf2/diagnostics/synthetic_signals.py
@@ -1,0 +1,61 @@
+"""Lightweight synthetic diagnostic signal generators.
+
+Each helper operates on an iterable of :class:`~dpf2.core.bases.CouplingState`
+objects representing the circuit/plasma coupling at successive time steps.
+The functions are intentionally simple and serve as stand-ins for more
+specialised diagnostics that would exist in a full application.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+import math
+
+from ..core.bases import CouplingState
+
+
+def current_waveform(history: Iterable[CouplingState]) -> List[float]:
+    """Return the circuit current for each time step."""
+
+    return [float(state.current) for state in history]
+
+
+def voltage_waveform(history: Iterable[CouplingState]) -> List[float]:
+    """Return the capacitor voltage for each time step."""
+
+    return [float(state.voltage) for state in history]
+
+
+def rogowski_signal(history: Iterable[CouplingState], dt: float) -> List[float]:
+    """Compute a synthetic Rogowski coil signal ``dI/dt``."""
+
+    currents = current_waveform(history)
+    if len(currents) < 2 or dt <= 0:
+        return [0.0 for _ in currents]
+    deriv = [(currents[i + 1] - currents[i]) / dt for i in range(len(currents) - 1)]
+    deriv.append(deriv[-1])
+    return deriv
+
+
+def bdot_signal(history: Iterable[CouplingState], radius: float, dt: float) -> List[float]:
+    """Generate a simple B-dot probe signal assuming axial field geometry."""
+
+    mu0 = 4.0 * math.pi * 1e-7
+    if radius <= 0:
+        raise ValueError("radius must be positive")
+    currents = current_waveform(history)
+    B = [mu0 * I / (2.0 * math.pi * radius) for I in currents]
+    if len(B) < 2 or dt <= 0:
+        return [0.0 for _ in B]
+    deriv = [(B[i + 1] - B[i]) / dt for i in range(len(B) - 1)]
+    deriv.append(deriv[-1])
+    return deriv
+
+
+__all__ = [
+    "current_waveform",
+    "voltage_waveform",
+    "rogowski_signal",
+    "bdot_signal",
+]
+

--- a/src/dpf2/plasma_model.py
+++ b/src/dpf2/plasma_model.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 # Backward compatibility wrapper
+from typing import Any
+
 from .pinch_models import (
     AnalyticPinchModel,
     PinchResult,
@@ -8,6 +10,28 @@ from .pinch_models import (
     PinchModelBase,
 )
 from .ablation import ablation_mass_energy_source, insulator_sleeve_area
+from .core.bases import CouplingState, PlasmaSolverBase
+
+
+def advance_plasma_with_circuit(
+    plasma: PlasmaSolverBase, state: Any, coupling: CouplingState, dt: float
+) -> CouplingState:
+    """Advance a plasma solver and return updated coupling terms.
+
+    The helper hides the common ceremony required when coupling a
+    :class:`PlasmaSolverBase` implementation to an external circuit.  The
+    supplied ``coupling`` provides the instantaneous circuit current and
+    voltage which are fed into :meth:`PlasmaSolverBase.step`.  After the
+    plasma is advanced, the new inductance and EMF terms are retrieved via
+    :meth:`PlasmaSolverBase.coupling_interface` and returned as a fresh
+    :class:`CouplingState` instance.
+    """
+
+    plasma.step(state, dt, coupling.current, coupling.voltage)
+    fb = plasma.coupling_interface()
+    return CouplingState(
+        Lp=fb.Lp, emf=fb.emf, current=coupling.current, voltage=coupling.voltage
+    )
 
 __all__ = [
     "AnalyticPinchModel",
@@ -16,4 +40,5 @@ __all__ = [
     "PinchModelBase",
     "ablation_mass_energy_source",
     "insulator_sleeve_area",
+    "advance_plasma_with_circuit",
 ]

--- a/src/dpf2/synthetic_diagnostics.py
+++ b/src/dpf2/synthetic_diagnostics.py
@@ -187,6 +187,21 @@ class SyntheticDiagnostics(ConfigSectionBase):
             f"Detectors: {num_det}, Geometry: {geom}, IDs: {ids}"
         )
 
+    def enabled_modules(self) -> List[str]:
+        """Return names of diagnostic modules enabled via configuration."""
+
+        mapping = {
+            "current_waveform": self.synthetic_current_waveform_enabled,
+            "voltage_waveform": self.synthetic_voltage_waveform_enabled,
+            "coupled_current_waveform": self.synthetic_coupled_current_waveform_enabled,
+            "coupled_voltage_waveform": self.synthetic_coupled_voltage_waveform_enabled,
+            "rogowski_signal": self.synthetic_rogowski_signal_enabled,
+            "bdot_signal": self.synthetic_bdot_signal_enabled,
+            "neutron_tof": self.synthetic_neutron_tof_enabled,
+            "xray_pinhole": self.synthetic_xray_pinhole_enabled,
+        }
+        return [name for name, flag in mapping.items() if flag]
+
     def hash_synthetic_diagnostics_config(self) -> str:
         data = self.model_dump(by_alias=True, exclude={"synthetic_diagnostics_config_hash"})
         serialized = json.dumps(data, sort_keys=True, default=str)


### PR DESCRIPTION
## Summary
- formalize plasma/circuit exchange with new `CouplingState` helper
- refactor circuit and plasma helpers to trade `CouplingState` objects each step
- add lightweight synthetic diagnostic signal generators and config hooks

## Testing
- `pytest` *(fails: missing modules and data)*
- `pytest tests/test_synthetic_diagnostics.py` *(fails: SyntheticDiagnostics.parse_obj missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bb681c1c832a9a8983fa3ffd5b28