### PR TITLE
Implement full telegrapher solver with reflections

### DIFF
--- a/src/dpf2/rlc_solver.py
+++ b/src/dpf2/rlc_solver.py
@@ -47,6 +47,7 @@ class DistributedRLCSolution:
     voltage: np.ndarray
     branch_currents: np.ndarray
     node_voltages: np.ndarray
+    reflections: np.ndarray | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -61,6 +62,7 @@ def solve_distributed_circuit(
     dt: float,
     I0: float = 0.0,
     frequency: float | None = None,
+    Z_load: float | complex | None = None,
     n_threads: int = 1,
 ) -> DistributedRLCSolution:
     """Integrate an RLC network using a very small nodal analysis scheme.
@@ -69,28 +71,69 @@ def solve_distributed_circuit(
     required by the unit tests.  All capacitors are aggregated into a single
     equivalent element between the first and last nodes.  Inductive branches are
     solved via a linear system enforcing Kirchhoff's current law at each node.
+    When ``frequency`` is provided the solver evaluates the telegrapher
+    equations in the frequency domain for cascaded transmission line segments
+    with an optional terminating ``Z_load``.
     """
 
     switches = list(switches or [])
 
     # Simplified frequency domain solution for cascaded transmission line
-    # segments.  When ``frequency`` is supplied we evaluate the telegrapher
-    # equations for each segment and assume the line is matched to avoid
-    # reflections.  The output voltage therefore only experiences the combined
-    # attenuation and phase delay described by the propagation constants of all
-    # segments.  This path is primarily used in unit tests and bypasses the more
-    # involved time domain solver.
+    # segments.  When ``frequency`` is supplied we evaluate the full telegrapher
+    # equations for each segment allowing mismatched characteristic impedances
+    # and an arbitrary terminating ``Z_load``.  Dispersion models supplied by
+    # :class:`TransmissionLineSegment` are honoured through the frequency
+    # dependant propagation constants and characteristic impedances.  The
+    # solution is obtained via multiplication of ABCD matrices and reflection
+    # coefficients are tracked for each segment.
     if frequency is not None and segments:
         w = 2.0 * np.pi * frequency
         n_steps = int(t_end / dt) + 1
         t = np.array([i * dt for i in range(n_steps)])
         vin = np.array([np.sin(w * ti) for ti in t]) * V0
 
-        gamma_total = 0.0 + 0.0j
-        for seg in segments:
-            gamma_total += seg.propagation_constant(frequency) * seg.length
+        if Z_load is None:
+            ZL = segments[-1].characteristic_impedance(frequency)
+        else:
+            ZL = np.inf if Z_load == np.inf else complex(Z_load)
 
-        H = cmath.exp(-gamma_total)
+        # Reflection coefficients are computed from the load backwards to the
+        # source while the overall ABCD matrix is accumulated from source to
+        # load.
+        reflections: list[complex] = []
+        Z_eff = ZL
+        for seg in reversed(segments):
+            refl = seg.reflection_coefficient(frequency, Z_eff)
+            reflections.insert(0, refl)
+            Z0 = seg.characteristic_impedance(frequency)
+            gamma = seg.propagation_constant(frequency)
+            tanh_gl = cmath.tanh(gamma * seg.length)
+            Z_eff = Z0 * (Z_eff + Z0 * tanh_gl) / (Z0 + Z_eff * tanh_gl)
+
+        A_tot, B_tot, C_tot, D_tot = 1.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 1.0 + 0.0j
+        for seg in segments:
+            gamma = seg.propagation_constant(frequency) * seg.length
+            Z0 = seg.characteristic_impedance(frequency)
+            cosh_gl = cmath.cosh(gamma)
+            sinh_gl = cmath.sinh(gamma)
+            A = cosh_gl
+            B = Z0 * sinh_gl
+            C = (1.0 / Z0) * sinh_gl
+            D = cosh_gl
+            A_tot, B_tot, C_tot, D_tot = (
+                A_tot * A + B_tot * C,
+                A_tot * B + B_tot * D,
+                C_tot * A + D_tot * C,
+                C_tot * B + D_tot * D,
+            )
+
+        if ZL == np.inf:
+            H = 1.0 / A_tot
+            Zin = A_tot / C_tot if C_tot != 0 else np.inf
+        else:
+            H = 1.0 / (A_tot + B_tot / ZL)
+            Zin = (A_tot * ZL + B_tot) / (C_tot * ZL + D_tot)
+
         amp = abs(H)
         phase = cmath.phase(H)
         vout = np.array([np.sin(w * ti + phase) for ti in t]) * (amp * V0)
