### PR TITLE
feat: add verbose simulation diagnostics and plotting

### DIFF
--- a/pydantic_stub.py
+++ b/pydantic_stub.py
@@ -56,6 +56,11 @@ def Field(default=None, **kwargs):  # pragma: no cover - trivial passthrough
 
 ConfigDict = dict
 
+
+class ValidationError(Exception):
+    """Placeholder for :class:`pydantic.ValidationError`."""
+    pass
+
 # ---------------------------------------------------------------------------
 # ``pydantic.dataclasses`` compatibility
 # ---------------------------------------------------------------------------

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -10,7 +10,6 @@ import click
 from dpf2.core.config import DPFConfig
 from dpf2.core.simulation import DPFSimulation
 from dpf2.exceptions import ConfigurationError, SimulationRuntimeError
-from .validate import run_validation
 
 logger = logging.getLogger(__name__)
 
@@ -23,12 +22,36 @@ def main() -> None:
 @main.command()
 @click.option("-c", "--config", type=click.Path(exists=False), help="Path to config file")
 @click.option("-o", "--output", type=click.Path(), default="output", help="Output directory")
-def simulate(config: str | None, output: str) -> None:
+@click.option("--verbose", is_flag=True, help="Report solver progress and energy diagnostics")
+def simulate(config: str | None, output: str, verbose: bool) -> None:
     """Run a DPF simulation."""
     try:
+        if verbose:
+            logging.basicConfig(level=logging.INFO)
         cfg = DPFConfig.from_file(config) if config else DPFConfig()
         sim = DPFSimulation(cfg)
-        sim.run(output_dir=output)
+        times, currents, voltages = sim.run(output_dir=output, verbose=verbose)
+
+        try:
+            import matplotlib.pyplot as plt
+
+            plt.figure()
+            plt.plot(times, currents, label="current")
+            if voltages:
+                plt.plot(times, voltages, label="voltage")
+            plt.xlabel("time [s]")
+            plt.legend()
+            plt.tight_layout()
+            quicklook = Path(output) / "quicklook.png"
+            plt.savefig(quicklook)
+            try:  # pragma: no cover - interactive plot optional
+                plt.show()
+            except Exception:
+                pass
+            click.echo(f"Plot written to {quicklook}")
+        except Exception as e:  # pragma: no cover - plotting optional
+            if verbose:
+                click.echo(f"Plotting failed: {e}")
     except ConfigurationError as e:
         logger.error("Configuration error: %s", e)
         raise click.ClickException(f"Configuration error: {e}")
@@ -46,6 +69,7 @@ def simulate(config: str | None, output: str) -> None:
 @click.option("--outdir", type=click.Path(file_okay=False), default="validation")
 def validate(config: str, dataset: str, outdir: str) -> None:
     """Run a validation simulation and compare with experimental data."""
+    from .validate import run_validation
     try:
         ok = run_validation(Path(config), dataset, outdir=Path(outdir))
         if not ok:
@@ -118,14 +142,24 @@ def wizard(output: str) -> None:
 
     # --- Device size -------------------------------------------------
     click.echo("Device geometry:")
+    click.echo("  Electrode dimensions set the physical scale of the device.")
     cathode_radius = click.prompt(
-        "Cathode radius [m]", type=float, default=defaults.cathode_radius, show_default=True
+        "Cathode radius [m]",
+        type=click.FloatRange(1e-3, 1.0),
+        default=defaults.cathode_radius,
+        show_default=True,
     )
     anode_radius = click.prompt(
-        "Anode radius [m]", type=float, default=defaults.anode_radius, show_default=True
+        "Anode radius [m] (must exceed cathode radius)",
+        type=click.FloatRange(1e-3, 1.0),
+        default=defaults.anode_radius,
+        show_default=True,
     )
     electrode_length = click.prompt(
-        "Electrode length [m]", type=float, default=defaults.electrode_length, show_default=True
+        "Electrode length [m]",
+        type=click.FloatRange(1e-3, 2.0),
+        default=defaults.electrode_length,
+        show_default=True,
     )
 
     # --- Fill gas ----------------------------------------------------
@@ -133,7 +167,7 @@ def wizard(output: str) -> None:
     gas_type = click.prompt("Fill gas", type=str, default=defaults.gas_type, show_default=True)
     initial_pressure = click.prompt(
         "Initial pressure [Pa]",
-        type=float,
+        type=click.FloatRange(1.0, None),
         default=defaults.initial_pressure,
         show_default=True,
     )
