### PR TITLE
Add FastAPI/React web app skeleton with authentication and job submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,11 @@ env/
 # Byte-compiled / cache
 __pycache__/
 *.pyc
+
+# Web frontend artifacts
+web/frontend/node_modules/
+web/frontend/dist/
+
+# Web runtime logs and uploads
+web/audit.log
+web/uploads/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,10 @@ dependencies = [
 server = [
     "flask",
     "flask-sock",
-    "werkzeug"
+    "werkzeug",
+    "fastapi",
+    "uvicorn",
+    "python-multipart"
 ]
 warpx = [
     "pywarpx",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ numba
 sympy
 werkzeug
 tqdm
+fastapi
+uvicorn
+python-multipart

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from pydantic import BaseModel
+
+from dpf2.dpf_config import DPFConfig
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+AUDIT_LOG = BASE_DIR / "audit.log"
+UPLOAD_DIR = BASE_DIR / "uploads"
+logging.basicConfig(level=logging.INFO, filename=str(AUDIT_LOG), format="%(asctime)s %(message)s")
+logger = logging.getLogger("dpf-web")
+
+users = {
+    "admin": {"username": "admin", "password": "secret", "role": "admin"},
+    "user": {"username": "user", "password": "secret", "role": "user"},
+}
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+app = FastAPI()
+
+
+def get_current_user(token: str = Depends(oauth2_scheme)):
+    user = users.get(token)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+        )
+    return user
+
+
+def require_role(role: str):
+    def _checker(user=Depends(get_current_user)):
+        if user["role"] not in {role, "admin"}:
+            raise HTTPException(status_code=403, detail="Not authorized")
+        return user
+
+    return _checker
+
+
+@app.post("/token")
+def login(form_data: OAuth2PasswordRequestForm = Depends()):
+    user = users.get(form_data.username)
+    if not user or user["password"] != form_data.password:
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+    return {"access_token": user["username"], "token_type": "bearer"}
+
+
+class RunRequest(BaseModel):
+    config: Dict[str, Any]
+
+
+@app.post("/run")
+def run_simulation(req: RunRequest, user=Depends(get_current_user)):
+    cfg = DPFConfig.model_validate(req.config)
+    run_id = dispatch_to_hpc(cfg, user["username"])
+    logger.info("action=submit user=%s run_id=%s", user["username"], run_id)
+    return {"run_id": run_id}
+
+
+def dispatch_to_hpc(cfg: DPFConfig, username: str) -> str:
+    run_id = f"run-{int(datetime.utcnow().timestamp())}"
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    (UPLOAD_DIR / f"{run_id}.json").write_text(cfg.model_dump_json())
+    # Placeholder for real HPC dispatch
+    return run_id
+
+
+@app.get("/results/{run_id}")
+def get_results(run_id: str, user=Depends(require_role("admin"))):
+    path = UPLOAD_DIR / f"{run_id}.json"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Run not found")
+    logger.info("action=get_results user=%s run_id=%s", user["username"], run_id)
+    return json.loads(path.read_text())

--- a/web/frontend/index.html
+++ b/web/frontend/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>DPF2 Web</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/web/frontend/package.json
+++ b/web/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "dpf2-web",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "axios": "^1.6.7"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  },
+  "scripts": {
+    "start": "vite",
+    "build": "vite build"
+  }
+}

--- a/web/frontend/src/App.jsx
+++ b/web/frontend/src/App.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+export default function App() {
+  const [token, setToken] = useState('');
+  const [config, setConfig] = useState('{}');
+  const [runId, setRunId] = useState('');
+
+  const login = async (e) => {
+    e.preventDefault();
+    const form = new FormData(e.target);
+    const { data } = await axios.post('/token', form);
+    setToken(data.access_token);
+  };
+
+  const submitConfig = async (e) => {
+    e.preventDefault();
+    const cfg = JSON.parse(config);
+    const { data } = await axios.post('/run', { config: cfg }, { headers: { Authorization: `Bearer ${token}` } });
+    setRunId(data.run_id);
+  };
+
+  return (
+    <div>
+      {!token && (
+        <form onSubmit={login}>
+          <h3>Login</h3>
+          <input name="username" placeholder="username" />
+          <input name="password" type="password" placeholder="password" />
+          <button type="submit">Login</button>
+        </form>
+      )}
+      {token && (
+        <form onSubmit={submitConfig}>
+          <h3>Submit Config</h3>
+          <textarea rows={10} cols={50} value={config} onChange={(e) => setConfig(e.target.value)} />
+          <br />
+          <button type="submit">Run</button>
+        </form>
+      )}
+      {runId && <p>Submitted run: {runId}</p>}
+    </div>
+  );
+}

--- a/web/frontend/src/main.jsx
+++ b/web/frontend/src/main.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+
+createRoot(document.getElementById('root')).render(<App />);

--- a/web/frontend/vite.config.js
+++ b/web/frontend/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/token': 'http://localhost:8000',
+      '/run': 'http://localhost:8000',
+      '/results': 'http://localhost:8000'
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- introduce FastAPI backend with token-based auth, role checks, and audit logging
- add React frontend for login and config submission
- document new server dependencies and ignore frontend build artifacts

## Testing
- `pip install fastapi uvicorn python-multipart` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'werkzeug'; ImportError: cannot import name 'HallMHD' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b1c27823fc832a89e11f6025898eb0