### PR TITLE
Add live plot option and diagnostics hooks

### DIFF
--- a/examples/notebooks/interactive_simulation.ipynb
+++ b/examples/notebooks/interactive_simulation.ipynb
@@ -1,0 +1,50 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Interactive Simulation Demo\n",
+    "Run a DPF simulation with live updating current/voltage plots."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "%matplotlib notebook\n",
+    "from dpf2.core.config import DPFConfig\n",
+    "from dpf2.core.simulation import DPFSimulation\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "cfg = DPFConfig.with_defaults()\n",
+    "sim = DPFSimulation(cfg)\n",
+    "\n",
+    "times, currents, voltages = [], [], []\n",
+    "fig, ax = plt.subplots()\n",
+    "(line_i,) = ax.plot([], [], label='current')\n",
+    "(line_v,) = ax.plot([], [], label='voltage')\n",
+    "ax.set_xlabel('time [s]')\n",
+    "ax.legend()\n",
+    "\n",
+    "def update(step, time):\n",
+    "    times.append(time)\n",
+    "    currents.append(sim.current)\n",
+    "    voltages.append(sim.voltage)\n",
+    "    line_i.set_data(times, currents)\n",
+    "    line_v.set_data(times, voltages)\n",
+    "    ax.relim(); ax.autoscale_view()\n",
+    "\n",
+    "sim.run(progress_cb=update)\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"},
+  "language_info": {"name": "python", "version": "3.11"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -192,6 +192,11 @@ def main() -> None:
 )
 @click.option("--verbose", is_flag=True, help="Report solver progress and energy diagnostics")
 @click.option(
+    "--live-plot",
+    is_flag=True,
+    help="Stream current/voltage plots during simulation",
+)
+@click.option(
     "--synthetic",
     type=click.Path(exists=True, dir_okay=False),
     default=None,
@@ -209,6 +214,7 @@ def simulate(
     voltage: float | None,
     segment_length: float | None,
     verbose: bool,
+    live_plot: bool,
     synthetic: str | None,
     diagnostics: bool,
     wizard: bool,
@@ -276,27 +282,33 @@ def simulate(
         live_currents: list[float] = []
         live_voltages: list[float] = []
         plot_backend: tuple | None = None
-        if click.get_text_stream("stdout").isatty():
-            try:
-                import matplotlib.pyplot as mplt
-
-                if hasattr(mplt, "ion") and hasattr(mplt, "subplots"):
-                    mplt.ion()
-                    fig, ax = mplt.subplots()
-                    (line_i,) = ax.plot([], [], label="current")
-                    (line_v,) = ax.plot([], [], label="voltage")
-                    ax.set_xlabel("time [s]")
-                    ax.legend()
-                    fig.tight_layout()
-                    plot_backend = ("matplotlib", mplt, fig, ax, line_i, line_v)
-            except Exception:
+        if live_plot:
+            if click.get_text_stream("stdout").isatty():
                 try:
-                    import plotext as ptx
+                    import matplotlib.pyplot as mplt
 
-                    plot_backend = ("plotext", ptx)
-                    ptx.clt()
+                    if hasattr(mplt, "ion") and hasattr(mplt, "subplots"):
+                        mplt.ion()
+                        fig, ax = mplt.subplots()
+                        (line_i,) = ax.plot([], [], label="current")
+                        (line_v,) = ax.plot([], [], label="voltage")
+                        ax.set_xlabel("time [s]")
+                        ax.legend()
+                        fig.tight_layout()
+                        plot_backend = ("matplotlib", mplt, fig, ax, line_i, line_v)
                 except Exception:
-                    plot_backend = None
+                    try:
+                        import plotext as ptx
+
+                        plot_backend = ("plotext", ptx)
+                        ptx.clt()
+                    except Exception:
+                        plot_backend = None
+            else:
+                click.echo(
+                    "--live-plot requested but no interactive terminal detected; disabling.",
+                    err=True,
+                )
 
         progress_cb = None
         pbar = None

--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import dataclass
 
 from pathlib import Path
-from typing import Dict, Sequence
+from typing import Dict, Sequence, Callable
 
 from concurrent.futures import ThreadPoolExecutor
 
@@ -156,7 +156,17 @@ class SimulationEngine:
         energy_csv: str | None = None,
         energy_tol: float | None = None,
         diagnostics: Sequence[DiagnosticsBase] | None = None,
+        progress_cb: Callable[[int, float, float, float], None] | None = None,
     ) -> SimulationResults:
+        """Run the simulation and return aggregated results.
+
+        Parameters
+        ----------
+        progress_cb:
+            Optional callback invoked after each circuit step with
+            ``(step, time, current, voltage)`` allowing in-situ diagnostics
+            or live visualisation.
+        """
         sc = self.config.simulation_control
         dt = sc.min_dt or 1e-9
         t_end = sc.time_end - sc.time_start
@@ -189,6 +199,7 @@ class SimulationEngine:
 
         current = circuit.currents[-1]
         voltage = circuit.voltages[-1]
+        step = 0
         while circuit.time[-1] < t_end:
             state = CouplingState(current=current, voltage=voltage)
             # Optional multithreading for circuit stepping
@@ -209,6 +220,9 @@ class SimulationEngine:
                     diag.record(updated, circuit.time[-1])
 
             current, voltage = updated.current, updated.voltage
+            step += 1
+            if progress_cb is not None:
+                progress_cb(step, circuit.time[-1], current, voltage)
 
         t = np.array(circuit.time)
         current_arr = np.array(circuit.currents)

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -59,3 +59,21 @@ def test_engine_ensemble_statistics():
     assert isinstance(results, EnsembleResults)
     assert results.current_mean.shape == results.time.shape
     assert results.current_std.shape == results.time.shape
+
+
+def test_engine_progress_callback():
+    cfg = DPFConfig.with_defaults()
+    cfg = cfg.model_copy(
+        update={
+            "simulation_control": cfg.simulation_control.model_copy(update={"time_end": 1e-6})
+        }
+    )
+    engine = SimulationEngine(cfg)
+    calls: list[float] = []
+
+    def cb(step: int, time: float, current: float, voltage: float) -> None:
+        calls.append(time)
+
+    engine.run(progress_cb=cb)
+    assert len(calls) > 0
+    assert all(calls[i] <= calls[i + 1] for i in range(len(calls) - 1))


### PR DESCRIPTION
## Summary
- add `--live-plot` CLI option to stream current and voltage during runs
- expose progress callback in `SimulationEngine` for in-situ diagnostics
- provide interactive simulation notebook example

## Testing
- `pytest tests/test_simulation_engine.py::test_engine_progress_callback -q` *(fails: AttributeError: type object 'GridResolution' has no attribute 'parse_obj')*

------
https://chatgpt.com/codex/tasks/task_e_68b0df15e634832ab626c0fffcdcf811