### PR TITLE
Add mutual inductance coupling and synthetic diagnostic CLI

### DIFF
--- a/src/dpf2/circuit_solver.py
+++ b/src/dpf2/circuit_solver.py
@@ -164,11 +164,13 @@ class CircuitSolver:
 
         Lp = coupling.Lp
         emf = coupling.emf
+        M = coupling.mutual_inductance
 
         Ltot = self.circuit.L + Lp
         num = self.circuit.V0 - self.circuit.R * current - voltage - emf - back_emf
         dIdt = num / Ltot
         dVdt = -current / self.circuit.C
+        back_reaction = M * dIdt if M != 0.0 else coupling.back_reaction
 
         new_current = current + dIdt * dt
         new_voltage = voltage + dVdt * dt
@@ -184,7 +186,14 @@ class CircuitSolver:
                 inductive=0.5 * Ltot * new_current**2,
             )
 
-        return CouplingState(Lp=Lp, emf=emf, current=new_current, voltage=new_voltage)
+        return CouplingState(
+            Lp=Lp,
+            emf=emf,
+            current=new_current,
+            voltage=new_voltage,
+            mutual_inductance=M,
+            back_reaction=back_reaction,
+        )
 
 
 def _profile_to_interp(profile, t_scale: float, y_scale: float):

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -9,8 +9,15 @@ import click
 
 from dpf2.core.config import DPFConfig
 from dpf2.core.simulation import DPFSimulation
+from dpf2.core.bases import CouplingState
+from dpf2.diagnostics.synthetic_signals import (
+    current_waveform,
+    voltage_waveform,
+    rogowski_signal,
+    bdot_signal,
+)
+from dpf2.synthetic_diagnostics import SyntheticDiagnostics
 from dpf2.exceptions import ConfigurationError, SimulationRuntimeError
-from .validate import run_validation
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +54,8 @@ def simulate(config: str | None, output: str) -> None:
 def validate(config: str, dataset: str, outdir: str) -> None:
     """Run a validation simulation and compare with experimental data."""
     try:
+        from .validate import run_validation
+
         ok = run_validation(Path(config), dataset, outdir=Path(outdir))
         if not ok:
             raise click.ClickException("Validation failed")
@@ -87,6 +96,68 @@ def plot(input: str, output: str) -> None:
     plt.tight_layout()
     plt.savefig(output)
     click.echo(f"Plot written to {output}")
+
+
+@main.command()
+@click.option(
+    "--history",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="JSON file containing a list of CouplingState dictionaries",
+)
+@click.option(
+    "--config",
+    type=click.Path(exists=True, dir_okay=False),
+    required=False,
+    help="Optional synthetic diagnostics configuration JSON",
+)
+@click.option("--current", is_flag=True, help="Output current waveform")
+@click.option("--voltage", is_flag=True, help="Output voltage waveform")
+@click.option("--rogowski", is_flag=True, help="Output Rogowski signal")
+@click.option("--bdot", is_flag=True, help="Output B-dot signal")
+@click.option("--dt", type=float, default=1e-9, help="Time step for derivatives [s]")
+@click.option(
+    "--radius", type=float, default=0.01, help="Probe radius for B-dot signal [m]"
+)
+def diagnostics(
+    history: str,
+    config: str | None,
+    current: bool,
+    voltage: bool,
+    rogowski: bool,
+    bdot: bool,
+    dt: float,
+    radius: float,
+) -> None:
+    """Generate synthetic diagnostics from a coupling history."""
+
+    data = json.loads(Path(history).read_text())
+    states = [CouplingState(**d) for d in data]
+
+    outputs: dict[str, list[float]] = {}
+
+    if config:
+        cfg_data = json.loads(Path(config).read_text())
+        cfg = SyntheticDiagnostics.model_validate(cfg_data)
+        if cfg.synthetic_current_waveform_enabled:
+            outputs["current"] = current_waveform(states)
+        if cfg.synthetic_voltage_waveform_enabled:
+            outputs["voltage"] = voltage_waveform(states)
+        if cfg.synthetic_rogowski_signal_enabled:
+            outputs["rogowski"] = rogowski_signal(states, dt)
+        if cfg.synthetic_bdot_signal_enabled:
+            outputs["bdot"] = bdot_signal(states, radius, dt)
+
+    if current:
+        outputs["current"] = current_waveform(states)
+    if voltage:
+        outputs["voltage"] = voltage_waveform(states)
+    if rogowski:
+        outputs["rogowski"] = rogowski_signal(states, dt)
+    if bdot:
+        outputs["bdot"] = bdot_signal(states, radius, dt)
+
+    click.echo(json.dumps(outputs))
 
 
 @main.command()

