### PR TITLE
Integrate GPU kernels and streaming diagnostics

### DIFF
--- a/scripts/sweep_jobs.py
+++ b/scripts/sweep_jobs.py
@@ -1,0 +1,56 @@
+"""Launch parameter sweep jobs using :class:`~dpf2.hpc.JobManager`."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+from dpf2.hpc import JobManager
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True, help="Base configuration file")
+    parser.add_argument("--param", type=str, required=True, help="Parameter name to vary")
+    parser.add_argument(
+        "--values", type=float, nargs="+", required=True, help="List of parameter values"
+    )
+    parser.add_argument(
+        "--scheduler",
+        type=str,
+        default="mpi",
+        choices=["mpi", "slurm", "awsbatch"],
+        help="Job scheduler backend",
+    )
+    parser.add_argument(
+        "--outdir", type=Path, default=Path("sweep_results"), help="Directory for outputs"
+    )
+    args = parser.parse_args()
+
+    args.outdir.mkdir(exist_ok=True)
+    jm = JobManager(args.scheduler)
+
+    job_files: list[Path] = []
+    for val in args.values:
+        script = args.outdir / f"job_{args.param}_{val:.3g}.sh"
+        cmd = (
+            f"python scripts/parameter_sweep.py --config {args.config} --param {args.param} "
+            f"--values {val} --outdir {args.outdir}"
+        )
+        script.write_text(f"#!/bin/bash\n{cmd}\n")
+        script.chmod(0o755)
+        jm.submit(str(script))
+        job_files.append(args.outdir / f"{args.param}_{val:.3g}.npz")
+
+    for res in job_files:
+        if res.exists():
+            data = np.load(res)
+            print(f"{res.stem}: peak current {data['current'].max():.3e} A")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/src/dpf2/diagnostics/streaming.py
+++ b/src/dpf2/diagnostics/streaming.py
@@ -59,12 +59,20 @@ class XRayEmissionStreamer(DiagnosticsBase):
     ) -> None:
         self.callback = callback
         self.comparator = comparator
+        self._total = 0.0
 
     def record(self, state: CouplingState, time: float) -> None:
         power = abs(state.current * state.voltage) * 1.0e-3
+        self._total += power
         self.callback(time, power)
         if self.comparator is not None:
             self.comparator.compare(time, power)
+
+    @property
+    def total_power(self) -> float:
+        """Return accumulated X-ray emission estimate."""
+
+        return self._total
 
 
 class RealTimeComparator:

--- a/src/dpf2/rlc_solver.py
+++ b/src/dpf2/rlc_solver.py
@@ -24,6 +24,18 @@ from .gpu_utils import xp, solve_linear, to_cpu
 import cmath
 import numpy as np
 
+try:  # pragma: no cover - cupy optional
+    import cupy as cp  # type: ignore
+    _currents_kernel = cp.ElementwiseKernel(
+        "float64 prev, float64 vi, float64 vj, float64 R, float64 L, float64 dt",
+        "float64 out",
+        "out = prev + ((vi - vj - R * prev) / L) * dt;",
+        "rlc_update_currents",
+    )
+except Exception:  # pragma: no cover - fallback when cupy unavailable
+    cp = None  # type: ignore
+    _currents_kernel = None
+
 try:  # pragma: no cover - MPI is optional
     from mpi4py import MPI  # type: ignore
 except Exception:  # pragma: no cover - graceful fallback when mpi4py missing
@@ -403,20 +415,43 @@ def solve_distributed_circuit(
             v_full[node_index[n]] = v_unknown[unk_index[n]] if n_unknown else 0.0
 
         # Update branch currents with solved voltages
-        for idx_b, br in enumerate(branches):
-            i = node_index[br.from_node]
-            j = node_index[br.to_node]
-            if br.delay_steps > 0 and k - br.delay_steps >= 0:
-                vi = node_voltages[k - br.delay_steps, i]
-                vj = node_voltages[k - br.delay_steps, j]
-            elif br.delay_steps > 0:
-                vi = node_voltages[0, i]
-                vj = node_voltages[0, j]
-            else:
-                vi = v_full[i]
-                vj = v_full[j]
-            dIdt = (vi - vj - br.R * currents[k - 1, idx_b]) / br.L
-            currents[k, idx_b] = currents[k - 1, idx_b] + dIdt * dt
+        if _currents_kernel is not None and n_branches:
+            vi_arr = xp.zeros(n_branches)
+            vj_arr = xp.zeros(n_branches)
+            R_arr = xp.array([br.R for br in branches])
+            L_arr = xp.array([br.L for br in branches])
+            for idx_b, br in enumerate(branches):
+                i = node_index[br.from_node]
+                j = node_index[br.to_node]
+                if br.delay_steps > 0 and k - br.delay_steps >= 0:
+                    vi = node_voltages[k - br.delay_steps, i]
+                    vj = node_voltages[k - br.delay_steps, j]
+                elif br.delay_steps > 0:
+                    vi = node_voltages[0, i]
+                    vj = node_voltages[0, j]
+                else:
+                    vi = v_full[i]
+                    vj = v_full[j]
+                vi_arr[idx_b] = vi
+                vj_arr[idx_b] = vj
+            currents[k] = _currents_kernel(
+                currents[k - 1], vi_arr, vj_arr, R_arr, L_arr, dt
+            )
+        else:
+            for idx_b, br in enumerate(branches):
+                i = node_index[br.from_node]
+                j = node_index[br.to_node]
+                if br.delay_steps > 0 and k - br.delay_steps >= 0:
+                    vi = node_voltages[k - br.delay_steps, i]
+                    vj = node_voltages[k - br.delay_steps, j]
+                elif br.delay_steps > 0:
+                    vi = node_voltages[0, i]
+                    vj = node_voltages[0, j]
+                else:
+                    vi = v_full[i]
+                    vj = v_full[j]
+                dIdt = (vi - vj - br.R * currents[k - 1, idx_b]) / br.L
+                currents[k, idx_b] = currents[k - 1, idx_b] + dIdt * dt
 
         node_voltages[k] = v_full
 

--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -34,6 +34,7 @@ from .circuit_config import CircuitConfig
 
 from .circuit_solver import RLCCircuit, CircuitSolver, run_circuit_simulation
 from .core.bases import PlasmaSolverBase, CouplingState, DiagnosticsBase
+from .diagnostics import NeutronYieldStreamer, XRayEmissionStreamer
 from .pinch_models import (
     AnalyticPinchModel,
     SemiAnalyticPinchModel,
@@ -208,6 +209,8 @@ class SimulationEngine:
         energy_csv: str | None = None,
         energy_tol: float | None = None,
         diagnostics: Sequence[DiagnosticsBase] | None = None,
+        neutron_cb: Callable[[float, float], None] | None = None,
+        xray_cb: Callable[[float, float], None] | None = None,
         progress_cb: Callable[[int, float, float, float], None] | None = None,
     ) -> SimulationResults:
         """Run the simulation and return aggregated results.
