### PR TITLE
Add telegrapher-based transmission line analysis

### DIFF
--- a/src/dpf2/circuit/distributed.py
+++ b/src/dpf2/circuit/distributed.py
@@ -25,6 +25,8 @@ from dataclasses import dataclass, field
 from typing import Iterable, Sequence, List
 
 import numpy as np
+import math
+import cmath
 
 __all__ = ["TransmissionLineSegment", "TriggeredSwitch", "assemble_matrices"]
 
@@ -89,6 +91,7 @@ class TransmissionLineSegment:
     C_profile: Sequence[tuple[float, float]] | None = None
     propagation_velocity: float | None = None
     skin_effect_coeff: float = 0.0
+    dielectric_loss_coeff: float = 0.0
 
     def delay(self) -> float:
         """Return propagation delay for this segment in seconds."""
@@ -97,19 +100,69 @@ class TransmissionLineSegment:
             return self.length / self.propagation_velocity
         return 0.0
 
-    def totals(self, t: float = 0.0, frequency: float | None = None) -> tuple[float, float, float]:
+    def totals(self, t: float = 0.0, frequency: float | None = None) -> tuple[float, float, float | complex]:
         """Return the total ``(L, R, C)`` for this segment.
 
-        ``frequency`` can be provided to account for a simple skin effect model
-        where the resistive component increases with ``sqrt(frequency)``.
+        ``frequency`` can be provided to account for frequency dependant skin
+        effect resistance and dielectric losses.  When ``frequency`` is given the
+        returned capacitance may be complex to model dielectric loss via a loss
+        tangent.  The simplistic models here are sufficient for the unit tests
+        and mirror the behaviour of the real application only qualitatively.
         """
 
         L = self.L_per_m * self.length + self.L_parasitic + _interp_profile(self.L_profile, t)
         R = self.R_per_m * self.length + self.R_parasitic + _interp_profile(self.R_profile, t)
         if frequency is not None and self.skin_effect_coeff:
-            R += self.skin_effect_coeff * self.length * float(np.sqrt(frequency))
+            R += self.skin_effect_coeff * self.length * float(math.sqrt(frequency))
         C = self.C_per_m * self.length + self.C_parasitic + _interp_profile(self.C_profile, t)
+        if frequency is not None and self.dielectric_loss_coeff:
+            loss_tan = self.dielectric_loss_coeff * float(math.sqrt(frequency))
+            C = complex(C) * (1.0 - 1j * loss_tan)
         return L, R, C
+
+    # ------------------------------------------------------------------
+    # Frequency domain helpers
+
+    def _params_at_freq(self, frequency: float) -> tuple[float, float, float, float]:
+        """Return per-unit ``(R, L, C, G)`` accounting for dispersion models."""
+
+        w = 2.0 * np.pi * frequency
+        R = self.R_per_m
+        if self.skin_effect_coeff:
+            R += self.skin_effect_coeff * float(math.sqrt(frequency))
+        L = self.L_per_m
+        C = self.C_per_m
+        G = 0.0
+        if self.dielectric_loss_coeff:
+            loss_tan = self.dielectric_loss_coeff * float(math.sqrt(frequency))
+            G = w * C * loss_tan
+        return R, L, C, G
+
+    def propagation_constant(self, frequency: float) -> complex:
+        """Return the complex propagation constant ``gamma`` at ``frequency``."""
+
+        w = 2.0 * np.pi * frequency
+        R, L, C, G = self._params_at_freq(frequency)
+        return cmath.sqrt((R + 1j * w * L) * (G + 1j * w * C))
+
+    def characteristic_impedance(self, frequency: float) -> complex:
+        """Return the characteristic impedance at ``frequency``."""
+
+        w = 2.0 * np.pi * frequency
+        R, L, C, G = self._params_at_freq(frequency)
+        return cmath.sqrt((R + 1j * w * L) / (G + 1j * w * C))
+
+    def reflection_coefficient(self, frequency: float, Z_load: float | complex | None) -> complex:
+        """Return the reflection coefficient for a load ``Z_load``.
+
+        ``Z_load`` may be ``None`` or ``np.inf`` to model an open circuit.
+        """
+
+        Z0 = self.characteristic_impedance(frequency)
+        if Z_load is None or Z_load == np.inf:
+            return 1.0 + 0.0j
+        ZL = complex(Z_load)
+        return (ZL - Z0) / (ZL + Z0)
 
 
 @dataclass

