### PR TITLE
Support EM feedback in frequency-domain circuit solver

### DIFF
--- a/src/dpf2/rlc_solver.py
+++ b/src/dpf2/rlc_solver.py
@@ -221,6 +221,17 @@ def solve_distributed_circuit(
         phase_I = cmath.phase(I_src)
         total_I = xp.array([xp.sin(w * ti + phase_I) for ti in t]) * amp_I
 
+        # Couple to optional EM solver using the generated time series
+        if em_solver is not None:
+            em_state: Any | None = None
+            for idx in range(n_steps):
+                I_src_t = float(to_cpu(total_I[idx]))
+                V_in_t = float(to_cpu(vin[idx]))
+                em_state = em_solver.step(em_state, dt, I_src_t, V_in_t)
+                fb = em_solver.coupling_interface()
+                total_I[idx] += fb.back_reaction
+                vin[idx] += fb.voltage
+
         # Reflection coefficients for backward compatibility
         if Z_load is None:
             ZL = segments[-1].characteristic_impedance(frequency)

--- a/tests/physics/test_radiation_mhd_coupling.py
+++ b/tests/physics/test_radiation_mhd_coupling.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from dpf2.physics.radiation_mhd_solver import RadiationMHDSolver
+from dpf2.circuit.distributed import TransmissionLineSegment
+from dpf2.rlc_solver import solve_distributed_circuit
+
+
+def test_frequency_domain_coupling_zero_back_reaction():
+    seg = TransmissionLineSegment(
+        from_node=0,
+        to_node=1,
+        length=1.0,
+        L_per_m=1e-6,
+        R_per_m=0.0,
+        C_per_m=1e-10,
+    )
+    solver = RadiationMHDSolver()
+    freq = 1e7
+    dt = 1e-9
+    t_end = 1e-8
+    res = solve_distributed_circuit(
+        [seg],
+        [],
+        V0=1.0,
+        t_end=t_end,
+        dt=dt,
+        frequency=freq,
+        em_solver=solver,
+    )
+    ref = solve_distributed_circuit([seg], [], V0=1.0, t_end=t_end, dt=dt, frequency=freq)
+    assert np.allclose(res.current, ref.current)
+    assert np.allclose(res.voltage, ref.voltage)
+    assert solver.coupling_interface().back_reaction == 0.0


### PR DESCRIPTION
## Summary
- incorporate EM solver feedback in frequency-domain RLC simulations
- add regression test for frequency-domain radiation MHD coupling

## Testing
- `pytest tests/physics/test_radiation_mhd_coupling.py tests/physics/test_em_circuit_coupling.py tests/physics/test_telegrapher_branch.py`

------
https://chatgpt.com/codex/tasks/task_e_68b894003064832a88aa5ce2998cf80a