### PR TITLE
Add AMR wrapper and geometry loaders with integration tests

### DIFF
--- a/src/dpf2/geometry/__init__.py
+++ b/src/dpf2/geometry/__init__.py
@@ -1,5 +1,11 @@
 """Geometry utilities for DPF simulations."""
 
 from .inductance import coaxial_inductance, loop_mutual_inductance
+from .loaders import load_cad_geometry, load_unstructured_mesh
 
-__all__ = ["coaxial_inductance", "loop_mutual_inductance"]
+__all__ = [
+    "coaxial_inductance",
+    "loop_mutual_inductance",
+    "load_cad_geometry",
+    "load_unstructured_mesh",
+]

--- a/src/dpf2/geometry/loaders.py
+++ b/src/dpf2/geometry/loaders.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+
+def load_cad_geometry(path: Path) -> Dict[str, Any]:
+    """Load a minimal CAD style geometry description from ``path``.
+
+    The expected format is JSON containing ``nodes`` and ``elements`` lists.
+    """
+    return json.loads(Path(path).read_text())
+
+
+def load_unstructured_mesh(path: Path) -> Dict[str, Any]:
+    """Load a very small subset of an unstructured mesh format.
+
+    If ``path`` has a ``.json`` suffix the same format as :func:`load_cad_geometry`
+    is assumed.  Otherwise a simple text format is parsed where the first line is
+    the number of nodes followed by that many lines of ``x y z`` coordinates.  The
+    next line gives the number of elements followed by index triples.
+    """
+    p = Path(path)
+    if p.suffix.lower() == ".json":
+        return json.loads(p.read_text())
+
+    lines = [ln.strip() for ln in p.read_text().splitlines() if ln.strip()]
+    n_nodes = int(lines[0])
+    nodes = [list(map(float, ln.split())) for ln in lines[1 : 1 + n_nodes]]
+    n_elem = int(lines[1 + n_nodes])
+    elements = [list(map(int, ln.split())) for ln in lines[2 + n_nodes : 2 + n_nodes + n_elem]]
+    return {"nodes": nodes, "elements": elements}

--- a/src/dpf2/mesh/__init__.py
+++ b/src/dpf2/mesh/__init__.py
@@ -1,5 +1,17 @@
+"""Mesh utilities and adaptive refinement wrappers."""
+
 from .mesh2d import Mesh2D, MeshCell
 from .mesh3d import Mesh3D, MeshCell3D
 from .boundaries import apply_bc
+from .amr import AMRMesh, plasma_gradient_refinement, wavefront_refinement
 
-__all__ = ["Mesh2D", "MeshCell", "Mesh3D", "MeshCell3D", "apply_bc"]
+__all__ = [
+    "Mesh2D",
+    "MeshCell",
+    "Mesh3D",
+    "MeshCell3D",
+    "apply_bc",
+    "AMRMesh",
+    "plasma_gradient_refinement",
+    "wavefront_refinement",
+]

