### PR TITLE
Add MPI scaffolding, radiation transport, and PIC coupling tests

### DIFF
--- a/src/dpf2/physics/__init__.py
+++ b/src/dpf2/physics/__init__.py
@@ -1,6 +1,6 @@
 from .mhd import ResistiveMHD
 from .energy import EnergyTracker
-from .pic import SimplePIC
+from .pic import SimplePIC, HybridPIC
 from .eos import TabulatedEOS, load_tabulated_eos, load_standard_eos
 from .radiation import RadiationTransport
 from .pic_driver import PicDriver
@@ -32,6 +32,7 @@ __all__ = [
     "ResistiveMHD",
     "EnergyTracker",
     "SimplePIC",
+    "HybridPIC",
     "TabulatedEOS",
     "load_tabulated_eos",
     "load_standard_eos",

--- a/src/dpf2/physics/pic.py
+++ b/src/dpf2/physics/pic.py
@@ -65,4 +65,26 @@ class SimplePIC(PlasmaSolverBase):
         return CouplingState(back_reaction=self.circuit_feedback.back_reaction)
 
 
-__all__ = ["SimplePIC"]
+@dataclass
+class HybridPIC(SimplePIC):
+    """Hybrid kinetic solver blending PIC particles with a fluid response.
+
+    The model extends :class:`SimplePIC` by adding a prescribed fraction of the
+    circuit current as a fluid contribution to the back‑reaction.  This keeps
+    the implementation intentionally lightweight while exercising the coupling
+    hooks in unit tests.
+    """
+
+    fluid_fraction: float = 0.0
+
+    def step(self, state: Any, dt: float, current: float, voltage: float) -> Any:
+        state = super().step(state, dt, current, voltage)
+        fluid_current = current * self.fluid_fraction
+        total = self.circuit_feedback.back_reaction + fluid_current
+        self.circuit_feedback = CouplingState(
+            current=current, voltage=voltage, back_reaction=total
+        )
+        return state
+
+
+__all__ = ["SimplePIC", "HybridPIC"]

--- a/src/dpf2/rlc_solver.py
+++ b/src/dpf2/rlc_solver.py
@@ -22,6 +22,17 @@ from concurrent.futures import ThreadPoolExecutor
 # it provides the minimal functionality used below (``array``).
 from .gpu_utils import xp, solve_linear, to_cpu
 import cmath
+import numpy as np
+
+try:  # pragma: no cover - MPI is optional
+    from mpi4py import MPI  # type: ignore
+except Exception:  # pragma: no cover - graceful fallback when mpi4py missing
+    MPI = None
+
+try:  # pragma: no cover - GPU backend optional
+    from numba import cuda  # type: ignore
+except Exception:  # pragma: no cover - fallback when numba unavailable
+    cuda = None
 
 from .circuit.distributed import TransmissionLineSegment, TriggeredSwitch, assemble_matrices
 
@@ -82,6 +93,9 @@ def solve_distributed_circuit(
     """
 
     switches = list(switches or [])
+    comm = MPI.COMM_WORLD if MPI else None
+    rank = comm.Get_rank() if comm is not None else 0
+    size = comm.Get_size() if comm is not None else 1
 
     # Simplified frequency domain solution for cascaded transmission line
     # segments.  When ``frequency`` is supplied we evaluate the full telegrapher
@@ -94,72 +108,97 @@ def solve_distributed_circuit(
     if frequency is not None and segments:
         w = 2.0 * xp.pi * frequency
         n_steps = int(t_end / dt) + 1
-        t = xp.array([i * dt for i in range(n_steps)])
-        vin = xp.array([xp.sin(w * ti) for ti in t]) * V0
 
-        if Z_load is None:
-            ZL = segments[-1].characteristic_impedance(frequency)
+        if size > 1:
+            counts = [n_steps // size + (1 if r < n_steps % size else 0) for r in range(size)]
+            offsets = [sum(counts[:r]) for r in range(size)]
+            local_idx = range(offsets[rank], offsets[rank] + counts[rank])
+            t_local = xp.array([i * dt for i in local_idx])
+            vin_local = xp.array([xp.sin(w * ti) for ti in t_local]) * V0
+            if comm is not None:
+                t = xp.array(np.concatenate(comm.allgather(to_cpu(t_local))))
+                vin = xp.array(np.concatenate(comm.allgather(to_cpu(vin_local))))
         else:
-            ZL = np.inf if Z_load == np.inf else complex(Z_load)
+            t = xp.array([i * dt for i in range(n_steps)])
+            vin = xp.array([xp.sin(w * ti) for ti in t]) * V0
 
-        # Reflection coefficients are computed from the load backwards to the
-        # source while the overall ABCD matrix is accumulated from source to
-        # load.
-        reflections: list[complex] = []
-        Z_eff = ZL
-        for seg in reversed(segments):
-            refl = seg.reflection_coefficient(frequency, Z_eff)
-            reflections.insert(0, refl)
-            Z0 = seg.characteristic_impedance(frequency)
-            gamma = seg.propagation_constant(frequency)
-            tanh_gl = cmath.tanh(gamma * seg.length)
-            Z_eff = Z0 * (Z_eff + Z0 * tanh_gl) / (Z0 + Z_eff * tanh_gl)
+        if rank == 0:
+            if Z_load is None:
+                ZL = segments[-1].characteristic_impedance(frequency)
+            else:
+                ZL = np.inf if Z_load == np.inf else complex(Z_load)
 
-        A_tot, B_tot, C_tot, D_tot = 1.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 1.0 + 0.0j
-        for seg in segments:
-            gamma = seg.propagation_constant(frequency) * seg.length
-            Z0 = seg.characteristic_impedance(frequency)
-            cosh_gl = cmath.cosh(gamma)
-            sinh_gl = cmath.sinh(gamma)
-            A = cosh_gl
-            B = Z0 * sinh_gl
-            C = (1.0 / Z0) * sinh_gl
-            D = cosh_gl
-            A_tot, B_tot, C_tot, D_tot = (
-                A_tot * A + B_tot * C,
-                A_tot * B + B_tot * D,
-                C_tot * A + D_tot * C,
-                C_tot * B + D_tot * D,
+            reflections: list[complex] = []
+            Z_eff = ZL
+            for seg in reversed(segments):
+                refl = seg.reflection_coefficient(frequency, Z_eff)
+                reflections.insert(0, refl)
+                Z0 = seg.characteristic_impedance(frequency)
+                gamma = seg.propagation_constant(frequency)
+                tanh_gl = cmath.tanh(gamma * seg.length)
+                Z_eff = Z0 * (Z_eff + Z0 * tanh_gl) / (Z0 + Z_eff * tanh_gl)
+
+            A_tot, B_tot, C_tot, D_tot = 1.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 1.0 + 0.0j
+            for seg in segments:
+                gamma = seg.propagation_constant(frequency) * seg.length
+                Z0 = seg.characteristic_impedance(frequency)
+                cosh_gl = cmath.cosh(gamma)
+                sinh_gl = cmath.sinh(gamma)
+                A = cosh_gl
+                B = Z0 * sinh_gl
+                C = (1.0 / Z0) * sinh_gl
+                D = cosh_gl
+                A_tot, B_tot, C_tot, D_tot = (
+                    A_tot * A + B_tot * C,
+                    A_tot * B + B_tot * D,
+                    C_tot * A + D_tot * C,
+                    C_tot * B + D_tot * D,
+                )
+
+            if ZL == np.inf:
+                H = 1.0 / A_tot
+                Zin = A_tot / C_tot if C_tot != 0 else np.inf
+            else:
+                H = 1.0 / (A_tot + B_tot / ZL)
+                Zin = (A_tot * ZL + B_tot) / (C_tot * ZL + D_tot)
+
+            amp = abs(H)
+            phase = cmath.phase(H)
+            I_amp = V0 / (abs(Zin) if Zin != 0 else 1e-12)
+            I_phase = -cmath.phase(Zin)
+        else:  # pragma: no cover - non-root ranks receive broadcasts
+            amp = phase = I_amp = I_phase = 0.0
+
+        if comm is not None and size > 1:
+            amp = comm.bcast(amp, root=0)
+            phase = comm.bcast(phase, root=0)
+            I_amp = comm.bcast(I_amp, root=0)
+            I_phase = comm.bcast(I_phase, root=0)
+
+        if size > 1:
+            vout_local = xp.array([xp.sin(w * ti + phase) for ti in t_local]) * (amp * V0)
+            current_local = xp.array([xp.sin(w * ti + I_phase) for ti in t_local]) * I_amp
+            branch_local = current_local[:, None]
+            vout = xp.array(np.concatenate(comm.allgather(to_cpu(vout_local))))
+            current = xp.array(np.concatenate(comm.allgather(to_cpu(current_local))))
+            branch_currents = xp.array(
+                np.concatenate(comm.allgather(to_cpu(branch_local)), axis=0)
             )
-
-        if ZL == np.inf:
-            H = 1.0 / A_tot
-            Zin = A_tot / C_tot if C_tot != 0 else np.inf
         else:
-            H = 1.0 / (A_tot + B_tot / ZL)
-            Zin = (A_tot * ZL + B_tot) / (C_tot * ZL + D_tot)
-
-        amp = abs(H)
-        phase = cmath.phase(H)
-        vout = xp.array([xp.sin(w * ti + phase) for ti in t]) * (amp * V0)
+            vout = xp.array([xp.sin(w * ti + phase) for ti in t]) * (amp * V0)
+            current = xp.array([xp.sin(w * ti + I_phase) for ti in t]) * I_amp
+            branch_currents = current[:, None]
 
         node_voltages = xp.zeros((len(t), 2))
         node_voltages[:, 0] = vin
         node_voltages[:, 1] = vout
 
-        I_amp = V0 / (abs(Zin) if Zin != 0 else 1e-12)
-        I_phase = -cmath.phase(Zin)
-        current = xp.array([xp.sin(w * ti + I_phase) for ti in t]) * I_amp
-        branch_currents = current[:, None]
-
         return DistributedRLCSolution(
-
             t=to_cpu(t),
             current=to_cpu(current),
             voltage=to_cpu(vin),
             branch_currents=to_cpu(branch_currents),
             node_voltages=to_cpu(node_voltages),
-
         )
 
     # ------------------------------------------------------------------

--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -42,6 +42,7 @@ from .pinch_models import (
 )
 
 from .physics.energy import EnergyTracker
+from .physics.radiation import RadiationTransport, MultiGroupDiffusion
 
 
 __all__ = ["SimulationEngine", "SimulationResults", "EnsembleResults"]
@@ -222,27 +223,9 @@ class SimulationEngine:
         dt = sc.min_dt or 1e-9
         t_end = sc.time_end - sc.time_start
 
-        if plasma_solver is not None:
-            cc: CircuitConfig = self.config.circuit_config
-            num = int(t_end / dt) + 1
-            t, current, _, _, _ = run_circuit_simulation(
-                cc, t_end * 1e6, num_points=num, plasma_solver=plasma_solver, plasma_state=None
-            )
-            t_xp = self.xp.array(t)
-            cur_xp = self.xp.array(current)
-            zeros = self.xp.zeros_like(t_xp)
-            return SimulationResults(
-                time=self._to_numpy(t_xp),
-                current=self._to_numpy(cur_xp),
-                radius=self._to_numpy(zeros),
-                temperature=self._to_numpy(zeros),
-                pressure=self._to_numpy(zeros),
-                neutron_yield=0.0,
-                axial_position=None,
-            )
-
         circuit = self._setup_circuit()
         tracker = EnergyTracker()
+        radiation = RadiationTransport(MultiGroupDiffusion([0.0]), dx=1.0)
 
         # Record initial energies
         tracker.add(
@@ -253,8 +236,17 @@ class SimulationEngine:
         current = circuit.currents[-1]
         voltage = circuit.voltages[-1]
         step = 0
+        plasma_state = None
         while circuit.time[-1] < t_end:
             state = CouplingState(current=current, voltage=voltage)
+            if plasma_solver is not None:
+                plasma_state = plasma_solver.step(plasma_state, dt, current, voltage)
+                iface = plasma_solver.coupling_interface()
+                br = iface.back_reaction
+                if self.comm is not None and self.comm.size > 1:  # pragma: no cover - MPI
+                    br = self.comm.allreduce(br, op=MPI.SUM)
+                state.back_reaction = br
+
             # Optional multithreading for circuit stepping
             if self._executor is not None:
                 future = self._executor.submit(
@@ -264,9 +256,14 @@ class SimulationEngine:
             else:
                 updated = circuit.step(state, 0.0, dt, energy_tracker=tracker)
 
-            # Broadcast updated state across MPI ranks if requested
             if self.comm is not None and (self.comm.size > 1):  # pragma: no cover - MPI
                 updated = self.comm.bcast(updated, root=0)
+
+            # Radiation transport coupling
+            rad_in = tracker.thermal[-1] if tracker.thermal else 0.0
+            rad_out, rad_groups = radiation.step(rad_in, dt)
+            tracker.thermal[-1] = float(rad_out)
+            tracker.radiative[-1] = float(np.sum(rad_groups))
 
             if diagnostics:
                 for diag in diagnostics:

--- a/tests/physics/test_pic_coupling.py
+++ b/tests/physics/test_pic_coupling.py
@@ -1,0 +1,30 @@
+import pytest
+
+from dpf2.physics.pic import SimplePIC, HybridPIC
+
+
+def test_simple_pic_coupling():
+    pic = SimplePIC(
+        charge=1.0,
+        mass=1.0,
+        length=1.0,
+        positions=[0.0, 0.5],
+        velocities=[0.0, 0.0],
+    )
+    pic.step(None, dt=1.0, current=0.0, voltage=1.0)
+    iface = pic.coupling_interface()
+    assert iface.back_reaction == pytest.approx(2.0)
+
+
+def test_hybrid_pic_coupling():
+    pic = HybridPIC(
+        charge=1.0,
+        mass=1.0,
+        length=1.0,
+        positions=[0.0, 0.5],
+        velocities=[0.0, 0.0],
+        fluid_fraction=0.5,
+    )
+    pic.step(None, dt=1.0, current=2.0, voltage=1.0)
+    iface = pic.coupling_interface()
+    assert iface.back_reaction == pytest.approx(3.0)


### PR DESCRIPTION
## Summary
- parallelize distributed RLC solver with optional MPI scatter/gather and GPU hooks
- integrate radiation transport and MPI-aware plasma coupling in simulation engine
- add HybridPIC model and regression tests for PIC coupling

## Testing
- `pytest` *(fails: ImportError - missing optional dependencies and 26 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e5b6b8e8832a9e754c2972a895c8