### PR TITLE
Enable mixed-precision GPU linear algebra and benchmarking

### DIFF
--- a/src/dpf2/gpu_utils.py
+++ b/src/dpf2/gpu_utils.py
@@ -1,0 +1,109 @@
+"""Utility helpers for optional GPU acceleration.
+
+This module provides a light abstraction over the array backend used by the
+code base.  When :mod:`cupy` is available it is used to execute operations on
+GPU; otherwise it falls back to :mod:`numpy`.
+
+The :func:`solve_linear` helper implements a mixed–precision linear solver with
+iterative refinement.  The system is first solved in single precision and then
+refined in double precision which provides a good balance between speed and
+accuracy on modern GPU hardware.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+import math
+import types
+
+
+try:  # pragma: no cover - optional GPU dependency
+    import cupy as _cp
+
+    xp = _cp
+
+    def to_cpu(arr: Any) -> Any:
+        """Return a host ``numpy`` array for ``arr``."""
+
+        return _cp.asnumpy(arr)
+
+except Exception:  # pragma: no cover - fallback to CPU numpy or a very small stub
+    try:
+        import numpy as _np  # type: ignore
+
+        xp = _np
+
+        def to_cpu(arr: Any) -> Any:
+            return arr
+
+    except Exception:  # pragma: no cover - final pure Python fallback
+        xp = types.SimpleNamespace(
+            array=lambda data, dtype=None: [float(x) for x in data]
+            if isinstance(data, (list, tuple))
+            else [float(data)],
+            zeros=lambda shape, dtype=None: [0.0 for _ in range(shape)]
+            if isinstance(shape, int)
+            else [[0.0 for _ in range(shape[1])] for _ in range(shape[0])],
+            sin=math.sin,
+            pi=math.pi,
+            dot=lambda a, b: sum(x * y for x, y in zip(a, b)),
+        )
+
+        def to_cpu(arr: Any) -> Any:
+            return arr
+
+
+def solve_linear(M: Any, b: Any, *, refine: bool = True) -> Any:
+    """Solve ``M x = b`` using the active array module ``xp``.
+
+    Parameters
+    ----------
+    M, b:
+        Matrix and right‑hand side vector defining the linear system.
+    refine:
+        When ``True`` the routine performs a single iteration of iterative
+        refinement using double precision to improve accuracy of the initial
+        single precision solution.
+    """
+
+    try:
+        A32 = xp.array(M, dtype=getattr(xp, "float32", float))
+        b32 = xp.array(b, dtype=getattr(xp, "float32", float))
+        x = xp.linalg.solve(A32, b32)
+        if refine and hasattr(xp, "float64"):
+            A64 = xp.array(M, dtype=getattr(xp, "float64", float))
+            b64 = xp.array(b, dtype=getattr(xp, "float64", float))
+            x64 = x.astype(getattr(xp, "float64", float)) if hasattr(x, "astype") else [float(v) for v in x]
+            r = b64 - xp.dot(A64, x64)
+            delta = xp.linalg.solve(A64, r)
+            x = x64 + delta
+        return x
+    except Exception:
+        # Very small dense Gaussian elimination suitable for tests and stub backends
+        M = [[float(M[i][j]) for j in range(len(b))] for i in range(len(b))]
+        b = [float(bb) for bb in b]
+        n = len(b)
+        for i in range(n):
+            pivot = M[i][i]
+            if pivot == 0.0:
+                for j in range(i + 1, n):
+                    if M[j][i] != 0.0:
+                        M[i], M[j] = M[j], M[i]
+                        b[i], b[j] = b[j], b[i]
+                        pivot = M[i][i]
+                        break
+            factor = pivot
+            for j in range(i, n):
+                M[i][j] /= factor
+            b[i] /= factor
+            for k in range(n):
+                if k == i:
+                    continue
+                factor = M[k][i]
+                for j in range(i, n):
+                    M[k][j] -= factor * M[i][j]
+                b[k] -= factor * b[i]
+        return xp.array(b) if hasattr(xp, "array") else b
+
+
+__all__ = ["xp", "to_cpu", "solve_linear"]

--- a/src/dpf2/physics/mhd.py
+++ b/src/dpf2/physics/mhd.py
@@ -20,19 +20,25 @@ unit and integration tests throughout the code base.
 from __future__ import annotations
 
 from dataclasses import dataclass
-try:
-    import numpy as np  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - fallback for test environment
-    import types, math
+try:  # pragma: no cover - prefer GPU acceleration when available
+    import cupy as np  # type: ignore
+except Exception:  # pragma: no cover - fall back to numpy or a small stub
+    try:
+        import numpy as np  # type: ignore
+    except ModuleNotFoundError:  # pragma: no cover - very small fallback
+        import types, math
 
-    np = types.SimpleNamespace(
-        array=lambda x: list(x) if isinstance(x, (list, tuple)) else [x],
-        zeros=lambda shape: [[0.0] * shape[1] for _ in range(shape[0])] if isinstance(shape, tuple) else [0.0] * shape,
-        sqrt=math.sqrt,
-        dot=lambda a, b: sum(x * y for x, y in zip(a, b)),
-        zeros_like=lambda arr: [0.0 for _ in arr],
-        ndarray=list,
-    )
+        np = types.SimpleNamespace(
+            array=lambda x: list(x) if isinstance(x, (list, tuple)) else [x],
+            zeros=lambda shape: [[0.0] * shape[1] for _ in range(shape[0])] if isinstance(shape, tuple) else [0.0] * shape,
+            sqrt=math.sqrt,
+            dot=lambda a, b: sum(x * y for x, y in zip(a, b)),
+            zeros_like=lambda arr: [0.0 for _ in arr],
+            ndarray=list,
+            sin=math.sin,
+            cos=math.cos,
+            pi=math.pi,
+        )
 
 # ``MultiGroupDiffusion`` is an optional dependency; the lightweight stub below
 # allows importing this module in minimal test environments where the full

--- a/src/dpf2/rlc_solver.py
+++ b/src/dpf2/rlc_solver.py
@@ -15,12 +15,12 @@ used by the tests introduced in this exercise.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Sequence
+from typing import Sequence, Any
 from concurrent.futures import ThreadPoolExecutor
 
 # ``numpy`` may be replaced by a light‑weight stub in the test environment but
 # it provides the minimal functionality used below (``array``).
-import numpy as np
+from .gpu_utils import xp, solve_linear, to_cpu
 import cmath
 
 from .circuit.distributed import TransmissionLineSegment, TriggeredSwitch, assemble_matrices
@@ -40,13 +40,17 @@ __all__ = ["run_circuit_simulation", "solve_distributed_circuit", "DistributedRL
 
 @dataclass
 class DistributedRLCSolution:
-    """Container returned by :func:`solve_distributed_circuit`."""
+    """Container returned by :func:`solve_distributed_circuit`.
 