--- a/src/dpf2/mesh/amr.py
+++ b/src/dpf2/mesh/amr.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Any, Optional
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import pyamrex  # type: ignore
+except Exception:  # pragma: no cover - gracefully degrade if backend missing
+    pyamrex = None  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Refinement criteria helpers
+
+def plasma_gradient_refinement(field: np.ndarray, threshold: float) -> np.ndarray:
+    """Return mask of cells where the gradient magnitude exceeds ``threshold``."""
+    if field is None:
+        raise ValueError("field must be provided")
+    arr = np.asarray(field)
+    shape = arr.shape
+    if arr.ndim == 1:
+        mask = [False] * shape[0]
+        for i in range(shape[0]):
+            left = arr[i - 1 if i > 0 else 0]
+            right = arr[i + 1 if i < shape[0] - 1 else shape[0] - 1]
+            gx = float(right) - float(left)
+            mag = abs(gx) * 0.5
+            mask[i] = mag > threshold
+    else:
+        mask = [[False] * shape[1] for _ in range(shape[0])]
+        for i in range(shape[0]):
+            for j in range(shape[1]):
+                left = arr[i - 1 if i > 0 else 0, j]
+                right = arr[i + 1 if i < shape[0] - 1 else shape[0] - 1, j]
+                down = arr[i, j - 1 if j > 0 else 0]
+                up = arr[i, j + 1 if j < shape[1] - 1 else shape[1] - 1]
+                gx = float(right) - float(left)
+                gy = float(up) - float(down)
+                mag = (gx ** 2 + gy ** 2) ** 0.5 * 0.5
+                mask[i][j] = mag > threshold
+    return np.array(mask)
+
+
+def wavefront_refinement(field: np.ndarray, prev_field: np.ndarray, threshold: float) -> np.ndarray:
+    """Tag cells where the change between two fields exceeds ``threshold``."""
+    if field is None or prev_field is None:
+        raise ValueError("Both current and previous fields are required")
+    arr = np.asarray(field)
+    prev = np.asarray(prev_field)
+    shape = arr.shape
+    if arr.ndim == 1:
+        mask = [False] * shape[0]
+        for i in range(shape[0]):
+            if abs(float(arr[i]) - float(prev[i])) > threshold:
+                mask[i] = True
+    else:
+        mask = [[False] * shape[1] for _ in range(shape[0])]
+        for i in range(shape[0]):
+            for j in range(shape[1]):
+                if abs(float(arr[i, j]) - float(prev[i, j])) > threshold:
+                    mask[i][j] = True
+    return np.array(mask)
+
+
+@dataclass
+class AMRMesh:
+    """Light‑weight wrapper around a pyAMReX style AMR interface."""
+
+    shape: tuple[int, int, int]
+    criteria: Dict[str, float]
+
+    def __post_init__(self) -> None:
+        self._backend = pyamrex
+        self._last_mask: Optional[np.ndarray] = None
+
+    # ------------------------------------------------------------------
+    def refine(
+        self,
+        plasma_state: Optional[Dict[str, Any]] = None,
+        prev_field: Optional[np.ndarray] = None,
+    ) -> None:
+        """Apply refinement criteria and notify the backend."""
+        if plasma_state is None:
+            return
+
+        density = plasma_state.get("density")
+        field = plasma_state.get("field")
+
+        mask = np.zeros(self.shape, dtype=bool)
+        grad_thresh = self.criteria.get("gradient_threshold")
+        if density is not None and grad_thresh is not None:
+            mask |= plasma_gradient_refinement(np.asarray(density), grad_thresh)
+
+        wave_thresh = self.criteria.get("wavefront_threshold")
+        if field is not None and prev_field is not None and wave_thresh is not None:
+            mask |= wavefront_refinement(np.asarray(field), np.asarray(prev_field), wave_thresh)
+
+        self._last_mask = mask
+
+        if self._backend and hasattr(self._backend, "amr"):
+            self._backend.amr.tag_cells(mask.astype(np.int8))
+            if hasattr(self._backend, "warpx"):
+                self._backend.warpx.regrid()
+
+    # ------------------------------------------------------------------
+    def tagging_stats(self) -> Dict[str, int]:
+        if self._last_mask is None:
+            return {"tagged_cells": 0}
+        return {"tagged_cells": int(self._last_mask.sum())}

--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -134,6 +134,9 @@ class SimulationEngine:
         if num_threads and num_threads > 1:
             self._executor = ThreadPoolExecutor(max_workers=num_threads)
 
+        # Adaptive mesh refinement driver
+        self._mesh = self._setup_mesh()
+
     # ------------------------------------------------------------------
     def _setup_circuit(self) -> CircuitSolver:
         cc: CircuitConfig = self.config.circuit_config
@@ -144,6 +147,18 @@ class SimulationEngine:
             V0=cc.V0 * 1e3,
         )
         return CircuitSolver(circuit)
