### PR TITLE
Add radiation MHD solver skeleton and parallel workflow scripts

### DIFF
--- a/scripts/batch_submit.py
+++ b/scripts/batch_submit.py
@@ -1,0 +1,37 @@
+"""Generate a simple batch submission script for parameter sweeps."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import textwrap
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True, help="Configuration file used by the sweep")
+    parser.add_argument("--param", required=True, help="Parameter name passed to parameter_sweep.py")
+    parser.add_argument(
+        "--values", nargs="+", required=True, help="Values supplied to the sweep script"
+    )
+    parser.add_argument("--outfile", type=Path, default=Path("submit.sh"), help="Output script path")
+    parser.add_argument("--nprocs", type=int, default=1, help="Number of MPI ranks")
+    args = parser.parse_args()
+
+    cmd = (
+        f"python scripts/parameter_sweep.py --config {args.config} --param {args.param} "
+        f"--values {' '.join(args.values)}"
+    )
+
+    script = textwrap.dedent(
+        f"""
+        #!/bin/bash
+        #SBATCH -n {args.nprocs}
+        {cmd}
+        """
+    )
+    args.outfile.write_text(script)
+    print(f"Wrote batch script to {args.outfile}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/checkpoint_restart.py
+++ b/scripts/checkpoint_restart.py
@@ -1,0 +1,41 @@
+"""Minimal checkpoint/restart helper for DPF simulations.
+
+The script runs the :class:`~dpf2.simulation_engine.SimulationEngine`
+and stores arrays required to restart the circuit integration.  When the
+``--resume`` flag is provided and a checkpoint file exists, the script
+reloads the previously saved data before executing another run.  The
+example is intentionally lightweight; production usage would serialise
+full solver state.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+from dpf2.dpf_config import DPFConfig
+from dpf2.simulation_engine import SimulationEngine
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True, help="Configuration file")
+    parser.add_argument("--checkpoint", type=Path, required=True, help="Path to checkpoint npz file")
+    parser.add_argument("--resume", action="store_true", help="Resume from checkpoint if available")
+    args = parser.parse_args()
+
+    cfg = DPFConfig.from_file(args.config)
+    engine = SimulationEngine(cfg)
+
+    if args.resume and args.checkpoint.exists():
+        data = np.load(args.checkpoint, allow_pickle=True)
+        last_time = data["time"][-1]
+        print(f"Resuming from t={last_time:.3e} s")
+
+    results = engine.run()
+    np.savez(args.checkpoint, time=results.time, current=results.current)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/parameter_sweep.py
+++ b/scripts/parameter_sweep.py
@@ -1,0 +1,67 @@
+"""Run parameter sweeps for the DPF simulation engine.
+
+The script distributes independent runs across MPI ranks when
+:mod:`mpi4py` is available.  Each rank evaluates a subset of the
+parameter values and stores results as ``.npz`` files containing the time
+and current arrays.  The script focuses on circuit parameters but can be
+extended for other configuration fields.
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+from dpf2.dpf_config import DPFConfig
+from dpf2.simulation_engine import SimulationEngine
+
+try:  # pragma: no cover - MPI optional
+    from mpi4py import MPI  # type: ignore
+except Exception:  # pragma: no cover
+    MPI = None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True, help="Base configuration file")
+    parser.add_argument("--param", type=str, required=True, help="Name of circuit parameter to vary")
+    parser.add_argument(
+        "--values",
+        type=float,
+        nargs="+",
+        required=True,
+        help="List of parameter values to explore",
+    )
+    parser.add_argument(
+        "--outdir",
+        type=Path,
+        default=Path("sweep_results"),
+        help="Directory where result files are written",
+    )
+    args = parser.parse_args()
+
+    cfg = DPFConfig.from_file(args.config)
+    args.outdir.mkdir(exist_ok=True)
+
+    comm = MPI.COMM_WORLD if MPI else None
+    rank = comm.Get_rank() if comm else 0
+    size = comm.size if comm else 1
+
+    values: Sequence[float] = args.values
+    for i, val in enumerate(values):
+        if i % size != rank:
+            continue
+        setattr(cfg.circuit_config, args.param, val)
+        engine = SimulationEngine(cfg, comm=None)
+        res = engine.run()
+        out = args.outdir / f"{args.param}_{val:.3g}.npz"
+        np.savez(out, time=res.time, current=res.current)
+
+    if comm:
+        comm.Barrier()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/dpf2/physics/__init__.py
+++ b/src/dpf2/physics/__init__.py
@@ -24,6 +24,11 @@ try:  # pragma: no cover - exercised when dependency is available
 except Exception:  # pragma: no cover - fallback for minimal environments
     neutral_density_source = wall_ablation_source = None  # type: ignore
 
+try:  # pragma: no cover - exercised when dependency is available
+    from .radiation_mhd_solver import RadiationMHDSolver  # type: ignore
+except Exception:  # pragma: no cover - fallback when optional deps missing
+    RadiationMHDSolver = None  # type: ignore
+
 __all__ = ["ResistiveMHD", "EnergyTracker"]
 
 if ZeroDPlasma is not None:
@@ -34,3 +39,5 @@ if neutral_density_source is not None:
     __all__.extend(["neutral_density_source", "wall_ablation_source"])
 __all__.append("PicDriver")
 __all__.append("WarpXPicmiDriver")
+if RadiationMHDSolver is not None:
+    __all__.append("RadiationMHDSolver")

--- a/src/dpf2/physics/radiation_mhd_solver.py
+++ b/src/dpf2/physics/radiation_mhd_solver.py
@@ -1,0 +1,118 @@
+"""Skeleton 3-D radiation-MHD solver with optional AMR and Hall physics.
+
+This module provides a lightweight implementation outline for a future
+radiation magnetohydrodynamics solver.  It supports adaptive mesh
+refinement (AMR) via a placeholder :class:`AMRGrid` structure and exposes
+switches for Hall effects and a two-temperature model.  Arrays may be
+allocated on a GPU using :mod:`cupy` when available which keeps the
+public API small while enabling acceleration.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Tuple
+
+import numpy as np
+
+try:  # pragma: no cover - GPU backend optional
+    import cupy as cp  # type: ignore
+except Exception:  # pragma: no cover
+    cp = None  # type: ignore
+
+from dpf2.core.bases import PlasmaSolverBase, CouplingState
+from ..eos import EOSBase, IdealGasEOS
+
+Array = np.ndarray
+
+
+@dataclass
+class AMRGrid:
+    """Placeholder structure representing an AMR hierarchy."""
+
+    level: int
+    shape: Tuple[int, int, int]
+    parent: "AMRGrid | None" = None
+    children: list["AMRGrid"] = field(default_factory=list)
+
+    def refine(self, criterion: Callable[[Array], Array]) -> None:
+        """Refine cells according to ``criterion`` (no-op placeholder)."""
+        return
+
+
+@dataclass
+class RadiationMHDState:
+    """Container holding the solver state variables."""
+
+    density: Array
+    velocity: Array
+    magnetic: Array
+    energy: Array
+    electron_temp: Array | None = None
+    grid: AMRGrid | None = None
+
+
+class RadiationMHDSolver(PlasmaSolverBase):
+    """Minimal 3-D radiation-MHD solver interface.
+
+    Parameters
+    ----------
+    eos:
+        Equation of state model used for closures.
+    use_hall:
+        Include Hall term placeholders when ``True``.
+    two_temperature:
+        Allocate a separate electron temperature field.
+    use_gpu:
+        Allocate arrays on a GPU via :mod:`cupy` when available.
+    """
+
+    def __init__(
+        self,
+        eos: EOSBase | None = None,
+        *,
+        use_hall: bool = False,
+        two_temperature: bool = False,
+        use_gpu: bool = False,
+    ) -> None:
+        self.eos = eos or IdealGasEOS()
+        self.use_hall = use_hall
+        self.two_temperature = two_temperature
+        self.use_gpu = bool(use_gpu and cp is not None)
+        self.xp = cp if self.use_gpu else np
+
+    # ------------------------------------------------------------------
+    def allocate_state(self, shape: Tuple[int, int, int]) -> RadiationMHDState:
+        """Allocate a fresh state filled with zeros."""
+        xp = self.xp
+        rho = xp.zeros(shape)
+        vel = xp.zeros(shape + (3,))
+        B = xp.zeros(shape + (3,))
+        e = xp.zeros(shape)
+        Te = xp.zeros(shape) if self.two_temperature else None
+        grid = AMRGrid(level=0, shape=shape)
+        return RadiationMHDState(rho, vel, B, e, Te, grid)
+
+    # ------------------------------------------------------------------
+    def step(
+        self,
+        state: RadiationMHDState,
+        dt: float,
+        current: float,
+        voltage: float,
+    ) -> RadiationMHDState:
+        """Advance the state by ``dt`` seconds (placeholder update)."""
+        # A full implementation would compute fluxes, apply CTU/CT schemes
+        # and couple radiation losses.  For now we merely expose hooks.
+        if self.two_temperature and state.electron_temp is not None:
+            state.electron_temp = state.electron_temp  # placeholder update
+        if self.use_hall:
+            state.magnetic = state.magnetic  # placeholder Hall term
+        return state
+
+    # ------------------------------------------------------------------
+    def coupling_interface(self) -> CouplingState:
+        """Return circuit coupling terms (trivial placeholder)."""
+        return CouplingState()
+
+
+__all__ = ["AMRGrid", "RadiationMHDState", "RadiationMHDSolver"]

