### PR TITLE
feat: add Bayesian optimization and streaming comparisons

### DIFF
--- a/examples/digital_twin/closed_loop_pipeline.py
+++ b/examples/digital_twin/closed_loop_pipeline.py
@@ -1,0 +1,53 @@
+"""Example closed-loop optimisation pipeline for digital twin workflows.
+
+This script demonstrates how experimental diagnostics can be streamed and
+compared against simulation predictions to update model parameters in real
+time.  The workflow is intentionally lightweight and operates on the simple
+``CouplingState`` object used throughout the code base.
+"""
+
+from __future__ import annotations
+
+from dpf2.core.bases import CouplingState
+from dpf2.diagnostics.streaming import NeutronYieldStreamer, RealTimeComparator
+from dpf2.optimization import BayesianParameterInference, ParameterEstimate
+
+
+def forward_model(params: dict[str, float]) -> dict[str, float]:
+    """Minimal forward model linking parameters to diagnostics."""
+
+    # Here we assume the neutron yield scales with the square of a
+    # ``current_scale`` parameter for demonstration purposes.
+    scale = params["current_scale"]
+    return {"neutron_yield": 1.0e5 * scale ** 2}
+
+
+def main() -> None:
+    # -- Prior parameter estimate ----------------------------------------
+    inference = BayesianParameterInference(
+        {"current_scale": ParameterEstimate(mean=1.0, variance=0.5)},
+        forward_model,
+    )
+
+    # -- Set up streaming diagnostics and comparison hooks ---------------
+    def comparison_callback(t: float, sim: float, exp: float) -> None:
+        print(f"t={t:.2e}s  sim={sim:.2e}  exp={exp:.2e}  residual={exp - sim:.2e}")
+
+    comparator = RealTimeComparator(comparison_callback)
+    streamer = NeutronYieldStreamer(callback=lambda t, v: comparator.compare(t, v), comparator=comparator)
+
+    # Inject a synthetic experimental measurement at t=1 microsecond
+    comparator.ingest(1e-6, 5.0e5)
+
+    # -- Run a toy simulation step ---------------------------------------
+    state = CouplingState(current=2.0, voltage=0.0)
+    streamer.record(state, 1e-6)
+
+    # -- Update parameters using the measurement -------------------------
+    updated = inference.update({"neutron_yield": 5.0e5}, {"neutron_yield": 1.0e4})
+    print("Updated parameter means:", updated)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -18,7 +18,7 @@ from .synthetic_signals import (
     rogowski_signal,
     bdot_signal,
 )