--- a/src/dpf2/core/bases.py
+++ b/src/dpf2/core/bases.py
@@ -21,23 +21,38 @@ class CouplingState:
     current, voltage:
         Circuit current and capacitor voltage supplied to the plasma
         solver for advancing its state.
+    mutual_inductance:
+        Effective mutual inductance linking the plasma and external
+        circuit (Henries).
+    back_reaction:
+        Voltage induced on the circuit due to plasma motion or other
+        back‑reaction effects (Volts).
     """
 
     Lp: float = 0.0
     emf: float = 0.0
     current: float = 0.0
     voltage: float = 0.0
+    mutual_inductance: float = 0.0
+    back_reaction: float = 0.0
 
-    def as_tuple(self) -> Tuple[float, float, float, float]:
-        """Return the state as ``(Lp, emf, current, voltage)`` tuple.
+    def as_tuple(self) -> Tuple[float, float, float, float, float, float]:
+        """Return the state as ``(Lp, emf, current, voltage, M, V_br)`` tuple.
 
-        This helper simplifies unpacking when a solver prefers positional
-        access.  The method is intentionally lightweight to keep the
-        ``CouplingState`` dataclass as a minimal container for exchanged
-        quantities.
+        The final two values correspond to the mutual inductance ``M`` and
+        back‑reaction voltage ``V_br``.  ``as_tuple`` is primarily a
+        convenience helper for lightweight solvers that prefer positional
+        access to the coupling terms.
         """
 
-        return self.Lp, self.emf, self.current, self.voltage
+        return (
+            self.Lp,
+            self.emf,
+            self.current,
+            self.voltage,
+            self.mutual_inductance,
+            self.back_reaction,
+        )
 
 
 class PlasmaSolverBase(ABC):

--- a/src/dpf2/core/circuit.py
+++ b/src/dpf2/core/circuit.py
@@ -113,7 +113,14 @@ class RLCCircuitSolver(CircuitSolverBase):
         self.currents.append(new_current)
         self.voltages.append(new_voltage)
 
-        return CouplingState(Lp=Lp, emf=emf, current=new_current, voltage=new_voltage)
+        return CouplingState(
+            Lp=Lp,
+            emf=emf,
+            current=new_current,
+            voltage=new_voltage,
+            mutual_inductance=M,
+            back_reaction=V_mutual,
+        )
 
 
 __all__ = ["RLCCircuitSolver"]

--- a/src/dpf2/core/external_circuit.py
+++ b/src/dpf2/core/external_circuit.py
@@ -29,12 +29,21 @@ class ExternalCircuit(CircuitSolverBase):
         Lp = coupling.Lp
         emf = coupling.emf
         current = coupling.current
+        M = coupling.mutual_inductance
+        back_reaction = coupling.back_reaction
 
         Ltot = self.inductance + Lp
         dI = (back_emf - emf) * dt / max(Ltot, 1.0e-30)
         self.current = current + dI
         self.inductance = Ltot
-        return CouplingState(Lp=Lp, emf=emf, current=self.current, voltage=back_emf)
+        return CouplingState(
+            Lp=Lp,
+            emf=emf,
+            current=self.current,
+            voltage=back_emf,
+            mutual_inductance=M,
+            back_reaction=back_reaction,
+        )
 
 
 __all__ = ["ExternalCircuit"]

