### PR TITLE
Add notebook mode and structured CLI error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ simulation = DPFSimulation(config)
 result = simulation.run()
 ```
 
-Configuration files use the `DPFConfig` schema defined in this repository. See the [quickstart tutorial](docs/tutorials/quickstart.md) or its [Jupyter notebook](examples/notebooks/quickstart.ipynb) for a walk-through.
+Configuration files use the `DPFConfig` schema defined in this repository. See the [quickstart tutorial](docs/tutorials/quickstart.md) or its [Jupyter notebook](examples/notebooks/quickstart.ipynb) for a walk-through. Launch the notebook directly with:
+
+```bash
+dpf2 --notebook
+```
 
 ### Equation of State Backends
 

--- a/examples/notebooks/quickstart.ipynb
+++ b/examples/notebooks/quickstart.ipynb
@@ -1,59 +1,58 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# DPF2 Quickstart\n",
-    "Run a minimal Dense Plasma Focus simulation." 
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# DPF2 Quickstart\n",
+        "Run a minimal DPF simulation and plot the current waveform."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from dpf2.core.config import DPFConfig\n",
+        "from dpf2.core.simulation import DPFSimulation\n",
+        "import matplotlib.pyplot as plt"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "cfg = DPFConfig()\n",
+        "sim = DPFSimulation(cfg)\n",
+        "times, currents, voltages = sim.run()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "plt.plot(times, currents)\n",
+        "plt.xlabel('Time [s]')\n",
+        "plt.ylabel('Current [A]')"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
   },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
-    "from dpf_config import DPFConfig\n",
-    "from dpf2.simulation_engine import SimulationEngine\n",
-    "import matplotlib.pyplot as plt"
-   ],
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
-    "cfg = DPFConfig.with_defaults()\n",
-    "engine = SimulationEngine(cfg)\n",
-    "results = engine.run()\n",
-    "results.neutron_yield"
-   ],
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
-    "plt.plot(results.time * 1e6, results.current / 1e3)\n",
-    "plt.xlabel('Time [µs]')\n",
-    "plt.ylabel('Current [kA]')"
-   ],
-   "execution_count": null,
-   "outputs": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "pygments_lexer": "ipython3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/src/dpf2/cli/errors.py
+++ b/src/dpf2/cli/errors.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class CLIErrorInfo:
+    """Information describing a CLI error."""
+
+    code: str
+    hint: str
+
+
+ERRORS: dict[str, CLIErrorInfo] = {
+    "CONFIG": CLIErrorInfo("E001", "Check configuration path and values."),
+    "SIMULATION": CLIErrorInfo("E002", "Verify simulation parameters."),
+    "VALIDATION": CLIErrorInfo("E003", "Ensure dataset path and config are correct."),
+    "PLOT": CLIErrorInfo("E004", "Confirm the input contains HDF5 outputs."),
+    "DIAGNOSTICS": CLIErrorInfo("E005", "Provide valid history and configuration JSON files."),
+    "NOTEBOOK": CLIErrorInfo("E006", "Install Jupyter to use notebook mode."),
+    "UNEXPECTED": CLIErrorInfo("E999", "Please report this issue."),
+}
+
+
+def format_error(kind: str, message: str, hint: Optional[str] = None) -> str:
+    """Format an error message with code and remediation hint."""
+    info = ERRORS.get(kind, ERRORS["UNEXPECTED"])
+    msg = f"[{info.code}] {message}"
+    hint_text = hint or info.hint
+    if hint_text:
+        msg += f"\nHint: {hint_text}"
+    return msg

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -5,6 +5,10 @@ import dataclasses
 from pathlib import Path
 from dataclasses import asdict
 from typing import Any
+import os
+import subprocess
+import tempfile
+import textwrap
 
 import click
 
@@ -21,6 +25,7 @@ from dpf2.diagnostics.synthetic_signals import (
 )
 from dpf2.synthetic_diagnostics import SyntheticDiagnostics
 from dpf2.exceptions import ConfigurationError, SimulationRuntimeError
+from .errors import format_error
 
 
 def _prompt_with_range(prompt: str, default: float, minimum: float, maximum: float, tip: str) -> float:
@@ -56,6 +61,34 @@ def _to_float(val: Any) -> float:
         return float(val)
     except TypeError:
         return float(getattr(val, "data", val))
+
+
+def _launch_notebook() -> None:
+    """Launch Jupyter with DPF2 helpers preloaded."""
+    startup = textwrap.dedent(
+        """
+        import matplotlib.pyplot as plt
+        from dpf2.core.config import DPFConfig
+        from dpf2.core.simulation import DPFSimulation
+        from dpf2.synthetic_diagnostics import SyntheticDiagnostics
+        print('DPF2 notebook ready: DPFConfig, DPFSimulation, SyntheticDiagnostics loaded')
+        """
+    )
+    with tempfile.NamedTemporaryFile("w", delete=False) as fh:
+        fh.write(startup)
+    env = os.environ.copy()
+    env["PYTHONSTARTUP"] = fh.name
+    notebook = Path(__file__).resolve().parents[2] / "examples" / "notebooks" / "quickstart.ipynb"
+    try:
+        subprocess.run(["jupyter", "notebook", str(notebook)], env=env, check=True)
+    except FileNotFoundError:
+        raise click.ClickException(
+            format_error("NOTEBOOK", "Jupyter is not installed", "Install the 'notebook' package.")
+        )
+    except subprocess.CalledProcessError as e:
+        raise click.ClickException(
+            format_error("NOTEBOOK", f"Jupyter exited with code {e.returncode}")
+        )
 
 logger = logging.getLogger(__name__)
 
@@ -175,9 +208,20 @@ def build_config_wizard() -> DPFConfig:
     return DPFConfig(**cfg_dict)
 
 
-@click.group()
-def main() -> None:
+@click.group(invoke_without_command=True)
+@click.option(
+    "--notebook",
+    is_flag=True,
+    help="Launch Jupyter notebook with plotting widgets preloaded",
+)
+@click.pass_context
+def main(ctx: click.Context, notebook: bool) -> None:
     """Entry point for the DPF2 command line interface."""
+    if notebook:
+        _launch_notebook()
+        return
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
 
 
 @main.command()
@@ -443,19 +487,18 @@ def simulate(
                 click.echo(f"Plotting failed: {e}")
     except ConfigurationError as e:
         logger.error("Configuration error: %s", e)
-        msg = f"Configuration error: {e}"
+        hint = None
         if getattr(e, "hints", None):
-            hint_msg = "; ".join(f"{f}: {h}" for f, h in e.hints.items())
-            msg += f"\nHint: {hint_msg}"
+            hint = "; ".join(f"{f}: {h}" for f, h in e.hints.items())
         elif getattr(e, "fields", None):
-            msg += f". Check fields: {', '.join(e.fields)}"
-        raise click.ClickException(msg)
+            hint = f"Check fields: {', '.join(e.fields)}"
+        raise click.ClickException(format_error("CONFIG", str(e), hint))
     except SimulationRuntimeError as e:
         logger.error("Simulation error: %s", e)
-        raise click.ClickException(f"Simulation error: {e}")
+        raise click.ClickException(format_error("SIMULATION", str(e)))
     except Exception as e:
         logger.exception("Unexpected error running simulation")
-        raise click.ClickException(f"Unexpected error: {e}")
+        raise click.ClickException(format_error("UNEXPECTED", str(e)))
 
 
 @main.command()
@@ -470,9 +513,9 @@ def validate(config: str, dataset: str, outdir: str) -> None:
 
         ok = run_validation(Path(config), dataset, outdir=Path(outdir))
         if not ok:
-            raise click.ClickException("Validation failed")
+            raise click.ClickException(format_error("VALIDATION", "Validation failed"))
     except Exception as e:  # pragma: no cover - defensive
-        raise click.ClickException(str(e))
+        raise click.ClickException(format_error("VALIDATION", str(e)))
 
 
 @main.command("validate-config")
@@ -485,13 +528,12 @@ def validate_config(config: str) -> None:
         DPFConfig.from_file(config)
         click.echo("Configuration is valid")
     except ConfigurationError as e:
-        msg = str(e)
+        hint = None
         if getattr(e, "hints", None):
-            hint_msg = "; ".join(f"{f}: {h}" for f, h in e.hints.items())
-            msg += f"\nHint: {hint_msg}"
+            hint = "; ".join(f"{f}: {h}" for f, h in e.hints.items())
         elif getattr(e, "fields", None):
-            msg += f"\nCheck fields: {', '.join(e.fields)}"
-        raise click.ClickException(msg)
+            hint = f"Check fields: {', '.join(e.fields)}"
+        raise click.ClickException(format_error("CONFIG", str(e), hint))
 
 
 @main.command()
@@ -504,7 +546,7 @@ def plot(input: str, output: str) -> None:
 
     files = sorted(Path(input).glob("data_*.h5"))
     if not files:
-        raise click.ClickException(f"No HDF5 files found in {input}")
+        raise click.ClickException(format_error("PLOT", f"No HDF5 files found in {input}"))
 
     times, currents, voltages = [], [], []
     for fname in files:
@@ -516,7 +558,7 @@ def plot(input: str, output: str) -> None:
                 voltages.append(_to_float(fh["voltage"][()]))
 
     if not currents:
-        raise click.ClickException("No current data available")
+        raise click.ClickException(format_error("PLOT", "No current data available"))
 
     plt.figure()
     plt.plot(times, currents, label="current")
@@ -541,7 +583,7 @@ def plot_run(run_dir: str, output: str) -> None:
 
     files = sorted(Path(run_dir).glob("data_*.h5"))
     if not files:
-        raise click.ClickException(f"No HDF5 files found in {run_dir}")
+        raise click.ClickException(format_error("PLOT", f"No HDF5 files found in {run_dir}"))
 
     times, currents, voltages = [], [], []
     for fname in files:
@@ -553,7 +595,7 @@ def plot_run(run_dir: str, output: str) -> None:
                 voltages.append(_to_float(fh["voltage"][()]))
 
     if not currents:
-        raise click.ClickException("No current data available")
+        raise click.ClickException(format_error("PLOT", "No current data available"))
 
     plt.figure()
     plt.plot(times, currents, label="current")
@@ -598,34 +640,36 @@ def diagnostics(
     radius: float,
 ) -> None:
     """Generate synthetic diagnostics from a coupling history."""
+    try:
+        data = json.loads(Path(history).read_text())
+        states = [CouplingState(**d) for d in data]
 
-    data = json.loads(Path(history).read_text())
-    states = [CouplingState(**d) for d in data]
+        outputs: dict[str, list[float]] = {}
 
-    outputs: dict[str, list[float]] = {}
+        if config:
+            cfg_data = json.loads(Path(config).read_text())
+            cfg = SyntheticDiagnostics.model_validate(cfg_data)
+            if cfg.synthetic_current_waveform_enabled:
+                outputs["current"] = current_waveform(states)
+            if cfg.synthetic_voltage_waveform_enabled:
+                outputs["voltage"] = voltage_waveform(states)
+            if cfg.synthetic_rogowski_signal_enabled:
+                outputs["rogowski"] = rogowski_signal(states, dt)
+            if cfg.synthetic_bdot_signal_enabled:
+                outputs["bdot"] = bdot_signal(states, radius, dt)
 
-    if config:
-        cfg_data = json.loads(Path(config).read_text())
-        cfg = SyntheticDiagnostics.model_validate(cfg_data)
-        if cfg.synthetic_current_waveform_enabled:
+        if current:
             outputs["current"] = current_waveform(states)
-        if cfg.synthetic_voltage_waveform_enabled:
+        if voltage:
             outputs["voltage"] = voltage_waveform(states)
-        if cfg.synthetic_rogowski_signal_enabled:
+        if rogowski:
             outputs["rogowski"] = rogowski_signal(states, dt)
-        if cfg.synthetic_bdot_signal_enabled:
+        if bdot:
             outputs["bdot"] = bdot_signal(states, radius, dt)
 
-    if current:
-        outputs["current"] = current_waveform(states)
-    if voltage:
-        outputs["voltage"] = voltage_waveform(states)
-    if rogowski:
-        outputs["rogowski"] = rogowski_signal(states, dt)
-    if bdot:
-        outputs["bdot"] = bdot_signal(states, radius, dt)
-
-    click.echo(json.dumps(outputs))
+        click.echo(json.dumps(outputs))
+    except Exception as e:
+        raise click.ClickException(format_error("DIAGNOSTICS", str(e)))
 
 
 @main.command()


### PR DESCRIPTION
## Summary
- add `--notebook` option to launch a preloaded Jupyter environment
- introduce structured CLI error codes with remediation hints
- provide quickstart tutorial notebook and link from README

## Testing
- `pytest tests/test_cli_diagnostics.py tests/test_cli_extra_commands.py tests/test_cli_simulate.py -q`
- `pytest tests/test_cli_diag_frequency.py` *(fails: ModuleNotFoundError: No module named 'adios2')*

------
https://chatgpt.com/codex/tasks/task_e_68b0e5b0c7a4832abc26dcd804160a15