### PR TITLE
Add basic PIC, EOS, and radiation transport utilities

### DIFF
--- a/src/dpf2/physics/__init__.py
+++ b/src/dpf2/physics/__init__.py
@@ -1,5 +1,8 @@
 from .mhd import ResistiveMHD
-
+from .energy import EnergyTracker
+from .pic import SimplePIC
+from .eos import TabulatedEOS, load_tabulated_eos, load_standard_eos
+from .radiation import RadiationTransport
 from .pic_driver import PicDriver
 from .warpx_picmi import WarpXPicmiDriver
 
@@ -24,7 +27,15 @@ try:  # pragma: no cover - exercised when dependency is available
 except Exception:  # pragma: no cover - fallback for minimal environments
     neutral_density_source = wall_ablation_source = None  # type: ignore
 
-__all__ = ["ResistiveMHD", "EnergyTracker"]
+__all__ = [
+    "ResistiveMHD",
+    "EnergyTracker",
+    "SimplePIC",
+    "TabulatedEOS",
+    "load_tabulated_eos",
+    "load_standard_eos",
+    "RadiationTransport",
+]
 
 if ZeroDPlasma is not None:
     __all__.append("ZeroDPlasma")

--- a/src/dpf2/physics/eos.py
+++ b/src/dpf2/physics/eos.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Helpers for tabulated equations of state and opacity data."""
+
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import List, Sequence
+import json
+
+
+@dataclass
+class TabulatedEOS:
+    """Tabulated EOS with optional opacity data."""
+
+    rho: Sequence[float]
+    temperature: Sequence[float]
+    pressure: Sequence[Sequence[float]]
+    energy: Sequence[Sequence[float]]
+    opacity: Sequence[Sequence[float]] | None = None
+
+    def _interp1d(self, x: float, xp: Sequence[float], fp: Sequence[float]) -> float:
+        if x <= xp[0]:
+            return fp[0]
+        if x >= xp[-1]:
+            return fp[-1]
+        for i in range(len(xp) - 1):
+            if xp[i] <= x <= xp[i + 1]:
+                t = (x - xp[i]) / (xp[i + 1] - xp[i]) if xp[i + 1] != xp[i] else 0.0
+                return fp[i] * (1 - t) + fp[i + 1] * t
+        return fp[-1]
+
+    def _interp2d(self, x: float, y: float, table: Sequence[Sequence[float]]) -> float:
+        rows = [self._interp1d(y, self.temperature, row) for row in table]
+        return self._interp1d(x, self.rho, rows)
+
+    def pressure_at(self, rho: float, T: float) -> float:
+        return self._interp2d(rho, T, self.pressure)
+
+    def energy_at(self, rho: float, T: float) -> float:
+        return self._interp2d(rho, T, self.energy)
+
+    def opacity_at(self, rho: float, T: float) -> float:
+        if self.opacity is None:
+            raise ValueError("opacity table not available")
+        return self._interp2d(rho, T, self.opacity)
+
+
+# ---------------------------------------------------------------------------
+# Loaders
+# ---------------------------------------------------------------------------
+
+
+def load_tabulated_eos(path: str | Path) -> TabulatedEOS:
+    """Load EOS/opacity data from ``path``."""
+
+    with open(path) as f:
+        data = json.load(f)
+    def _to_float_list(seq):
+        return [float(x) for x in seq]
+
+    def _to_2d_list(seq2d):
+        return [[float(x) for x in row] for row in seq2d]
+
+    return TabulatedEOS(
+        rho=_to_float_list(data["rho"]),
+        temperature=_to_float_list(data["T"]),
+        pressure=_to_2d_list(data["p"]),
+        energy=_to_2d_list(data["e"]),
+        opacity=_to_2d_list(data["opacity"]) if "opacity" in data else None,
+    )
+
+
+def load_standard_eos(name: str) -> TabulatedEOS:
+    """Load one of the small built-in EOS tables distributed with the package."""
+
+    file = resources.files("dpf2.eos") / f"{name}.json"
+    with resources.as_file(file) as path:
+        return load_tabulated_eos(path)
+
+
+__all__ = ["TabulatedEOS", "load_tabulated_eos", "load_standard_eos"]

--- a/src/dpf2/physics/pic.py
+++ b/src/dpf2/physics/pic.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Lightweight particle-in-cell (PIC) solver.
+
+The solver is intentionally compact and targets unit tests and educational
+examples.  It advances a collection of macro particles in one spatial
+dimension under the influence of the electric field inferred from the circuit
+voltage.  A simple current estimate provides a coupling back to the circuit via
+:class:`~dpf2.core.bases.CouplingState`.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, List
+
+from ..core.bases import PlasmaSolverBase, CouplingState
+
+
+@dataclass
+class SimplePIC(PlasmaSolverBase):
+    """Very small 1‑D PIC model used for tests and examples.
+
+    Parameters
+    ----------
+    charge, mass:
+        Particle charge and mass in SI units.  All particles are assumed to be
+        identical macro particles.
+    length:
+        Length of the one‑dimensional domain.  Periodic boundaries are
+        imposed; particles leaving the domain wrap around to the opposite end.
+    positions, velocities:
+        Initial particle phase‑space coordinates.  The arrays are modified in
+        place by :meth:`step`.
+    """
+
+    charge: float
+    mass: float
+    length: float
+    positions: List[float]
+    velocities: List[float]
+    circuit_feedback: CouplingState = field(init=False, default_factory=CouplingState)
+
+    def step(self, state: Any, dt: float, current: float, voltage: float) -> Any:
+        """Advance particles by ``dt`` and compute circuit feedback."""
+
+        # Electric field assumed uniform over the domain.
+        E = voltage / self.length if self.length else 0.0
+        accel = self.charge / self.mass * E
+        self.velocities = [v + accel * dt for v in self.velocities]
+        self.positions = [
+            (x + v * dt) % self.length if self.length else x + v * dt
+            for x, v in zip(self.positions, self.velocities)
+        ]
+        # Estimate the plasma current from particle motion.
+        plasma_current = (
+            self.charge * sum(self.velocities) / self.length if self.length else 0.0
+        )
+        self.circuit_feedback = CouplingState(
+            current=current, voltage=voltage, back_reaction=plasma_current
+        )
+        return state
+
+    def coupling_interface(self) -> CouplingState:  # pragma: no cover - simple
+        """Expose the latest coupling information."""
+
+        return CouplingState(back_reaction=self.circuit_feedback.back_reaction)
+
+
+__all__ = ["SimplePIC"]

--- a/src/dpf2/physics/radiation.py
+++ b/src/dpf2/physics/radiation.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Modular radiation transport helpers."""
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple
+
+# ``MultiGroupDiffusion`` is optional; provide a minimal stub for test
+# environments where the radiation package is stripped down.
+try:  # pragma: no cover - exercised when package is present
+    from ..radiation.multigroup import MultiGroupDiffusion  # type: ignore
+except Exception:  # pragma: no cover - fallback for stripped environments
+    class MultiGroupDiffusion:  # type: ignore
+        def __init__(self, opacities):
+            self.opacities = list(opacities)
+            self.group_count = len(self.opacities)
+            self.energy = [[0.0] for _ in range(self.group_count)]
+
+        def diffuse(self, dx, dt):
+            return self.energy
+
+        def couple(self, fluid_energy, dt):
+            return fluid_energy
+
+
+@dataclass
+class RadiationTransport:
+    """High-level driver for multi-group radiation diffusion."""
+
+    diffusion: MultiGroupDiffusion
+    dx: float
+
+    def step(
+        self, fluid_energy: Sequence[float] | float, dt: float
+    ) -> Tuple[Sequence[float] | float, Sequence[Sequence[float]]]:
+        """Diffuse radiation and exchange energy with ``fluid_energy``."""
+
+        updated = self.diffusion.couple(fluid_energy, dt)
+        self.diffusion.diffuse(self.dx, dt)
+        return updated, self.diffusion.energy
+
+
+__all__ = ["RadiationTransport", "MultiGroupDiffusion"]