--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -13,6 +13,8 @@ from .scope_trace import compute_scope_trace
 from .synthetic_signals import (
     current_waveform,
     voltage_waveform,
+    coupled_current_waveform,
+    coupled_voltage_waveform,
     rogowski_signal,
     bdot_signal,
 )
@@ -23,6 +25,8 @@ __all__ = [
     "compute_scope_trace",
     "current_waveform",
     "voltage_waveform",
+    "coupled_current_waveform",
+    "coupled_voltage_waveform",
     "rogowski_signal",
     "bdot_signal",
 ]

--- a/src/dpf2/diagnostics/synthetic_signals.py
+++ b/src/dpf2/diagnostics/synthetic_signals.py
@@ -26,6 +26,22 @@ def voltage_waveform(history: Iterable[CouplingState]) -> List[float]:
     return [float(state.voltage) for state in history]
 
 
+def coupled_current_waveform(history: Iterable[CouplingState]) -> List[float]:
+    """Return current including simple back-reaction term.
+
+    The ``CouplingState.back_reaction`` value is interpreted as a voltage
+    contribution which is scaled by unity for this synthetic diagnostic.
+    """
+
+    return [float(state.current + state.back_reaction) for state in history]
+
+
+def coupled_voltage_waveform(history: Iterable[CouplingState]) -> List[float]:
+    """Return voltage including mutual inductance contribution."""
+
+    return [float(state.voltage + state.mutual_inductance) for state in history]
+
+
 def rogowski_signal(history: Iterable[CouplingState], dt: float) -> List[float]:
     """Compute a synthetic Rogowski coil signal ``dI/dt``."""
 
@@ -55,6 +71,8 @@ def bdot_signal(history: Iterable[CouplingState], radius: float, dt: float) -> L
 __all__ = [
     "current_waveform",
     "voltage_waveform",
+    "coupled_current_waveform",
+    "coupled_voltage_waveform",
     "rogowski_signal",
     "bdot_signal",
 ]

--- a/src/dpf2/physics/hall_mhd.py
+++ b/src/dpf2/physics/hall_mhd.py
@@ -120,7 +120,13 @@ class HallMHD(ResistiveMHD):
         # accounted for via ``emf`` above.
         self.inductance = Lp
         self.back_emf = emf
-        self.circuit_feedback = CouplingState(Lp=Lp, emf=emf, current=self.current)
+        self.circuit_feedback = CouplingState(
+            Lp=Lp,
+            emf=emf,
+            current=self.current,
+            mutual_inductance=0.0,
+            back_reaction=0.0,
+        )
 
         if circuit is not None:
             updated = circuit.step(self.circuit_feedback, 0.0, dt)

--- a/src/dpf2/physics/simple_plasma.py
+++ b/src/dpf2/physics/simple_plasma.py
@@ -40,7 +40,14 @@ class ZeroDPlasma(PlasmaSolverBase):
         Lp, emf = self.inductance_model(self.time, current, voltage)
         self.inductance = Lp
         self.back_emf = emf
-        self.circuit_feedback = CouplingState(Lp=Lp, emf=emf, current=current, voltage=voltage)
+        self.circuit_feedback = CouplingState(
+            Lp=Lp,
+            emf=emf,
+            current=current,
+            voltage=voltage,
+            mutual_inductance=0.0,
+            back_reaction=0.0,
+        )
         return state
 
     # ------------------------------------------------------------------
@@ -50,6 +57,8 @@ class ZeroDPlasma(PlasmaSolverBase):
         return CouplingState(
             Lp=self.circuit_feedback.Lp,
             emf=self.circuit_feedback.emf,
+            mutual_inductance=0.0,
+            back_reaction=0.0,
         )
 
     # ------------------------------------------------------------------

