### PR TITLE
docs: add advanced workflow tutorial and API stubs

### DIFF
--- a/docs/api/dpf2.circuit.md
+++ b/docs/api/dpf2.circuit.md
@@ -1,0 +1,1 @@
+::: dpf2.circuit

--- a/docs/api/dpf2.physics.md
+++ b/docs/api/dpf2.physics.md
@@ -1,0 +1,1 @@
+::: dpf2.physics

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,8 +3,8 @@
 Welcome to the DPF2 documentation. This site provides:
 
 - A comprehensive [User Guide](user_guide.md) covering installation, configuration, physics modules, examples, and server usage.
-- An [API Reference](api_reference.md) generated directly from the source code with links to examples.
-- Ready-to-use [configuration templates](config_templates/) with validation hints.
-- Step-by-step [tutorials](tutorials/) such as the [Quickstart](tutorials/quickstart.md) with an accompanying [Jupyter notebook](../examples/notebooks/quickstart.ipynb).
+- An [API Reference](api_reference.md) generated directly from the source code with links to examples and component modules such as [circuit](api/dpf2.circuit.md) and [physics](api/dpf2.physics.md).
+- Ready-to-use [configuration templates](config_templates/) with validation hints and an [example config](../examples/config.json) to start from.
+- Step-by-step [tutorials](tutorials/) including the [Quickstart](tutorials/quickstart.md) and [Advanced Workflow](tutorials/advanced_workflow.md) with an accompanying [Jupyter notebook](../examples/notebooks/quickstart.ipynb).
 
 Use the navigation to explore the simulator and learn how to extend it.

--- a/docs/tutorials/advanced_workflow.md
+++ b/docs/tutorials/advanced_workflow.md
@@ -1,0 +1,48 @@
+# Advanced Workflow Tutorial
+
+Run DPF2 on a cluster, monitor progress, and collect results.
+
+## 1. Submit to an HPC scheduler
+
+The `dpf2 simulate` command can be launched from a batch script. With Slurm:
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=dpf2
+#SBATCH --time=00:30:00
+#SBATCH --ntasks=4
+#SBATCH --output=logs/%j.out
+
+module load python
+cd $SLURM_SUBMIT_DIR
+srun dpf2 simulate -c config.json -o run --diagnostics
+```
+
+The job reads `config.json` (see [examples/config.json](../../examples/config.json) or the [configuration templates](../config_templates/)) and writes diagnostics to the `run` directory.
+
+## 2. Stream live diagnostics
+
+For quick feedback, enable the live plot option:
+
+```bash
+dpf2 simulate -c config.json -o run --live-plot
+```
+
+The terminal streams current and voltage traces during execution. Use `--verbose` for detailed logging.
+
+## 3. Retrieve results
+
+When the job completes, copy the run directory back and extract waveforms:
+
+```bash
+scp -r mycluster:~/runs/latest ./run
+dpf2 diagnostics --history run/history.json --current --voltage > traces.json
+```
+
+You can also produce plots directly:
+
+```bash
+dpf2 plot-run --history run/history.json --output current.png
+```
+
+See the [HPC design notes](../HPC_DESIGN.md) for more on scaling and cluster integration.


### PR DESCRIPTION
## Summary
- document advanced cluster workflow with submission, monitoring, and results extraction
- add API doc stubs for `dpf2.circuit` and `dpf2.physics`
- expand index with cross-links and example configuration

## Testing
- `mkdocs gen-files docs/api/dpf2.circuit.md docs/api/dpf2.physics.md` *(fails: command not found)*
- `pytest` *(fails: missing dependencies; 27 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cb01a6bc832aa529268e3b68fbaf