### PR TITLE
Add HPC job manager, containerization, and visualization pipeline

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,0 +1,7 @@
+# Simple container for running dpf2 simulations
+FROM python:3.12-slim
+WORKDIR /app
+COPY .. /app
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir .
+CMD ["dpf2"]

--- a/infrastructure/Singularity.def
+++ b/infrastructure/Singularity.def
@@ -1,0 +1,12 @@
+Bootstrap: docker
+From: python:3.12-slim
+
+%post
+    pip install -r /app/requirements.txt
+    pip install /app
+
+%files
+    .. /app
+
+%runscript
+    exec dpf2 "$@"

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -1,0 +1,52 @@
+# Terraform configuration for deploying dpf2 on AWS Batch
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  required_version = ">= 1.5.0"
+}
+
+provider "aws" {
+  region = var.region
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+# Minimal Batch compute environment
+resource "aws_batch_compute_environment" "dpf2" {
+  compute_environment_name = "dpf2"
+  service_role             = aws_iam_role.batch_service.arn
+  type                     = "MANAGED"
+
+  compute_resources {
+    max_vcpus = 16
+    type      = "EC2"
+    subnets   = []
+    security_group_ids = []
+    instance_types = ["m5.large"]
+  }
+}
+
+resource "aws_iam_role" "batch_service" {
+  name = "dpf2-batch-service-role"
+  assume_role_policy = data.aws_iam_policy_document.batch_assume.json
+}
+
+data "aws_iam_policy_document" "batch_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["batch.amazonaws.com"]
+    }
+  }
+}
+
+# Job queue and definition would be added here.

--- a/src/dpf2/hpc/__init__.py
+++ b/src/dpf2/hpc/__init__.py
@@ -1,0 +1,4 @@
+"""HPC job management utilities."""
+from .manager import JobManager
+
+__all__ = ["JobManager"]