--- a/src/dpf2/rlc_solver.py
+++ b/src/dpf2/rlc_solver.py
@@ -20,6 +20,7 @@ from typing import Sequence
 # ``numpy`` may be replaced by a light‑weight stub in the test environment but
 # it provides the minimal functionality used below (``array``).
 import numpy as np
+import cmath
 
 from .circuit.distributed import TransmissionLineSegment, TriggeredSwitch, assemble_matrices
 
@@ -70,31 +71,38 @@ def solve_distributed_circuit(
 
     switches = list(switches or [])
 
-    # Simplified analytic handling for pure transmission line problems.  If a
-    # ``frequency`` is supplied and all segments define a propagation velocity we
-    # treat the network as a cascade of delay lines with optional attenuation due
-    # to a very small skin‑effect resistance model.  This path is primarily used
-    # in regression tests and bypasses the general time domain solver.
-    if frequency is not None and segments and all(seg.propagation_velocity for seg in segments):
+    # Simplified frequency domain solution for cascaded transmission line
+    # segments.  When ``frequency`` is supplied we evaluate the telegrapher
+    # equations for each segment and assume the line is matched to avoid
+    # reflections.  The output voltage therefore only experiences the combined
+    # attenuation and phase delay described by the propagation constants of all
+    # segments.  This path is primarily used in unit tests and bypasses the more
+    # involved time domain solver.
+    if frequency is not None and segments:
         w = 2.0 * np.pi * frequency
         n_steps = int(t_end / dt) + 1
         t = np.array([i * dt for i in range(n_steps)])
         vin = np.array([np.sin(w * ti) for ti in t]) * V0
-        total_delay = sum(seg.delay() for seg in segments)
-        attenuation = 1.0
-        total_R = 0.0
+
+        gamma_total = 0.0 + 0.0j
         for seg in segments:
-            if seg.skin_effect_coeff:
-                attenuation *= np.exp(-seg.skin_effect_coeff * seg.length * np.sqrt(frequency))
-            total_R += seg.R_per_m * seg.length + seg.R_parasitic
-            if seg.skin_effect_coeff:
-                total_R += seg.skin_effect_coeff * seg.length * np.sqrt(frequency)
-        vout = np.array([np.sin(w * (ti - total_delay)) for ti in t]) * (attenuation * V0)
+            gamma_total += seg.propagation_constant(frequency) * seg.length
+
+        H = cmath.exp(-gamma_total)
+        amp = abs(H)
+        phase = cmath.phase(H)
+        vout = np.array([np.sin(w * ti + phase) for ti in t]) * (amp * V0)
+
         node_voltages = np.zeros((len(t), 2))
         node_voltages[:, 0] = vin
         node_voltages[:, 1] = vout
-        current = (vin - vout) / (total_R if total_R != 0 else 1e-12)
+
+        Zin = segments[0].characteristic_impedance(frequency)
+        I_amp = V0 / (abs(Zin) if Zin != 0 else 1e-12)
+        I_phase = -cmath.phase(Zin)
+        current = np.array([np.sin(w * ti + I_phase) for ti in t]) * I_amp
         branch_currents = current[:, None]
+
         return DistributedRLCSolution(
             t=t,
             current=current,

--- a/tests/test_distributed_circuit.py
+++ b/tests/test_distributed_circuit.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import importlib.util
 import types
 import numpy as np
+import cmath
+import math
 import pytest
 
 # Load CircuitModel without importing the full dpf2 package
@@ -344,32 +346,74 @@ def test_branched_network_current_split_and_energy():
     assert np.isclose(initial, final, rtol=1e-3)
 
 
-def test_transmission_line_phase_delay_and_skin_attenuation():
+def test_transmission_line_phase_and_attenuation_across_frequencies():
     seg = TransmissionLineSegment(
         0,
         1,
-        length=10.0,
-        L_per_m=0.0,
-        R_per_m=0.0,
-        C_per_m=0.0,
-        propagation_velocity=1e8,
+        length=1.0,
+        L_per_m=1e-6,
+        R_per_m=1e-3,
+        C_per_m=1e-9,
         skin_effect_coeff=1e-3,
+        dielectric_loss_coeff=1e-4,
     )
 
     f1 = 1e6
+    f2 = 5e6
     res1 = solve_distributed_circuit([seg], None, V0=1.0, t_end=5e-6, dt=1e-8, frequency=f1)
-    f2 = 4e6
     res2 = solve_distributed_circuit([seg], None, V0=1.0, t_end=5e-6, dt=1e-8, frequency=f2)
 
-    amp1 = max(res1.node_voltages[:, 1])
-    amp2 = max(res2.node_voltages[:, 1])
-    exp1 = np.exp(-seg.skin_effect_coeff * seg.length * np.sqrt(f1))
-    exp2 = np.exp(-seg.skin_effect_coeff * seg.length * np.sqrt(f2))
-    assert np.isclose(amp1, exp1, rtol=1e-3)
-    assert np.isclose(amp2, exp2, rtol=1e-3)
+    def _measure(res, freq):
+        vals_out = [row[1] for row in res.node_voltages]
+        vals_in = [row[0] for row in res.node_voltages]
+        amp = (max(vals_out) - min(vals_out)) / 2.0
+        period = int((1.0 / freq) / (res.t[1] - res.t[0]))
+        vals_in_period = vals_in[:period]
+        vals_out_period = vals_out[:period]
+        idx_in = max(range(len(vals_in_period)), key=lambda i: vals_in_period[i])
+        idx_out = max(range(len(vals_out_period)), key=lambda i: vals_out_period[i])
+        delay = res.t[idx_out] - res.t[idx_in]
+        phase = -2.0 * np.pi * freq * delay
+        return amp, phase
 
-    idx_in = max(range(len(res1.t)), key=lambda i: res1.node_voltages[i, 0])
-    idx_out = max(range(len(res1.t)), key=lambda i: res1.node_voltages[i, 1])
-    delay_meas = res1.t[idx_out] - res1.t[idx_in]
-    assert np.isclose(delay_meas, seg.delay(), rtol=1e-3, atol=res1.t[1] - res1.t[0])
+    amp1, phase1 = _measure(res1, f1)
+    amp2, phase2 = _measure(res2, f2)
+
+    H1 = cmath.exp(-seg.propagation_constant(f1) * seg.length)
+    H2 = cmath.exp(-seg.propagation_constant(f2) * seg.length)
+    assert np.isclose(amp1, abs(H1), rtol=1e-2)
+    assert np.isclose(amp2, abs(H2), rtol=1e-2)
+    assert np.isclose(phase1, cmath.phase(H1), rtol=1e-2, atol=2e-2)
+    assert np.isclose(phase2, cmath.phase(H2), rtol=1e-2, atol=1e-1)
+
+
+def test_reflection_coefficient_frequency_dependence():
+    seg = TransmissionLineSegment(
+        0,
+        1,
+        length=1.0,
+        L_per_m=1e-6,
+        R_per_m=1e-3,
+        C_per_m=1e-9,
+        skin_effect_coeff=1e-3,
+        dielectric_loss_coeff=1e-4,
+    )
+    ZL = 75.0
+    f1, f2 = 1e6, 5e6
+    r1 = seg.reflection_coefficient(f1, ZL)
+    r2 = seg.reflection_coefficient(f2, ZL)
+
+    def _manual(freq):
+        w = 2.0 * np.pi * freq
+        R = seg.R_per_m + seg.skin_effect_coeff * math.sqrt(freq)
+        L = seg.L_per_m
+        C = seg.C_per_m
+        loss = seg.dielectric_loss_coeff * math.sqrt(freq)
+        G = w * C * loss
+        Z0 = cmath.sqrt((R + 1j * w * L) / (G + 1j * w * C))
+        return (ZL - Z0) / (ZL + Z0)
+
+    assert abs(r1 - _manual(f1)) < 1e-12
+    assert abs(r2 - _manual(f2)) < 1e-12
+    assert not np.isclose(abs(r1), abs(r2))
 


### PR DESCRIPTION
## Summary
- extend TransmissionLineSegment with frequency-domain telegrapher helpers including skin-depth and dielectric loss models
- apply telegrapher equations in solve_distributed_circuit for phase and attenuation handling
- add tests checking phase shift, attenuation, and reflection coefficients across frequencies

## Testing
- `pytest -q` *(fails: missing optional dependencies such as dpf2.physics and scipy)*
- `pytest tests/test_distributed_circuit.py::test_transmission_line_phase_and_attenuation_across_frequencies -q`
- `pytest tests/test_distributed_circuit.py::test_reflection_coefficient_frequency_dependence -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0db3810b4832ab6f81f3aa7b01f0c