+
+    # ------------------------------------------------------------------
+    def _setup_mesh(self):
+        """Instantiate an AMR mesh wrapper when refinement criteria provided."""
+        crit = self.config.parallel_settings.amr_refinement_criteria
+        if not crit:
+            return None
+        from .mesh import AMRMesh
+
+        gr = self.config.grid_resolution
+        shape = (getattr(gr, "nx", 1), getattr(gr, "ny", 1), getattr(gr, "nz", 1))
+        return AMRMesh(shape, crit)
 
     # ------------------------------------------------------------------
     def run(
@@ -207,6 +222,9 @@ class SimulationEngine:
             if diagnostics:
                 for diag in diagnostics:
                     diag.record(updated, circuit.time[-1])
+
+            if self._mesh is not None:
+                self._mesh.refine()
 
             current, voltage = updated.current, updated.voltage
 

--- a/tests/integration/test_geometry_loaders.py
+++ b/tests/integration/test_geometry_loaders.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+from dpf2.geometry import load_cad_geometry, load_unstructured_mesh
+
+
+def test_load_cad_geometry(tmp_path):
+    data = {"nodes": [[0, 0, 0], [1, 0, 0], [0, 1, 0]], "elements": [[0, 1, 2]]}
+    path = tmp_path / "cad.json"
+    path.write_text(json.dumps(data))
+    loaded = load_cad_geometry(path)
+    assert loaded == data
+
+
+def test_load_unstructured_mesh(tmp_path):
+    content = "\n".join([
+        "3",
+        "0 0 0",
+        "1 0 0",
+        "0 1 0",
+        "1",
+        "0 1 2",
+    ])
+    path = tmp_path / "mesh.txt"
+    path.write_text(content)
+    loaded = load_unstructured_mesh(path)
+    assert loaded["nodes"][0] == [0.0, 0.0, 0.0]
+    assert loaded["elements"][0] == [0, 1, 2]

--- a/tests/mesh/test_amr_criteria.py
+++ b/tests/mesh/test_amr_criteria.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from dpf2.mesh import plasma_gradient_refinement, wavefront_refinement
+
+
+def test_plasma_gradient_refinement_tags_cells():
+    density = np.array([[0.0, 0.0], [0.0, 1.0]])
+    mask = plasma_gradient_refinement(density, threshold=0.5)
+    assert mask[1, 1]
+
+
+def test_wavefront_refinement_detects_change():
+    prev = np.zeros((2, 2))
+    curr = np.zeros((2, 2))
+    curr[0, 0] = 1.0
+    mask = wavefront_refinement(curr, prev, threshold=0.2)
+    assert mask[0, 0]

--- a/tests/test_simulation_engine_amr_driver.py
+++ b/tests/test_simulation_engine_amr_driver.py
@@ -1,0 +1,34 @@
+import sys
+
+import pydantic_stub
+
+sys.modules.setdefault("pydantic", pydantic_stub)
+sys.modules.setdefault("pydantic.dataclasses", pydantic_stub.dataclasses)
+
+from dpf2.dpf_config import DPFConfig
+from dpf2.simulation_engine import SimulationEngine
+import numpy as np
+
+
+def test_simulation_engine_invokes_amr(monkeypatch):
+    cfg = DPFConfig.with_defaults()
+    cfg.simulation_control.time_end = 1e-9
+    cfg.simulation_control.min_dt = 1e-9
+    cfg.parallel_settings.amr_refinement_criteria = {"gradient_threshold": 0.1}
+    called = {}
+
+    def fake_refine(self, plasma_state=None, prev_field=None):
+        called["refine"] = True
+
+    def fake_run(self, time, current):
+        from types import SimpleNamespace
+        n = len(time)
+        zeros = np.zeros(n)
+        return SimpleNamespace(time=time, radius=zeros, temperature=zeros, pressure=zeros, neutron_yield=0.0, axial_position=None)
+
+    monkeypatch.setattr("dpf2.mesh.amr.AMRMesh.refine", fake_refine)
+    monkeypatch.setattr("dpf2.pinch_models.AnalyticPinchModel.run", fake_run)
+
+    engine = SimulationEngine(cfg)
+    engine.run()
+    assert called.get("refine")


### PR DESCRIPTION
## Summary
- introduce AMRMesh wrapper with gradient and wavefront refinement helpers
- integrate optional AMR driver into SimulationEngine
- add CAD and unstructured geometry loaders and corresponding tests

## Testing
- `python - <<'PY'
import sys, pytest
import pydantic_stub
sys.modules['pydantic'] = pydantic_stub
sys.modules['pydantic.dataclasses'] = pydantic_stub.dataclasses
pytest.main(['tests/mesh/test_amr_criteria.py','tests/integration/test_geometry_loaders.py','tests/test_simulation_engine_amr_driver.py'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b0df358874832abaeebcd00cf710b5