### PR TITLE
test: update radiation MHD import path

### DIFF
--- a/tests/physics/test_radiation_mhd_amr.py
+++ b/tests/physics/test_radiation_mhd_amr.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from dpf2.physics.radiation_mhd_solver import RadiationMHDSolver
+from dpf2.physics.radiation_mhd import RadiationMHDSolver
 from dpf2.circuit.distributed import TransmissionLineSegment
 from dpf2.rlc_solver import solve_distributed_circuit
 


### PR DESCRIPTION
## Summary
- update radiation MHD solver import in radiation-MHD AMR test

## Testing
- `pytest tests/physics/test_radiation_mhd_amr.py` *(fails: No module named 'dpf2.physics.radiation_mhd')*
- `pre-commit run --files tests/physics/test_radiation_mhd_amr.py` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b89401cd10832aa2dc0c790ce65401