--- a/src/dpf2/plasma_model.py
+++ b/src/dpf2/plasma_model.py
@@ -30,7 +30,12 @@ def advance_plasma_with_circuit(
     plasma.step(state, dt, coupling.current, coupling.voltage)
     fb = plasma.coupling_interface()
     return CouplingState(
-        Lp=fb.Lp, emf=fb.emf, current=coupling.current, voltage=coupling.voltage
+        Lp=fb.Lp,
+        emf=fb.emf,
+        current=coupling.current,
+        voltage=coupling.voltage,
+        mutual_inductance=fb.mutual_inductance,
+        back_reaction=fb.back_reaction,
     )
 
 __all__ = [

--- a/src/dpf2/simulation/circuit.py
+++ b/src/dpf2/simulation/circuit.py
@@ -381,6 +381,7 @@ class CircuitModel:
         voltage = coupling.voltage
         Lp = coupling.Lp
         emf = coupling.emf
+        M = coupling.mutual_inductance
 
         R_tot = self.R0 + self.ESR
         L_tot = self.L0 + self.ESL + self.Ls + Lp
@@ -392,6 +393,7 @@ class CircuitModel:
 
         dIdt = numerator / L_tot if L_tot != 0.0 else 0.0
         dVdt = -current / self.C
+        back_reaction = M * dIdt if M != 0.0 else coupling.back_reaction
 
         new_current = current + dIdt * dt
         new_voltage = voltage + dVdt * dt
@@ -399,7 +401,14 @@ class CircuitModel:
         self.I = new_current
         self.Q = new_voltage * self.C
 
-        return CouplingState(Lp=Lp, emf=emf, current=new_current, voltage=new_voltage)
+        return CouplingState(
+            Lp=Lp,
+            emf=emf,
+            current=new_current,
+            voltage=new_voltage,
+            mutual_inductance=M,
+            back_reaction=back_reaction,
+        )
 
     def _step_rk4(self, state: SimulationState, dt: float) -> float:
         """

--- a/src/pydantic/__init__.py
+++ b/src/pydantic/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses as _dc
 import types as _types
+import sys
 
 
 class BaseModel:
@@ -54,3 +55,10 @@ _dataclasses.dataclass = _dc.dataclass
 
 dataclasses = _types.ModuleType("pydantic.dataclasses")
 dataclasses.dataclass = _dc.dataclass
+sys.modules[__name__ + ".dataclasses"] = dataclasses
+
+
+class ValidationError(Exception):  # pragma: no cover - simple stub
+    """Minimal stand-in for :class:`pydantic.ValidationError`."""
+
+    pass

--- a/tests/test_cli_diagnostics.py
+++ b/tests/test_cli_diagnostics.py
@@ -1,0 +1,25 @@
+import json
+from click.testing import CliRunner
+
+from dpf2.cli.main import diagnostics
+
+
+def test_cli_outputs_current_and_voltage(tmp_path):
+    history = [
+        {"Lp": 0.0, "emf": 0.0, "current": 0.0, "voltage": 1.0},
+        {"Lp": 0.0, "emf": 0.0, "current": 1.0, "voltage": 0.5},
+        {"Lp": 0.0, "emf": 0.0, "current": 2.0, "voltage": 0.0},
+    ]
+    hist_path = tmp_path / "history.json"
+    hist_path.write_text(json.dumps(history))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        diagnostics,
+        ["--history", str(hist_path), "--current", "--voltage"],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["current"] == [0.0, 1.0, 2.0]
+    assert data["voltage"] == [1.0, 0.5, 0.0]
+


### PR DESCRIPTION
## Summary
- track mutual inductance and circuit back-reaction in CouplingState and circuit solvers
- add synthetic diagnostic helpers and expose via `dpf2 diagnostics` CLI command
- provide regression test for CLI current/voltage traces

## Testing
- `pytest -q` *(fails: missing dependencies such as adios2, matplotlib)*
- `pytest tests/test_cli_diagnostics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0cd4be1c0832abe605473f5a0d1da