@@ -218,6 +221,9 @@ class SimulationEngine:
             Optional callback invoked after each circuit step with
             ``(step, time, current, voltage)`` allowing in-situ diagnostics
             or live visualisation.
+        neutron_cb, xray_cb:
+            Callbacks receiving ``(time, value)`` for streaming neutron
+            yield and X-ray emission respectively.
         """
         sc = self.config.simulation_control
         dt = sc.min_dt or 1e-9
@@ -237,6 +243,12 @@ class SimulationEngine:
         voltage = circuit.voltages[-1]
         step = 0
         plasma_state = None
+        diag_list = list(diagnostics or [])
+        if neutron_cb is not None:
+            diag_list.append(NeutronYieldStreamer(neutron_cb))
+        if xray_cb is not None:
+            diag_list.append(XRayEmissionStreamer(xray_cb))
+
         while circuit.time[-1] < t_end:
             state = CouplingState(current=current, voltage=voltage)
             if plasma_solver is not None:
@@ -265,8 +277,8 @@ class SimulationEngine:
             tracker.thermal[-1] = float(rad_out)
             tracker.radiative[-1] = float(np.sum(rad_groups))
 
-            if diagnostics:
-                for diag in diagnostics:
+            if diag_list:
+                for diag in diag_list:
                     diag.record(updated, circuit.time[-1])
 
             if self._mesh is not None:

--- a/src/dpf2/solvers/axisymmetric_hlld.py
+++ b/src/dpf2/solvers/axisymmetric_hlld.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Any
 
-import numpy as np
+from ..gpu_utils import xp as np
 
 from dpf2.core.bases import PlasmaSolverBase
 

--- a/src/dpf2/solvers/muscl_hancock.py
+++ b/src/dpf2/solvers/muscl_hancock.py
@@ -1,7 +1,21 @@
 """MUSCL-Hancock scheme for MHD."""
 from __future__ import annotations
 
-import numpy as np
+from ..gpu_utils import xp
+
+try:  # pragma: no cover - optional GPU backend
+    import cupy as cp  # type: ignore
+    _minmod_kernel = cp.ElementwiseKernel(
+        "float64 a, float64 b",
+        "float64 out",
+        "out = (a*b > 0) ? ((fabs(a) < fabs(b)) ? a : b) : 0.0;",
+        "minmod_kernel",
+    )
+except Exception:  # pragma: no cover - fallback when cupy unavailable
+    cp = None  # type: ignore
+    _minmod_kernel = None
+
+np = xp
 
 
 class MUSCLHancock:
@@ -23,6 +37,8 @@ class MUSCLHancock:
     # reconstruction utilities
     # ------------------------------------------------------------------
     def _minmod(self, a: np.ndarray, b: np.ndarray) -> np.ndarray:
+        if _minmod_kernel is not None:
+            return _minmod_kernel(a, b)  # type: ignore[no-untyped-call]
         return np.where(np.sign(a) == np.sign(b), np.sign(a) * np.minimum(np.abs(a), np.abs(b)), 0.0)
 
     def _slope(self, U: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
## Summary
- accelerate RLC solver branch updates with optional CuPy GPU kernel
- enable GPU-aware plasma solvers and add kernel-accelerated minmod limiter
- stream neutron yield and X-ray power via new hooks in `SimulationEngine`
- add `sweep_jobs.py` script to dispatch parameter sweeps through `JobManager`

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'HallMHD' from 'dpf2.physics', ModuleNotFoundError: No module named 'werkzeug', ModuleNotFoundError: No module named 'adios2', ModuleNotFoundError: No module named 'scipy.constants')*


------
https://chatgpt.com/codex/tasks/task_e_68b1caff6594832aaf68afadd58ab2d7