@@ -143,25 +177,25 @@ def wizard(output: str) -> None:
     click.echo("Capacitor bank and wiring values influence current rise.")
     capacitance = click.prompt(
         "Capacitance [F]",
-        type=float,
+        type=click.FloatRange(1e-9, None),
         default=defaults.capacitance,
         show_default=True,
     )
     inductance = click.prompt(
         "Inductance [H]",
-        type=float,
+        type=click.FloatRange(1e-9, None),
         default=defaults.inductance,
         show_default=True,
     )
     resistance = click.prompt(
         "Resistance [Ohm]",
-        type=float,
+        type=click.FloatRange(0.0, None),
         default=defaults.resistance,
         show_default=True,
     )
     charging_voltage = click.prompt(
         "Charging voltage [V]",
-        type=float,
+        type=click.FloatRange(1.0, None),
         default=defaults.charging_voltage,
         show_default=True,
     )
@@ -172,25 +206,25 @@ def wizard(output: str) -> None:
         click.echo("\nMesh and solver controls:")
         advanced_cfg["nr_cells"] = click.prompt(
             "Radial cells",
-            type=int,
+            type=click.IntRange(1, 10000),
             default=defaults.nr_cells,
             show_default=True,
         )
         advanced_cfg["nz_cells"] = click.prompt(
             "Axial cells",
-            type=int,
+            type=click.IntRange(1, 10000),
             default=defaults.nz_cells,
             show_default=True,
         )
         advanced_cfg["cfl_number"] = click.prompt(
             "CFL number",
-            type=float,
+            type=click.FloatRange(0.0, 1.0),
             default=defaults.cfl_number,
             show_default=True,
         )
         advanced_cfg["end_time"] = click.prompt(
             "Simulation end time [s]",
-            type=float,
+            type=click.FloatRange(0.0, None),
             default=defaults.end_time,
             show_default=True,
         )

--- a/src/dpf2/core/simulation.py
+++ b/src/dpf2/core/simulation.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+import logging
 
 from ..mesh import Mesh2D
 from .config import DPFConfig
 from ..io.data_writer import DataWriter
+
+logger = logging.getLogger(__name__)
 
 
 class DPFSimulation:
@@ -46,7 +49,8 @@ class DPFSimulation:
         end_time: float | None = None,
         output_dir: str | None = None,
         output_interval: float | None = None,
-    ) -> None:
+        verbose: bool = False,
+    ) -> tuple[list[float], list[float], list[float]]:
         """Advance the simulation until ``end_time``.
 
         Parameters
@@ -58,6 +62,14 @@ class DPFSimulation:
         output_interval:
             Time between data dumps.  Defaults to ``end_time`` (only final
             state).
+        verbose:
+            If ``True`` prints progress and simple energy diagnostics.
+
+        Returns
+        -------
+        (times, currents, voltages): tuple[list[float], list[float], list[float]]
+            Time history of the main circuit quantities for quick-look plotting
+            or diagnostics.
         """
 
         end = end_time or self.config.end_time
@@ -70,6 +82,10 @@ class DPFSimulation:
         # Write initial state
         self.writer.write_hdf5({"current": self.current, "voltage": self.voltage}, time=self.time)
         last_output = self.time
+
+        times = [self.time]
+        currents = [self.current]
+        voltages = [self.voltage]
 
         while self.time < end:
             dt = min(
@@ -94,9 +110,21 @@ class DPFSimulation:
 
             self.time += dt
 
+            times.append(self.time)
+            currents.append(self.current)
+            voltages.append(self.voltage)
+
+            if verbose:
+                energy = 0.5 * self.config.capacitance * self.voltage**2 + 0.5 * self.config.inductance * self.current**2
+                logger.info(
+                    "t=%g s I=%g A V=%g V energy=%g J", self.time, self.current, self.voltage, energy
+                )
+
             if (self.time - last_output) >= interval or self.time >= end:
                 self.writer.write_hdf5(
                     {"current": self.current, "voltage": self.voltage},
                     time=self.time,
                 )
                 last_output = self.time
+
+        return times, currents, voltages

--- a/tests/test_cli_simulate.py
+++ b/tests/test_cli_simulate.py
@@ -32,8 +32,10 @@ def test_simulate_accepts_short_flags(monkeypatch, tmp_path):
         def __init__(self, cfg):
             captured["cfg"] = cfg
 
-        def run(self, output_dir):
+        def run(self, output_dir, verbose=False):
             captured["output"] = output_dir
+            captured["verbose"] = verbose
+            return [0.0], [0.0], [0.0]
 
     monkeypatch.setattr(cli_main.DPFConfig, "from_file", staticmethod(fake_from_file), raising=False)
     monkeypatch.setattr(cli_main, "DPFSimulation", DummySim)


### PR DESCRIPTION
## Summary
- add `--verbose` option and quicklook plotting to `simulate`
- log solver progress and energy diagnostics
- add range-checked, documented wizard prompts

## Testing
- `pytest -q` *(fails: ImportError: missing optional dependencies)*
- `pytest tests/test_cli_simulate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0cd414a20832aa1f16a9b94474deb