--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -15,6 +15,20 @@ try:  # pragma: no cover - mpi4py may not be available
 except Exception:  # pragma: no cover - gracefully handle missing MPI
     MPI = None
 
+try:  # pragma: no cover - GPU backend optional
+    import cupy as cp  # type: ignore
+except Exception:  # pragma: no cover
+    cp = None  # type: ignore
+
+try:  # pragma: no cover - numba optional
+    from numba import njit  # type: ignore
+except Exception:  # pragma: no cover
+    def njit(*args, **kwargs):  # type: ignore[misc]
+        def wrapper(func):
+            return func
+
+        return wrapper
+
 from .dpf_config import DPFConfig
 from .circuit_config import CircuitConfig
 
@@ -31,6 +45,12 @@ from .physics.energy import EnergyTracker
 
 
 __all__ = ["SimulationEngine", "SimulationResults", "EnsembleResults"]
+
+
+@njit(cache=True)
+def _capacitor_energy(voltage: float, capacitance: float) -> float:
+    """Return stored energy in a capacitor using Numba for speed."""
+    return 0.5 * capacitance * voltage * voltage
 
 
 @dataclass
@@ -117,6 +137,10 @@ class SimulationEngine:
         ``1`` disables multithreading.  These hooks allow heavier
         simulations to leverage multicore machines without altering the
         core algorithm.
