### PR TITLE
Add parallel hooks, streaming diagnostics, and scaling tests

### DIFF
--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -18,6 +18,7 @@ from .synthetic_signals import (
     rogowski_signal,
     bdot_signal,
 )
+from .streaming import NeutronYieldStreamer, XRayEmissionStreamer
 
 __all__ = [
     "compute_neutron_yield",
@@ -29,6 +30,8 @@ __all__ = [
     "coupled_voltage_waveform",
     "rogowski_signal",
     "bdot_signal",
+    "NeutronYieldStreamer",
+    "XRayEmissionStreamer",
 ]
 
 # Compatibility helpers -------------------------------------------------------

--- a/src/dpf2/diagnostics/streaming.py
+++ b/src/dpf2/diagnostics/streaming.py
@@ -1,0 +1,57 @@
+"""Real-time streaming diagnostics for Dense Plasma Focus simulations.
+
+These diagnostics are intentionally lightweight and operate on the
+``CouplingState`` exchanged between circuit and plasma solvers.  Each
+diagnostic accepts a callback which is invoked with ``(time, value)`` for
+streaming to user interfaces or loggers.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from ..core.bases import DiagnosticsBase, CouplingState
+
+
+class NeutronYieldStreamer(DiagnosticsBase):
+    """Stream approximate neutron production rate.
+
+    The model here is intentionally simple and scales with the square of
+    the circuit current.  It is sufficient for testing hooks and
+    real-time visualisation but not for accurate physics predictions.
+    """
+
+    def __init__(self, callback: Callable[[float, float], None]) -> None:
+        self.callback = callback
+        self._total = 0.0
+
+    def record(self, state: CouplingState, time: float) -> None:
+        rate = 1.0e5 * state.current ** 2
+        self._total += rate
+        self.callback(time, rate)
+
+    @property
+    def total_yield(self) -> float:
+        """Return accumulated neutron yield estimate."""
+
+        return self._total
+
+
+class XRayEmissionStreamer(DiagnosticsBase):
+    """Stream simplified X-ray emission power.
+
+    The emission is approximated by ``|I * V|`` scaled to a convenient
+    magnitude.  Users may replace this with a more sophisticated model if
+    desired.
+    """
+
+    def __init__(self, callback: Callable[[float, float], None]) -> None:
+        self.callback = callback
+
+    def record(self, state: CouplingState, time: float) -> None:
+        power = abs(state.current * state.voltage) * 1.0e-3
+        self.callback(time, power)
+
+
+__all__ = ["NeutronYieldStreamer", "XRayEmissionStreamer"]
+

--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -4,16 +4,22 @@ import json
 from dataclasses import dataclass
 
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Sequence
 
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
+
+try:  # pragma: no cover - mpi4py may not be available
+    from mpi4py import MPI  # type: ignore
+except Exception:  # pragma: no cover - gracefully handle missing MPI
+    MPI = None
 
 from .dpf_config import DPFConfig
 from .circuit_config import CircuitConfig
 
 from .circuit_solver import RLCCircuit, CircuitSolver, run_circuit_simulation
-from .core.bases import PlasmaSolverBase, CouplingState
+from .core.bases import PlasmaSolverBase, CouplingState, DiagnosticsBase
 from .pinch_models import (
     AnalyticPinchModel,
     SemiAnalyticPinchModel,
@@ -96,10 +102,37 @@ class EnsembleResults:
 
 
 class SimulationEngine:
-    """Execute a minimal Dense Plasma Focus simulation."""
+    """Execute a minimal Dense Plasma Focus simulation.
 
-    def __init__(self, config: DPFConfig) -> None:
+    Parameters
+    ----------
+    config:
+        Simulation configuration.
+    comm:
+        Optional MPI communicator used for synchronising state across
+        ranks. If not provided, ``MPI.COMM_WORLD`` is used when
+        ``mpi4py`` is available.
+    num_threads:
+        Number of worker threads used for circuit stepping. A value of
+        ``1`` disables multithreading.  These hooks allow heavier
+        simulations to leverage multicore machines without altering the
+        core algorithm.
+    """
+
+    def __init__(
+        self,
+        config: DPFConfig,
+        comm: "MPI.Comm | None" = None,
+        num_threads: int = 1,
+    ) -> None:
         self.config = config.resolve_defaults()
+        # MPI communicator -------------------------------------------------
+        self.comm = comm if comm is not None else (MPI.COMM_WORLD if MPI else None)
+        self.rank = self.comm.Get_rank() if self.comm is not None else 0
+        # Thread pool ------------------------------------------------------
+        self._executor: ThreadPoolExecutor | None = None
+        if num_threads and num_threads > 1:
+            self._executor = ThreadPoolExecutor(max_workers=num_threads)
 
     # ------------------------------------------------------------------
     def _setup_circuit(self) -> CircuitSolver:
@@ -119,7 +152,10 @@ class SimulationEngine:
         pinch_model: str = "analytic",
 
         plasma_solver: PlasmaSolverBase | None = None,
-
+        *,
+        energy_csv: str | None = None,
+        energy_tol: float | None = None,
+        diagnostics: Sequence[DiagnosticsBase] | None = None,
     ) -> SimulationResults:
         sc = self.config.simulation_control
         dt = sc.min_dt or 1e-9
@@ -155,7 +191,23 @@ class SimulationEngine:
         voltage = circuit.voltages[-1]
         while circuit.time[-1] < t_end:
             state = CouplingState(current=current, voltage=voltage)
-            updated = circuit.step(state, 0.0, dt, energy_tracker=tracker)
+            # Optional multithreading for circuit stepping
+            if self._executor is not None:
+                future = self._executor.submit(
+                    circuit.step, state, 0.0, dt, energy_tracker=tracker
+                )
+                updated = future.result()
+            else:
+                updated = circuit.step(state, 0.0, dt, energy_tracker=tracker)
+
+            # Broadcast updated state across MPI ranks if requested
+            if self.comm is not None and (self.comm.size > 1):  # pragma: no cover - MPI
+                updated = self.comm.bcast(updated, root=0)
+
+            if diagnostics:
+                for diag in diagnostics:
+                    diag.record(updated, circuit.time[-1])
+
             current, voltage = updated.current, updated.voltage
 
         t = np.array(circuit.time)

--- a/tests/performance/test_scaling.py
+++ b/tests/performance/test_scaling.py
@@ -1,0 +1,68 @@
+"""Basic performance regression tests for simulation scaling."""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from concurrent.futures import ThreadPoolExecutor
+
+from dpf2.dpf_config import DPFConfig
+from dpf2.simulation_engine import SimulationEngine
+
+
+def _make_config(time_end: float) -> DPFConfig:
+    cfg = DPFConfig.with_defaults()
+    sc = cfg.simulation_control.model_copy(update={"time_end": time_end})
+    return cfg.model_copy(update={"simulation_control": sc})
+
+
+def test_problem_size_scaling():
+    """Larger problems should take at least as long as smaller ones."""
+
+    small_cfg = _make_config(1e-7)
+    large_cfg = _make_config(5e-7)
+
+    start = time.perf_counter()
+    SimulationEngine(small_cfg).run()
+    small_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    SimulationEngine(large_cfg).run()
+    large_time = time.perf_counter() - start
+
+    assert large_time >= small_time
+
+
+def test_thread_scaling_consistency():
+    """Threaded execution should produce the same result as serial."""
+
+    cfg = _make_config(5e-7)
+    serial = SimulationEngine(cfg, num_threads=1).run()
+    threaded = SimulationEngine(cfg, num_threads=2).run()
+
+    assert np.allclose(serial.current, threaded.current)
+
+
+def test_parallel_speedup():
+    """Running two simulations in parallel should not be slower than serial."""
+
+    cfg = _make_config(5e-7)
+
+    def run():
+        SimulationEngine(cfg).run()
+
+    start = time.perf_counter()
+    for _ in range(2):
+        run()
+    serial_time = time.perf_counter() - start
+
+    start = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=2) as ex:
+        list(ex.map(lambda _: run(), range(2)))
+    parallel_time = time.perf_counter() - start
+
+    # Allow some leeway for scheduling noise
+    assert parallel_time <= serial_time * 1.5
+


### PR DESCRIPTION
## Summary
- add MPI and threading hooks to `SimulationEngine` to enable parallel stepping and streaming diagnostics
- provide real-time neutron yield and X-ray emission streamers based on `CouplingState`
- include basic performance regression tests covering problem-size and thread scaling

## Testing
- `pytest tests/test_simulation_engine.py::test_engine_runs -q` *(fails: type object 'GridResolution' has no attribute 'parse_obj')*
- `pip install pydantic==1.10.8` *(fails: Could not find a version that satisfies the requirement pydantic==1.10.8)*
- `python -m py_compile src/dpf2/simulation_engine.py src/dpf2/diagnostics/streaming.py tests/performance/test_scaling.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0d635745c832ab2efec78170ccb02