-    t: np.ndarray
-    current: np.ndarray
-    voltage: np.ndarray
-    branch_currents: np.ndarray
-    node_voltages: np.ndarray
+    The arrays may originate from either :mod:`numpy` or :mod:`cupy`
+    depending on the active backend.
+    """
+
+    t: Any
+    current: Any
+    voltage: Any
+    branch_currents: Any
+    node_voltages: Any
 
 
 # ---------------------------------------------------------------------------
@@ -81,10 +85,10 @@ def solve_distributed_circuit(
     # segments.  This path is primarily used in unit tests and bypasses the more
     # involved time domain solver.
     if frequency is not None and segments:
-        w = 2.0 * np.pi * frequency
+        w = 2.0 * xp.pi * frequency
         n_steps = int(t_end / dt) + 1
-        t = np.array([i * dt for i in range(n_steps)])
-        vin = np.array([np.sin(w * ti) for ti in t]) * V0
+        t = xp.array([i * dt for i in range(n_steps)])
+        vin = xp.array([xp.sin(w * ti) for ti in t]) * V0
 
         gamma_total = 0.0 + 0.0j
         for seg in segments:
@@ -93,24 +97,24 @@ def solve_distributed_circuit(
         H = cmath.exp(-gamma_total)
         amp = abs(H)
         phase = cmath.phase(H)
-        vout = np.array([np.sin(w * ti + phase) for ti in t]) * (amp * V0)
+        vout = xp.array([xp.sin(w * ti + phase) for ti in t]) * (amp * V0)
 
-        node_voltages = np.zeros((len(t), 2))
+        node_voltages = xp.zeros((len(t), 2))
         node_voltages[:, 0] = vin
         node_voltages[:, 1] = vout
 
         Zin = segments[0].characteristic_impedance(frequency)
         I_amp = V0 / (abs(Zin) if Zin != 0 else 1e-12)
         I_phase = -cmath.phase(Zin)
-        current = np.array([np.sin(w * ti + I_phase) for ti in t]) * I_amp
+        current = xp.array([xp.sin(w * ti + I_phase) for ti in t]) * I_amp
         branch_currents = current[:, None]
 
         return DistributedRLCSolution(
-            t=t,
-            current=current,
-            voltage=vin,
-            branch_currents=branch_currents,
-            node_voltages=node_voltages,
+            t=to_cpu(t),
+            current=to_cpu(current),
+            voltage=to_cpu(vin),
+            branch_currents=to_cpu(branch_currents),
+            node_voltages=to_cpu(node_voltages),
         )
 
     # ------------------------------------------------------------------
@@ -124,11 +128,11 @@ def solve_distributed_circuit(
         nodes.add(sw.to_node)
     if not nodes:
         return DistributedRLCSolution(
-            t=np.zeros(0),
-            current=np.zeros(0),
-            voltage=np.zeros(0),
-            branch_currents=np.zeros((0, 0)),
-            node_voltages=np.zeros((0, 0)),
+            t=to_cpu(xp.zeros(0)),
+            current=to_cpu(xp.zeros(0)),
+            voltage=to_cpu(xp.zeros(0)),
+            branch_currents=to_cpu(xp.zeros((0, 0))),
+            node_voltages=to_cpu(xp.zeros((0, 0))),
         )
 
     node_list = sorted(nodes)
@@ -192,10 +196,10 @@ def solve_distributed_circuit(
     n_steps = int(t_end / dt) + 1
     t = [i * dt for i in range(n_steps)]
 
-    currents = np.zeros((n_steps, n_branches))
-    node_voltages = np.zeros((n_steps, n_nodes))
-    total_I = np.zeros(n_steps)
-    V_cap = np.zeros(n_steps)
+    currents = xp.zeros((n_steps, n_branches))
+    node_voltages = xp.zeros((n_steps, n_nodes))
+    total_I = xp.zeros(n_steps)
+    V_cap = xp.zeros(n_steps)
 
     total_I[0] = I0
     V_cap[0] = V0
@@ -203,36 +207,9 @@ def solve_distributed_circuit(
 
     # ------------------------------------------------------------------
     def _solve(M, b):
-        """Solve ``M x = b`` using ``numpy.linalg.solve`` if available."""
+        """Solve ``M x = b`` using the accelerated backend."""
 
-        try:  # pragma: no cover - prefer real numpy implementation
-            return np.linalg.solve(M, b)  # type: ignore[attr-defined]
-        except Exception:  # pragma: no cover - lightweight fallback
-            # Very small dense Gaussian elimination suitable for the tests
-            M = [[float(M[i][j]) for j in range(len(b))] for i in range(len(b))]
-            b = [float(bb) for bb in b]
-            n = len(b)
-            for i in range(n):
-                pivot = M[i][i]
-                if pivot == 0.0:
-                    for j in range(i + 1, n):
-                        if M[j][i] != 0.0:
-                            M[i], M[j] = M[j], M[i]
-                            b[i], b[j] = b[j], b[i]
-                            pivot = M[i][i]
-                            break
-                factor = pivot
-                for j in range(i, n):
-                    M[i][j] /= factor
-                b[i] /= factor
-                for k in range(n):
-                    if k == i:
-                        continue
-                    factor = M[k][i]
-                    for j in range(i, n):
-                        M[k][j] -= factor * M[i][j]
-                    b[k] -= factor * b[i]
-            return np.array(b)
+        return solve_linear(M, b)
 
     # ------------------------------------------------------------------
     for k in range(1, n_steps):
@@ -245,8 +222,8 @@ def solve_distributed_circuit(
         n_unknown = len(unknown_nodes)
         unk_index = {n: i for i, n in enumerate(unknown_nodes)}
 
-        M = np.zeros((n_unknown, n_unknown))
-        rhs = np.zeros(n_unknown)
+        M = xp.zeros((n_unknown, n_unknown))
+        rhs = xp.zeros(n_unknown)
 
         # Pre-compute constants for each branch
         a_vals = [0.0] * n_branches
@@ -286,10 +263,10 @@ def solve_distributed_circuit(
         if n_unknown:
             v_unknown = _solve(M, rhs)
         else:
-            v_unknown = np.zeros(0)
+            v_unknown = xp.zeros(0)
 
         # Compose full node voltage vector
-        v_full = np.zeros(n_nodes)
+        v_full = xp.zeros(n_nodes)
         v_full[node_index[src]] = V_cap[k - 1]
         v_full[node_index[ground]] = 0.0
         for n in unknown_nodes:
@@ -332,9 +309,9 @@ def solve_distributed_circuit(
             sw.update(tk + dt)
 
     return DistributedRLCSolution(
-        t=np.array(t),
-        current=np.array(total_I),
-        voltage=np.array(V_cap),
-        branch_currents=np.array(currents),
-        node_voltages=np.array(node_voltages),
+        t=to_cpu(xp.array(t)),
+        current=to_cpu(xp.array(total_I)),
+        voltage=to_cpu(xp.array(V_cap)),
+        branch_currents=to_cpu(xp.array(currents)),
+        node_voltages=to_cpu(xp.array(node_voltages)),
     )

--- a/tests/performance/benchmark_cpu_gpu.py
+++ b/tests/performance/benchmark_cpu_gpu.py
@@ -1,0 +1,86 @@
+"""Simple CPU/GPU scaling benchmark for linear solves.
+
+This script compares the execution time of a dense linear solve using
+``numpy`` on the CPU against ``cupy`` on the GPU when available.  It is not
+intended to be an exhaustive performance study but rather a quick check that
+the GPU pathway is operational.
+"""
+
+import time
+import random
+import sys
+from pathlib import Path
+
+try:  # optional CPU baseline using numpy if available
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - numpy not installed
+    np = None
+
+try:  # optional GPU benchmark
+    import cupy as cp  # type: ignore
+except Exception:  # pragma: no cover - GPU unavailable
+    cp = None
+
+
+def _rand_matrix(size: int):
+    return [[random.random() for _ in range(size)] for _ in range(size)]
+
+
+def _rand_vector(size: int):
+    return [random.random() for _ in range(size)]
+
+
+def benchmark_numpy(size: int, iterations: int) -> float:
+    A = np.random.rand(size, size).astype(np.float32)
+    b = np.random.rand(size).astype(np.float32)
+    np.linalg.solve(A, b)
+    start = time.time()
+    for _ in range(iterations):
+        np.linalg.solve(A, b)
+    return time.time() - start
+
+
+def benchmark_python(size: int, iterations: int) -> float:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+    from dpf2.gpu_utils import solve_linear
+
+    A = _rand_matrix(size)
+    b = _rand_vector(size)
+    solve_linear(A, b)
+    start = time.time()
+    for _ in range(iterations):
+        solve_linear(A, b)
+    return time.time() - start
+
+
+def benchmark_cupy(size: int, iterations: int) -> float:
+    A = cp.random.rand(size, size).astype(cp.float32)
+    b = cp.random.rand(size).astype(cp.float32)
+    cp.linalg.solve(A, b)
+    cp.cuda.Stream.null.synchronize()
+    start = time.time()
+    for _ in range(iterations):
+        cp.linalg.solve(A, b)
+    cp.cuda.Stream.null.synchronize()
+    return time.time() - start
+
+
+def main() -> None:
+    size = 256
+    iterations = 5
+    if np is not None:
+        cpu = benchmark_numpy(size, iterations)
+        print(f"CPU (numpy) : {cpu:.6f}s")
+    else:
+        cpu = benchmark_python(size, iterations)
+        print(f"CPU (python) : {cpu:.6f}s")
+
+    if cp is not None:
+        gpu = benchmark_cupy(size, iterations)
+        print(f"GPU (cupy) : {gpu:.6f}s")
+    else:
+        print("CuPy not available - GPU benchmark skipped")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/performance/test_gpu_benchmark.py
+++ b/tests/performance/test_gpu_benchmark.py
@@ -1,0 +1,19 @@
+"""Basic correctness check for the GPU-enabled linear solver."""
+
+import numpy as np
+import pytest
+
+from dpf2.gpu_utils import xp, solve_linear
+
+
+@pytest.mark.parametrize(
+    "A,b,expected",
+    [
+        (np.array([[3.0, 1.0], [1.0, 2.0]]), np.array([9.0, 8.0]), np.array([2.0, 3.0])),
+    ],
+)
+def test_solve_linear_matches_reference(A, b, expected):
+    x = solve_linear(A, b)
+    if hasattr(xp, "asnumpy"):
+        x = xp.asnumpy(x)
+    assert np.allclose(x, expected, atol=1e-5)


### PR DESCRIPTION
## Summary
- Add gpu_utils module providing CuPy/numpy backend selection and mixed-precision linear solver
- Accelerate RLC solver with GPU-aware arrays and iterative refinement
- Add optional CuPy support to MHD module and performance benchmarks

## Testing
- `pytest tests/test_rlc_solver.py tests/performance/test_gpu_benchmark.py`
- `pytest tests/test_mhd.py` *(fails: 'types.SimpleNamespace' object has no attribute 'asarray')*
- `python tests/performance/benchmark_cpu_gpu.py`

------
https://chatgpt.com/codex/tasks/task_e_68b0df27de94832a81d3afc046720b65