--- a/src/dpf2/hpc/manager.py
+++ b/src/dpf2/hpc/manager.py
@@ -1,0 +1,61 @@
+"""Simple job manager for scheduling simulations on HPC resources.
+
+This module provides a :class:`JobManager` that abstracts submission of
+simulation runs to different schedulers such as MPI via ``mpirun``,
+SLURM clusters and AWS Batch.  The implementation intentionally focuses on
+small scale examples and does not aim to expose the full feature set of the
+underlying schedulers.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import subprocess
+from typing import Any, Dict
+
+
+@dataclass
+class JobManager:
+    """Dispatch simulation jobs to different backends."""
+
+    scheduler: str = "slurm"
+
+    def submit(self, job_script: str, **kwargs: Any) -> Any:
+        """Submit ``job_script`` to the configured scheduler.
+
+        Parameters
+        ----------
+        job_script:
+            Path to a submission script or executable.
+        **kwargs:
+            Additional scheduler specific keyword arguments.
+
+        Returns
+        -------
+        Any
+            Scheduler specific return object.
+        """
+
+        if self.scheduler == "slurm":
+            cmd = ["sbatch", job_script]
+            return subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if self.scheduler == "awsbatch":
+            try:
+                import boto3  # type: ignore
+            except Exception as exc:  # pragma: no cover - optional dependency
+                raise RuntimeError("boto3 is required for AWS Batch submissions") from exc
+            batch = boto3.client("batch")
+            params: Dict[str, Any] = {
+                "jobName": kwargs.get("job_name", "dpf2-job"),
+                "jobQueue": kwargs["job_queue"],
+                "jobDefinition": kwargs["job_definition"],
+            }
+            if "parameters" in kwargs:
+                params["parameters"] = kwargs["parameters"]
+            return batch.submit_job(**params)
+        if self.scheduler == "mpi":
+            cmd = ["mpirun", job_script]
+            return subprocess.run(cmd, capture_output=True, text=True, check=False)
+        raise ValueError(f"Unsupported scheduler: {self.scheduler}")
+
+
+__all__ = ["JobManager"]

--- a/src/dpf2/post/__init__.py
+++ b/src/dpf2/post/__init__.py
@@ -1,0 +1,4 @@
+"""Post-processing utilities for simulation output."""
+from .visualize import generate_mesh, render_video
+
+__all__ = ["generate_mesh", "render_video"]

--- a/src/dpf2/post/visualize.py
+++ b/src/dpf2/post/visualize.py
@@ -1,0 +1,96 @@
+"""Visualization utilities using VTK.
+
+The functions in this module are intentionally lightweight wrappers around VTK
+primitives.  They convert NumPy arrays into VTK data structures to write mesh
+files and subsequently render those meshes to video.  ParaView can consume the
+produced ``.vtp`` files for further interactive exploration.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import vtk
+    from vtk.util.numpy_support import numpy_to_vtk
+except Exception:  # pragma: no cover
+    vtk = None
+    numpy_to_vtk = None
+
+
+def generate_mesh(points: np.ndarray, polys: np.ndarray, filename: Path) -> Path:
+    """Create a VTK PolyData mesh from ``points`` and ``polys``.
+
+    Parameters
+    ----------
+    points:
+        Array of vertex coordinates with shape ``(N, 3)``.
+    polys:
+        Connectivity array defining triangular faces.
+    filename:
+        Output ``.vtp`` file.
+    """
+
+    if vtk is None:
+        raise RuntimeError("VTK is required for mesh generation")
+
+    poly_data = vtk.vtkPolyData()
+    vtk_points = vtk.vtkPoints()
+    vtk_points.SetData(numpy_to_vtk(points))
+    poly_data.SetPoints(vtk_points)
+
+    cells = vtk.vtkCellArray()
+    flat = np.hstack([np.full((polys.shape[0], 1), 3), polys]).astype(np.int64)
+    cells.SetCells(polys.shape[0], numpy_to_vtk(flat.flatten()))
+    poly_data.SetPolys(cells)
+
+    writer = vtk.vtkXMLPolyDataWriter()
+    writer.SetFileName(str(filename))
+    writer.SetInputData(poly_data)
+    writer.Write()
+    return filename
+
+
+def render_video(mesh_file: Path, output: Path, n_frames: int = 360) -> Path:
+    """Render ``mesh_file`` to ``output`` video using VTK."""
+
+    if vtk is None:
+        raise RuntimeError("VTK is required for rendering")
+
+    reader = vtk.vtkXMLPolyDataReader()
+    reader.SetFileName(str(mesh_file))
+    reader.Update()
+
+    mapper = vtk.vtkPolyDataMapper()
+    mapper.SetInputConnection(reader.GetOutputPort())
+
+    actor = vtk.vtkActor()
+    actor.SetMapper(mapper)
+
+    renderer = vtk.vtkRenderer()
+    renderer.AddActor(actor)
+
+    window = vtk.vtkRenderWindow()
+    window.AddRenderer(renderer)
+    window.SetSize(800, 600)
+
+    w2i = vtk.vtkWindowToImageFilter()
+    w2i.SetInput(window)
+
+    writer = vtk.vtkFFMPEGWriter()
+    writer.SetInputConnection(w2i.GetOutputPort())
+    writer.SetFileName(str(output))
+    writer.Start()
+
+    for i in range(n_frames):
+        window.Render()
+        renderer.GetActiveCamera().Azimuth(360.0 / n_frames)
+        w2i.Modified()
+        writer.Write()
+
+    writer.End()
+    return output
+
+
+__all__ = ["generate_mesh", "render_video"]


### PR DESCRIPTION
## Summary
- add `JobManager` to submit jobs to SLURM, MPI, or AWS Batch
- containerize simulations via Docker/Singularity and provide Terraform AWS Batch example
- create VTK-based post-processing utilities for mesh generation and video rendering

## Testing
- `pytest` *(fails: FileNotFoundError, NameError, etc. during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c279773c832aaa6f0142333c16a9