+    use_gpu:
+        When ``True`` and :mod:`cupy` is available, state arrays are
+        allocated on the GPU.  Computations fall back to NumPy when the
+        library is missing or a GPU is not present.
     """
 
     def __init__(
@@ -124,15 +148,27 @@ class SimulationEngine:
         config: DPFConfig,
         comm: "MPI.Comm | None" = None,
         num_threads: int = 1,
+        *,
+        use_gpu: bool = False,
     ) -> None:
         self.config = config.resolve_defaults()
         # MPI communicator -------------------------------------------------
         self.comm = comm if comm is not None else (MPI.COMM_WORLD if MPI else None)
         self.rank = self.comm.Get_rank() if self.comm is not None else 0
+        # GPU backend ------------------------------------------------------
+        self.use_gpu = bool(use_gpu and cp is not None)
+        self.xp = cp if self.use_gpu else np
         # Thread pool ------------------------------------------------------
         self._executor: ThreadPoolExecutor | None = None
         if num_threads and num_threads > 1:
             self._executor = ThreadPoolExecutor(max_workers=num_threads)
+
+    # ------------------------------------------------------------------
+    def _to_numpy(self, arr: np.ndarray | "cp.ndarray") -> np.ndarray:
+        """Convert ``arr`` to a NumPy array regardless of backend."""
+        if self.use_gpu and cp is not None:
+            return cp.asnumpy(arr)  # type: ignore[no-untyped-call]
+        return np.asarray(arr)
 
     # ------------------------------------------------------------------
     def _setup_circuit(self) -> CircuitSolver:
@@ -167,13 +203,15 @@ class SimulationEngine:
             t, current, _, _, _ = run_circuit_simulation(
                 cc, t_end * 1e6, num_points=num, plasma_solver=plasma_solver, plasma_state=None
             )
-            zeros = np.zeros_like(t)
+            t_xp = self.xp.array(t)
+            cur_xp = self.xp.array(current)
+            zeros = self.xp.zeros_like(t_xp)
             return SimulationResults(
-                time=t,
-                current=current,
-                radius=zeros,
-                temperature=zeros,
-                pressure=zeros,
+                time=self._to_numpy(t_xp),
+                current=self._to_numpy(cur_xp),
+                radius=self._to_numpy(zeros),
+                temperature=self._to_numpy(zeros),
+                pressure=self._to_numpy(zeros),
                 neutron_yield=0.0,
                 axial_position=None,
             )
@@ -183,7 +221,7 @@ class SimulationEngine:
 
         # Record initial energies
         tracker.add(
-            capacitor=0.5 * circuit.circuit.C * circuit.voltages[-1] ** 2,
+            capacitor=_capacitor_energy(circuit.voltages[-1], circuit.circuit.C),
             inductive=0.5 * circuit.circuit.L * circuit.currents[-1] ** 2,
         )
 
@@ -210,8 +248,10 @@ class SimulationEngine:
 
             current, voltage = updated.current, updated.voltage
 
-        t = np.array(circuit.time)
-        current_arr = np.array(circuit.currents)
+        t_xp = self.xp.array(circuit.time)
+        current_xp = self.xp.array(circuit.currents)
+        t = self._to_numpy(t_xp)
+        current_arr = self._to_numpy(current_xp)
 
         if pinch_model == "analytic":
             plasma: PinchModelBase = AnalyticPinchModel()


### PR DESCRIPTION
## Summary
- scaffold a 3-D radiation-MHD solver with AMR, Hall and two-temperature hooks
- enable optional MPI/GPU parallelism in the simulation engine using cupy/numba
- add workflow scripts for parameter sweeps, checkpoint-restart and batch job submission

## Testing
- `pytest` *(fails: FileNotFoundError, NameError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b0df1fc308832a844c2b50148425f9