@@ -99,7 +142,6 @@ def solve_distributed_circuit(
         node_voltages[:, 0] = vin
         node_voltages[:, 1] = vout
 
-        Zin = segments[0].characteristic_impedance(frequency)
         I_amp = V0 / (abs(Zin) if Zin != 0 else 1e-12)
         I_phase = -cmath.phase(Zin)
         current = np.array([np.sin(w * ti + I_phase) for ti in t]) * I_amp
@@ -111,6 +153,7 @@ def solve_distributed_circuit(
             voltage=vin,
             branch_currents=branch_currents,
             node_voltages=node_voltages,
+            reflections=np.array(reflections),
         )
 
     # ------------------------------------------------------------------

--- a/tests/test_distributed_circuit.py
+++ b/tests/test_distributed_circuit.py
@@ -416,4 +416,91 @@ def test_reflection_coefficient_frequency_dependence():
     assert abs(r1 - _manual(f1)) < 1e-12
     assert abs(r2 - _manual(f2)) < 1e-12
     assert not np.isclose(abs(r1), abs(r2))
+def _measure_amp_phase(node_voltages, t, freq):
+    vals_out = [row[1] for row in node_voltages]
+    vals_in = [row[0] for row in node_voltages]
+    amp = (max(vals_out) - min(vals_out)) / 2.0
+    period = int((1.0 / freq) / (t[1] - t[0]))
+    vals_in_period = vals_in[:period]
+    vals_out_period = vals_out[:period]
+    idx_in = max(range(len(vals_in_period)), key=lambda i: vals_in_period[i])
+    idx_out = max(range(len(vals_out_period)), key=lambda i: vals_out_period[i])
+    delay = t[idx_out] - t[idx_in]
+    phase = -2.0 * np.pi * freq * delay
+    return amp, phase
+
+
+def test_single_segment_reflection_and_phase():
+    seg = TransmissionLineSegment(
+        from_node=0,
+        to_node=1,
+        length=1.0,
+        L_per_m=2.5e-7,
+        R_per_m=0.0,
+        C_per_m=1e-10,
+    )
+    freq = 1e7
+    ZL = 25.0
+    sol = solve_distributed_circuit([seg], [], V0=1.0, t_end=2e-6, dt=1e-9, frequency=freq, Z_load=ZL)
+
+    gamma = seg.propagation_constant(freq)
+    Z0 = seg.characteristic_impedance(freq)
+    H = 1.0 / (cmath.cosh(gamma * seg.length) + (Z0 / ZL) * cmath.sinh(gamma * seg.length))
+    amp_exp = abs(H)
+    phase_exp = cmath.phase(H)
+
+    amp_sol, phase_sol = _measure_amp_phase(sol.node_voltages, sol.t, freq)
+    assert np.isclose(amp_sol, amp_exp, rtol=1e-3, atol=1e-6)
+    assert np.isclose(phase_sol, phase_exp, rtol=1e-1, atol=1e-6)
+    refl = (ZL - Z0) / (ZL + Z0)
+    assert np.isclose(sol.reflections[0], refl, rtol=1e-6, atol=1e-6)
+
+
+def test_two_segment_interface_reflection():
+    seg1 = TransmissionLineSegment(
+        from_node=0,
+        to_node=1,
+        length=0.5,
+        L_per_m=2.5e-7,
+        R_per_m=0.0,
+        C_per_m=1e-10,
+    )
+    seg2 = TransmissionLineSegment(
+        from_node=1,
+        to_node=2,
+        length=0.5,
+        L_per_m=5.625e-7,
+        R_per_m=0.0,
+        C_per_m=1e-10,
+    )
+    freq = 1e7
+    ZL = seg2.characteristic_impedance(freq)
+    sol = solve_distributed_circuit([seg1, seg2], [], V0=1.0, t_end=2e-6, dt=1e-9, frequency=freq, Z_load=ZL)
+
+    Z0_1 = seg1.characteristic_impedance(freq)
+    Z0_2 = seg2.characteristic_impedance(freq)
+    gamma1 = seg1.propagation_constant(freq) * seg1.length
+    gamma2 = seg2.propagation_constant(freq) * seg2.length
+    M1 = [
+        [cmath.cosh(gamma1), Z0_1 * cmath.sinh(gamma1)],
+        [cmath.sinh(gamma1) / Z0_1, cmath.cosh(gamma1)],
+    ]
+    M2 = [
+        [cmath.cosh(gamma2), Z0_2 * cmath.sinh(gamma2)],
+        [cmath.sinh(gamma2) / Z0_2, cmath.cosh(gamma2)],
+    ]
+    # Manual 2x2 matrix multiplication
+    A = M1[0][0] * M2[0][0] + M1[0][1] * M2[1][0]
+    B = M1[0][0] * M2[0][1] + M1[0][1] * M2[1][1]
+    C = M1[1][0] * M2[0][0] + M1[1][1] * M2[1][0]
+    D = M1[1][0] * M2[0][1] + M1[1][1] * M2[1][1]
+    H = 1.0 / (A + B / ZL)
+    amp_exp = abs(H)
+    phase_exp = cmath.phase(H)
+    amp_sol, phase_sol = _measure_amp_phase(sol.node_voltages, sol.t, freq)
+    assert np.isclose(amp_sol, amp_exp, rtol=1e-3, atol=1e-6)
+    assert np.isclose(phase_sol, phase_exp, rtol=1e-1, atol=1e-6)
+    refl_int = (Z0_2 - Z0_1) / (Z0_2 + Z0_1)
+    assert np.isclose(sol.reflections[0], refl_int, rtol=1e-6, atol=1e-6)
+    assert np.isclose(sol.reflections[1], 0.0, atol=1e-12)
 


### PR DESCRIPTION
## Summary
- extend distributed circuit solver with ABCD-based telegrapher equations
- add optional load impedance and reflection coefficient tracking per segment
- introduce tests verifying reflection coefficients and phase delays against analytics

## Testing
- `pytest tests/test_distributed_circuit.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'HallMHD' from 'dpf2.physics' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b0df10a654832a8a8291dd405dc87e