--- a/tests/test_physics_eos_loader.py
+++ b/tests/test_physics_eos_loader.py
@@ -1,0 +1,24 @@
+import json
+
+from dpf2.physics.eos import load_tabulated_eos, load_standard_eos
+
+
+def test_standard_loader():
+    eos = load_standard_eos("argon")
+    val = eos.pressure_at(1.5, 15.0)
+    assert abs(val - 1.75) < 1e-12
+
+
+def test_opacity_loading(tmp_path):
+    data = {
+        "rho": [1.0, 2.0],
+        "T": [10.0, 20.0],
+        "p": [[1.0, 1.5], [2.0, 2.5]],
+        "e": [[100.0, 150.0], [200.0, 250.0]],
+        "opacity": [[0.1, 0.2], [0.3, 0.4]],
+    }
+    path = tmp_path / "table.json"
+    with path.open("w") as f:
+        json.dump(data, f)
+    eos = load_tabulated_eos(path)
+    assert abs(eos.opacity_at(1.0, 10.0) - 0.1) < 1e-12

--- a/tests/test_physics_pic_solver.py
+++ b/tests/test_physics_pic_solver.py
@@ -1,0 +1,17 @@
+from dpf2.physics.pic import SimplePIC
+from dpf2.core.bases import CouplingState
+
+
+def test_pic_updates_and_couples():
+    solver = SimplePIC(
+        charge=-1.0,
+        mass=1.0,
+        length=1.0,
+        positions=[0.0, 0.5],
+        velocities=[0.0, 0.0],
+    )
+    solver.step(None, dt=1.0, current=0.0, voltage=1.0)
+    assert any(v != 0.0 for v in solver.velocities)
+    feedback = solver.coupling_interface()
+    assert isinstance(feedback, CouplingState)
+    assert feedback.back_reaction != 0.0

--- a/tests/test_physics_radiation_solver.py
+++ b/tests/test_physics_radiation_solver.py
@@ -1,0 +1,10 @@
+from dpf2.physics.radiation import RadiationTransport
+from dpf2.radiation.multigroup import MultiGroupDiffusion
+
+
+def test_radiation_step_couples():
+    diffusion = MultiGroupDiffusion([0.1, 0.1])
+    solver = RadiationTransport(diffusion, dx=1.0)
+    fluid, radiation = solver.step([1.0], dt=0.1)
+    assert fluid[0] < 1.0
+    assert len(radiation) == 2


### PR DESCRIPTION
## Summary
- introduce simple 1-D particle-in-cell solver coupled with `CouplingState`
- add tabulated EOS/opacity loader with built-in dataset support
- provide modular radiation transport helper wrapping multigroup diffusion

## Testing
- `pytest` *(fails: missing optional dependencies)*
- `pytest tests/test_physics_pic_solver.py tests/test_physics_eos_loader.py tests/test_physics_radiation_solver.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0df2e5244832a91b33e07ab6ba946