### PR TITLE
feat: add nodal assembly for distributed circuits

### DIFF
--- a/src/dpf2/circuit/distributed.py
+++ b/src/dpf2/circuit/distributed.py
@@ -159,44 +159,69 @@ def assemble_matrices(
     switches: Sequence[TriggeredSwitch] | None = None,
     t: float = 0.0,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Assemble diagonal ``R``, ``L`` and ``C`` matrices for a network.
+    """Assemble node based ``R``, ``L`` and ``C`` matrices for a network.
 
-    The matrices simply contain the total values of each element on their
-    diagonals.  They are primarily a convenience for the unit tests and mimic a
-    very small subset of the behaviour of the real solver where a more complex
-    topology would be handled.
+    The original implementation used simple diagonal matrices assuming all
+    elements were connected in series.  For the extended exercises we need to be
+    able to handle arbitrary connectivity, branched networks and multiple
+    switches.  The matrices returned by this function therefore follow a very
+    small nodal analysis scheme: each two–terminal component stamps its value
+    into the matrices for the nodes it connects.  Kirchhoff's current and
+    voltage laws are implicitly satisfied by adding the value to both node
+    diagonals and subtracting it from the off–diagonal entries.
+
+    The row/column order of the matrices corresponds to the sorted list of all
+    node identifiers appearing in ``segments`` and ``switches``.  Components with
+    zero values simply have no effect on the matrices which keeps the
+    implementation concise while remaining perfectly adequate for the unit
+    tests.
     """
 
-    R_list: List[float] = []
-    L_list: List[float] = []
-    C_list: List[float] = []
+    switches = list(switches or [])
 
+    # Determine mapping from node identifiers to matrix indices
+    nodes = set()
     for seg in segments:
-        L, R, C = seg.totals(t)
-        R_list.append(R)
-        L_list.append(L)
-        C_list.append(C)
+        nodes.add(seg.from_node)
+        nodes.add(seg.to_node)
+    for sw in switches:
+        nodes.add(sw.from_node)
+        nodes.add(sw.to_node)
 
-    if switches:
-        for idx, sw in enumerate(switches):
-            if idx < len(R_list):
-                R_list[idx] += sw.resistance(t)
-                L_list[idx] += sw.L_parasitic
-                C_list[idx] += sw.C_parasitic
-            else:
-                R_list.append(sw.resistance(t))
-                L_list.append(sw.L_parasitic)
-                C_list.append(sw.C_parasitic)
-
-    n = len(R_list)
-    if n == 0:
+    if not nodes:
         return np.zeros((0, 0)), np.zeros((0, 0)), np.zeros((0, 0))
+
+    node_list = sorted(nodes)
+    idx = {node: i for i, node in enumerate(node_list)}
+    n = len(node_list)
 
     R = np.zeros((n, n))
     L = np.zeros((n, n))
     C = np.zeros((n, n))
-    for i in range(n):
-        R[i][i] = R_list[i]
-        L[i][i] = L_list[i]
-        C[i][i] = C_list[i]
+
+    def _stamp(i: int, j: int, value: float, mat: np.ndarray) -> None:
+        """Stamp a two‑terminal component value into ``mat``."""
+
+        if value == 0.0:
+            return
+        mat[i, i] += value
+        mat[j, j] += value
+        mat[i, j] -= value
+        mat[j, i] -= value
+
+    # Stamp transmission line segments
+    for seg in segments:
+        i, j = idx[seg.from_node], idx[seg.to_node]
+        L_val, R_val, C_val = seg.totals(t)
+        _stamp(i, j, R_val, R)
+        _stamp(i, j, L_val, L)
+        _stamp(i, j, C_val, C)
+
+    # Stamp switches (including parasitics)
+    for sw in switches:
+        i, j = idx[sw.from_node], idx[sw.to_node]
+        _stamp(i, j, sw.resistance(t), R)
+        _stamp(i, j, sw.L_parasitic, L)
+        _stamp(i, j, sw.C_parasitic, C)
+
     return R, L, C

--- a/src/dpf2/distributed_circuit.py
+++ b/src/dpf2/distributed_circuit.py
@@ -10,8 +10,13 @@ from .circuit.distributed import (
     TransmissionLineSegment,
     TriggeredSwitch,
     assemble_matrices,
-    Switch,
 )
+
+# Historically the public API exposed ``Switch`` which is now represented by
+# :class:`TriggeredSwitch`.  Provide an explicit alias to maintain backwards
+# compatibility with code importing ``Switch`` from this module or the legacy
+# path ``dpf2.distributed_circuit``.
+Switch = TriggeredSwitch
 
 __all__ = ["TransmissionLineSegment", "TriggeredSwitch", "assemble_matrices", "Switch"]
 

--- a/tests/test_distributed_circuit.py
+++ b/tests/test_distributed_circuit.py
@@ -298,3 +298,14 @@ def test_lumped_vs_distributed_segments_and_energy():
     assert np.isclose(initial, final, rtol=1e-3)
 
 
+def test_switch_alias_import():
+    """Compatibility layer should expose ``Switch`` as an alias."""
+
+    module_path = Path(__file__).resolve().parent.parent / "src/dpf2/distributed_circuit.py"
+    spec = importlib.util.spec_from_file_location("dpf2.distributed_circuit", module_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["dpf2.distributed_circuit"] = mod
+    spec.loader.exec_module(mod)
+
+    assert mod.Switch is mod.TriggeredSwitch
+

--- a/tests/test_triggered_switch.py
+++ b/tests/test_triggered_switch.py
@@ -32,8 +32,54 @@ def test_triggered_switch_and_matrix_assembly():
     R1, _, _ = assemble_matrices([seg], [sw], t=2e-6)
 
     L_expected, R_expected, C_expected = seg.totals()
-    assert np.allclose(L0[0, 0], L_expected)
-    assert np.allclose(C0[0, 0], C_expected)
-    assert np.allclose(R0[0, 0], R_expected + sw.R_on)
-    assert np.allclose(R1[0, 0], R_expected + sw.R_off)
+    on_val = R_expected + sw.R_on
+    off_val = R_expected + sw.R_off
+
+    # Expect a 2x2 nodal matrix with values stamped onto the connected nodes
+    expected_L = np.array([[L_expected, -L_expected], [-L_expected, L_expected]])
+    expected_C = np.array([[C_expected, -C_expected], [-C_expected, C_expected]])
+    expected_R_on = np.array([[on_val, -on_val], [-on_val, on_val]])
+    expected_R_off = np.array([[off_val, -off_val], [-off_val, off_val]])
+
+    assert np.allclose(L0, expected_L)
+    assert np.allclose(C0, expected_C)
+    assert np.allclose(R0, expected_R_on)
+    assert np.allclose(R1, expected_R_off)
+
+
+def test_branching_network_matrix_assembly():
+    """Multiple segments and a switch form a small branched network."""
+
+    seg1 = TransmissionLineSegment(0, 1, length=1.0, L_per_m=1.0, R_per_m=1.0, C_per_m=0.0)
+    seg2 = TransmissionLineSegment(1, 2, length=1.0, L_per_m=0.0, R_per_m=2.0, C_per_m=0.0)
+    sw = TriggeredSwitch(0, 2, closed=True, R_on=5.0, R_off=5.0)
+
+    R, L, C = assemble_matrices([seg1, seg2], [sw], t=0.0)
+
+    # Node order should be [0, 1, 2]
+    R1 = seg1.totals()[1]
+    R2 = seg2.totals()[1]
+    R3 = sw.resistance(0.0)
+
+    expected_R = np.array(
+        [
+            [R1 + R3, -R1, -R3],
+            [-R1, R1 + R2, -R2],
+            [-R3, -R2, R2 + R3],
+        ]
+    )
+
+    L1 = seg1.totals()[0]
+    expected_L = np.array(
+        [
+            [L1, -L1, 0.0],
+            [-L1, L1, 0.0],
+            [0.0, 0.0, 0.0],
+        ]
+    )
+
+    assert R.shape == (3, 3)
+    assert np.allclose(R, expected_R)
+    assert np.allclose(L, expected_L)
+    assert np.allclose(C, np.zeros((3, 3)))
 


### PR DESCRIPTION
## Summary
- build node-based R/L/C matrices using nodal analysis
- expose legacy `Switch` alias for `TriggeredSwitch`
- extend tests for branching networks and alias import

## Testing
- `venv/bin/pytest tests/test_triggered_switch.py tests/test_distributed_circuit.py`

------
https://chatgpt.com/codex/tasks/task_e_68b0cd3c986c832abfdc2003c75b5ac4