### PR TITLE
feat: add parallel solvers and streaming diagnostics tests

### DIFF
--- a/src/dpf2/plasma_model.py
+++ b/src/dpf2/plasma_model.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 # Backward compatibility wrapper
-from typing import Any
+from typing import Any, Sequence
+from concurrent.futures import ThreadPoolExecutor
 
 from .pinch_models import (
     AnalyticPinchModel,
@@ -67,6 +68,39 @@ def advance_plasma_with_circuit(
         back_reaction=back_reaction,
     )
 
+
+def advance_plasmas_with_circuit(
+    plasmas: Sequence[PlasmaSolverBase],
+    states: Sequence[Any],
+    couplings: Sequence[CouplingState],
+    dt: float,
+    n_threads: int = 1,
+) -> list[CouplingState]:
+    """Advance multiple plasma solvers in parallel.
+
+    Parameters
+    ----------
+    plasmas, states, couplings:
+        Sequences of plasma solvers, their corresponding state objects and
+        coupling states.
+    dt:
+        Timestep in seconds applied to all solvers.
+    n_threads:
+        Number of worker threads to use.  A value of ``1`` executes the
+        updates serially.
+    """
+
+    tasks = list(zip(plasmas, states, couplings))
+
+    def _run(args: tuple[PlasmaSolverBase, Any, CouplingState]) -> CouplingState:
+        p, s, c = args
+        return advance_plasma_with_circuit(p, s, c, dt)
+
+    if n_threads > 1:
+        with ThreadPoolExecutor(max_workers=n_threads) as ex:
+            return list(ex.map(_run, tasks))
+    return [_run(t) for t in tasks]
+
 __all__ = [
     "AnalyticPinchModel",
     "PinchResult",
@@ -75,4 +109,5 @@ __all__ = [
     "ablation_mass_energy_source",
     "insulator_sleeve_area",
     "advance_plasma_with_circuit",
+    "advance_plasmas_with_circuit",
 ]

--- a/src/dpf2/rlc_solver.py
+++ b/src/dpf2/rlc_solver.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Sequence
+from concurrent.futures import ThreadPoolExecutor
 
 # ``numpy`` may be replaced by a light‑weight stub in the test environment but
 # it provides the minimal functionality used below (``array``).
@@ -59,6 +60,7 @@ def solve_distributed_circuit(
     dt: float,
     I0: float = 0.0,
     frequency: float | None = None,
+    n_threads: int = 1,
 ) -> DistributedRLCSolution:
     """Integrate an RLC network using a very small nodal analysis scheme.
 
@@ -141,12 +143,24 @@ def solve_distributed_circuit(
 
     def _update_branch_lists(t: float) -> float:
         branches.clear()
-        for seg in segments:
+
+        def build_branch(seg: TransmissionLineSegment):
             L, R, _ = seg.totals(t, frequency)
             if L == 0.0 and R == 0.0:
-                continue  # pure capacitive branch handled via C matrix
+                return None  # pure capacitive branch handled via C matrix
             delay_steps = int(round(seg.delay() / dt)) if hasattr(seg, "delay") else 0
-            branches.append(_Branch(seg.from_node, seg.to_node, L or 1e-12, R, delay_steps))
+            return _Branch(seg.from_node, seg.to_node, L or 1e-12, R, delay_steps)
+
+        if n_threads > 1:
+            with ThreadPoolExecutor(max_workers=n_threads) as ex:
+                for br in ex.map(build_branch, segments):
+                    if br is not None:
+                        branches.append(br)
+        else:
+            for seg in segments:
+                br = build_branch(seg)
+                if br is not None:
+                    branches.append(br)
         for sw in switches:
             branches.append(
                 _Branch(sw.from_node, sw.to_node, sw.L_parasitic or 1e-12, sw.resistance(t), 0)

--- a/tests/test_parallel_execution.py
+++ b/tests/test_parallel_execution.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+from dpf2.plasma_model import advance_plasma_with_circuit, advance_plasmas_with_circuit
+from dpf2.physics.simple_plasma import ZeroDPlasma
+from dpf2.core.bases import CouplingState
+from dpf2.rlc_solver import solve_distributed_circuit
+from dpf2.circuit.distributed import TransmissionLineSegment
+
+
+def test_parallel_plasma_solver_matches_serial():
+    plasmas = [ZeroDPlasma(lambda t, I, V: (0.0, 0.0)) for _ in range(3)]
+    for p in plasmas:
+        p.coil_radius = 0.1
+    states = [{"radius": 0.05 + 0.01 * i} for i in range(3)]
+    couplings = [CouplingState(current=1.0 + i, voltage=0.0, mutual_inductance=0.0) for i in range(3)]
+    dt = 1e-6
+
+    seq = [
+        advance_plasma_with_circuit(p, s, c, dt)
+        for p, s, c in zip(plasmas, states, couplings)
+    ]
+    par = advance_plasmas_with_circuit(plasmas, states, couplings, dt, n_threads=2)
+
+    for a, b in zip(par, seq):
+        assert a.mutual_inductance == pytest.approx(b.mutual_inductance)
+        assert a.back_reaction == pytest.approx(b.back_reaction)
+
+
+def test_parallel_circuit_solver_matches_serial():
+    segs = [
+        TransmissionLineSegment(0, 1, 1.0, 1e-6, 0.1, 0.0),
+        TransmissionLineSegment(1, 2, 1.0, 1e-6, 0.1, 0.0),
+    ]
+
+    sol1 = solve_distributed_circuit(segs, [], V0=1.0, t_end=1e-6, dt=1e-7, n_threads=1)
+    sol2 = solve_distributed_circuit(segs, [], V0=1.0, t_end=1e-6, dt=1e-7, n_threads=2)
+
+    assert np.allclose(sol1.current, sol2.current)
+    assert np.allclose(sol1.voltage, sol2.voltage)
+

--- a/tests/test_streaming_diagnostics.py
+++ b/tests/test_streaming_diagnostics.py
@@ -1,0 +1,28 @@
+import pytest
+
+from dpf2.diagnostics.streaming import NeutronYieldStreamer, XRayEmissionStreamer
+from dpf2.core.bases import CouplingState
+
+
+def test_streaming_diagnostics_emit_values():
+    neutron_records = []
+    xray_records = []
+
+    n_stream = NeutronYieldStreamer(lambda t, v: neutron_records.append((t, v)))
+    x_stream = XRayEmissionStreamer(lambda t, v: xray_records.append((t, v)))
+
+    state = CouplingState(current=2.0, voltage=3.0)
+
+    n_stream.record(state, 1.0)
+    x_stream.record(state, 1.0)
+
+    assert neutron_records[0][0] == 1.0
+    assert neutron_records[0][1] == pytest.approx(1.0e5 * 4.0)
+
+    assert xray_records[0][0] == 1.0
+    assert xray_records[0][1] == pytest.approx(abs(2.0 * 3.0) * 1.0e-3)
+
+    # total_yield accumulates
+    n_stream.record(state, 2.0)
+    assert n_stream.total_yield == pytest.approx(1.0e5 * 4.0 * 2)
+


### PR DESCRIPTION
## Summary
- compute geometry-based mutual inductance and add threaded batch plasma advance helper
- parallelise distributed circuit solver with optional thread pool
- add tests for neutron/x-ray streaming diagnostics and parallel execution

## Testing
- `venv/bin/python -m pytest tests/test_streaming_diagnostics.py tests/test_parallel_execution.py tests/test_geometry_mutual_inductance.py`
- `venv/bin/python -m pytest` *(fails: module 'numpy' has no attribute 'Array', missing resources in other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b0db4bb800832a85adb7e36241892d