### PR TITLE
feat(cli): add validation prompts and verbose progress

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
     "numpy",
     "pydantic",
     "scipy",
-    "sympy"
+    "sympy",
+    "tqdm"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ h5py
 numba
 sympy
 werkzeug
+tqdm

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -19,6 +19,33 @@ from dpf2.diagnostics.synthetic_signals import (
 from dpf2.synthetic_diagnostics import SyntheticDiagnostics
 from dpf2.exceptions import ConfigurationError, SimulationRuntimeError
 
+
+def _prompt_with_range(prompt: str, default: float, minimum: float, maximum: float, tip: str) -> float:
+    """Prompt the user for a floating point value within a range.
+
+    Displays ``tip`` whenever the entered value falls outside ``minimum`` and
+    ``maximum`` and reprompts until a valid value is provided.
+    """
+
+    while True:
+        value = click.prompt(prompt, type=float, default=default)
+        if minimum <= value <= maximum:
+            return value
+        click.echo(f"{prompt} must be between {minimum} and {maximum}. {tip}")
+
+
+def _validate_range(name: str, value: float, minimum: float, maximum: float, tip: str) -> float:
+    """Validate that ``value`` lies within the given range.
+
+    Raises ``click.BadParameter`` with a contextual tip on failure.
+    """
+
+    if not (minimum <= value <= maximum):
+        raise click.BadParameter(
+            f"{name} must be between {minimum} and {maximum}. {tip}"
+        )
+    return value
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,15 +57,85 @@ def main() -> None:
 @main.command()
 @click.option("-c", "--config", type=click.Path(exists=False), help="Path to config file")
 @click.option("-o", "--output", type=click.Path(), default="output", help="Output directory")
+@click.option("--voltage", type=float, help="Charging voltage [V]")
+@click.option(
+    "--segment-length",
+    "segment_length",
+    type=float,
+    help="Electrode segment length [m]",
+)
 @click.option("--verbose", is_flag=True, help="Report solver progress and energy diagnostics")
-def simulate(config: str | None, output: str, verbose: bool) -> None:
+def simulate(
+    config: str | None,
+    output: str,
+    voltage: float | None,
+    segment_length: float | None,
+    verbose: bool,
+) -> None:
     """Run a DPF simulation."""
     try:
         if verbose:
             logging.basicConfig(level=logging.INFO)
         cfg = DPFConfig.from_file(config) if config else DPFConfig()
+
+        # Prompt and validate voltage
+        if voltage is None:
+            voltage = _prompt_with_range(
+                "Charging voltage [V]",
+                cfg.charging_voltage,
+                1000.0,
+                100000.0,
+                "Tip: values are in volts; try 15000 for 15 kV.",
+            )
+        else:
+            voltage = _validate_range(
+                "voltage", voltage, 1000.0, 100000.0, "Check the units (volts)."
+            )
+
+        # Prompt and validate segment length
+        if segment_length is None:
+            segment_length = _prompt_with_range(
+                "Segment length [m]",
+                cfg.electrode_length,
+                0.01,
+                1.0,
+                "Tip: specify meters; e.g. 0.1 for 10 cm.",
+            )
+        else:
+            segment_length = _validate_range(
+                "segment length",
+                segment_length,
+                0.01,
+                1.0,
+                "Ensure the length is given in metres.",
+            )
+
+        cfg.charging_voltage = voltage
+        cfg.electrode_length = segment_length
+
         sim = DPFSimulation(cfg)
-        times, currents, voltages = sim.run(output_dir=output, verbose=verbose)
+
+        progress_cb = None
+        pbar = None
+        if verbose:
+            from tqdm import tqdm
+
+            dt0 = cfg.cfl_number * min(sim.mesh.dr, sim.mesh.dz)
+            total_steps = int(cfg.end_time / dt0) + 1 if dt0 > 0 else None
+            pbar = tqdm(total=total_steps, desc="Simulating", unit="step")
+
+            def _update(step: int, time: float) -> None:
+                pbar.update(1)
+                pbar.set_postfix(time=f"{time:.3e}s")
+
+            progress_cb = _update
+
+        times, currents, voltages = sim.run(
+            output_dir=output, verbose=verbose, progress_cb=progress_cb
+        )
+
+        if pbar is not None:
+            pbar.close()
 
         try:
             import matplotlib.pyplot as plt

--- a/src/dpf2/core/simulation.py
+++ b/src/dpf2/core/simulation.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 import logging
 
 from ..mesh import Mesh2D
@@ -50,6 +50,7 @@ class DPFSimulation:
         output_dir: str | None = None,
         output_interval: float | None = None,
         verbose: bool = False,
+        progress_cb: Callable[[int, float], None] | None = None,
     ) -> tuple[list[float], list[float], list[float]]:
         """Advance the simulation until ``end_time``.
 
@@ -87,6 +88,7 @@ class DPFSimulation:
         currents = [self.current]
         voltages = [self.voltage]
 
+        step = 0
         while self.time < end:
             dt = min(
                 self.config.cfl_number * min(self.mesh.dr, self.mesh.dz),
@@ -109,6 +111,7 @@ class DPFSimulation:
                 )
 
             self.time += dt
+            step += 1
 
             times.append(self.time)
             currents.append(self.current)
@@ -119,6 +122,9 @@ class DPFSimulation:
                 logger.info(
                     "t=%g s I=%g A V=%g V energy=%g J", self.time, self.current, self.voltage, energy
                 )
+
+            if progress_cb is not None:
+                progress_cb(step, self.time)
 
             if (self.time - last_output) >= interval or self.time >= end:
                 self.writer.write_hdf5(


### PR DESCRIPTION
## Summary
- add interactive prompts for voltage and segment length with range validation
- show progress bar with step count and time during verbose simulations
- include tqdm dependency

## Testing
- `pytest` *(fails: missing optional dependencies e.g., werkzeug, adios2, scipy)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d0779f90832aae284b552bf194b0