-from .streaming import NeutronYieldStreamer, XRayEmissionStreamer
+from .streaming import NeutronYieldStreamer, XRayEmissionStreamer, RealTimeComparator
 
 __all__ = [
     "compute_neutron_yield",
@@ -32,6 +32,7 @@ __all__ = [
     "bdot_signal",
     "NeutronYieldStreamer",
     "XRayEmissionStreamer",
+    "RealTimeComparator",
 ]
 
 # Compatibility helpers -------------------------------------------------------

--- a/src/dpf2/diagnostics/streaming.py
+++ b/src/dpf2/diagnostics/streaming.py
@@ -8,7 +8,7 @@ streaming to user interfaces or loggers.
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Callable, Optional, Dict
 
 from ..core.bases import DiagnosticsBase, CouplingState
 
@@ -21,14 +21,21 @@ class NeutronYieldStreamer(DiagnosticsBase):
     real-time visualisation but not for accurate physics predictions.
     """
 
-    def __init__(self, callback: Callable[[float, float], None]) -> None:
+    def __init__(
+        self,
+        callback: Callable[[float, float], None],
+        comparator: Optional["RealTimeComparator"] = None,
+    ) -> None:
         self.callback = callback
+        self.comparator = comparator
         self._total = 0.0
 
     def record(self, state: CouplingState, time: float) -> None:
         rate = 1.0e5 * state.current ** 2
         self._total += rate
         self.callback(time, rate)
+        if self.comparator is not None:
+            self.comparator.compare(time, rate)
 
     @property
     def total_yield(self) -> float:
@@ -45,13 +52,46 @@ class XRayEmissionStreamer(DiagnosticsBase):
     desired.
     """
 
-    def __init__(self, callback: Callable[[float, float], None]) -> None:
+    def __init__(
+        self,
+        callback: Callable[[float, float], None],
+        comparator: Optional["RealTimeComparator"] = None,
+    ) -> None:
         self.callback = callback
+        self.comparator = comparator
 
     def record(self, state: CouplingState, time: float) -> None:
         power = abs(state.current * state.voltage) * 1.0e-3
         self.callback(time, power)
+        if self.comparator is not None:
+            self.comparator.compare(time, power)
 
 
-__all__ = ["NeutronYieldStreamer", "XRayEmissionStreamer"]
+class RealTimeComparator:
+    """Hold experimental measurements and compare to simulation streams.
+
+    Experimental values are ingested via :meth:`ingest` and are paired with
+    simulated values using the timestamp provided to :meth:`compare`.  When
+    both values for a given time are available the supplied ``callback`` is
+    invoked with ``(time, sim_value, exp_value)``.
+    """
+
+    def __init__(self, callback: Callable[[float, float, float], None]) -> None:
+        self.callback = callback
+        self._experimental: Dict[float, float] = {}
+
+    def ingest(self, time: float, value: float) -> None:
+        """Provide an experimental measurement for later comparison."""
+
+        self._experimental[time] = value
+
+    def compare(self, time: float, sim_value: float) -> None:
+        """Compare ``sim_value`` against any stored experimental datum."""
+
+        if time in self._experimental:
+            exp_value = self._experimental.pop(time)
+            self.callback(time, sim_value, exp_value)
+
+
+__all__ = ["NeutronYieldStreamer", "XRayEmissionStreamer", "RealTimeComparator"]
 

--- a/src/dpf2/optimization/__init__.py
+++ b/src/dpf2/optimization/__init__.py
@@ -1,0 +1,6 @@
+"""Optimization utilities for parameter inference and control."""
+
+from .bayesian import BayesianParameterInference, ParameterEstimate
+
+__all__ = ["BayesianParameterInference", "ParameterEstimate"]
+

--- a/src/dpf2/optimization/bayesian.py
+++ b/src/dpf2/optimization/bayesian.py
@@ -1,0 +1,77 @@
+"""Simple Bayesian parameter inference utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+
+@dataclass
+class ParameterEstimate:
+    """Gaussian estimate of a scalar parameter."""
+
+    mean: float
+    variance: float
+
+
+class BayesianParameterInference:
+    """Perform lightweight Bayesian updates for simulation parameters.
+
+    The implementation assumes independent Gaussian priors for each
+    parameter and a user supplied ``model`` that maps a parameter dictionary
+    to predicted diagnostic values.  The :meth:`update` method then performs a
+    Kalman-style update for any diagnostics provided, returning the updated
+    parameter means.
+    """
+
+    def __init__(
+        self,
+        parameters: Dict[str, ParameterEstimate],
+        model: Callable[[Dict[str, float]], Dict[str, float]],
+    ) -> None:
+        self.parameters = parameters
+        self.model = model
+
+    # ------------------------------------------------------------------
+    def update(
+        self,
+        diagnostics: Dict[str, float],
+        noise: Dict[str, float],
+    ) -> Dict[str, float]:
+        """Update parameter estimates using experimental diagnostics.
+
+        Parameters
+        ----------
+        diagnostics:
+            Mapping of diagnostic names to measured values.
+        noise:
+            Mapping of diagnostic names to measurement variances.
+
+        Returns
+        -------
+        Dict[str, float]
+            Updated parameter means.
+        """
+
+        # Evaluate the forward model at the current parameter means
+        param_means = {name: p.mean for name, p in self.parameters.items()}
+        prediction = self.model(param_means)
+
+        for name, obs in diagnostics.items():
+            if name not in prediction or name not in self.parameters:
+                continue
+
+            pred = prediction[name]
+            param = self.parameters[name]
+            meas_var = noise.get(name, 1.0)
+
+            # Kalman gain for scalar update
+            gain = param.variance / (param.variance + meas_var)
+            param.mean = pred + gain * (obs - pred)
+            param.variance = (1.0 - gain) * param.variance
+
+        return {name: p.mean for name, p in self.parameters.items()}
+
+
+__all__ = ["BayesianParameterInference", "ParameterEstimate"]
+


### PR DESCRIPTION
## Summary
- add Bayesian parameter inference module for updating simulation parameters
- add real-time comparison hooks to streaming diagnostics
- provide digital twin example demonstrating closed-loop optimisation

## Testing
- `pytest -q` *(fails: multiple missing dependency/import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b0df3a68b8832ab0780b1eb846bb8c