### PR TITLE
Return full coupling state from RadiationMHDSolver

### DIFF
--- a/src/dpf2/physics/radiation_mhd.py
+++ b/src/dpf2/physics/radiation_mhd.py
@@ -164,7 +164,7 @@ class RadiationMHDSolver(PlasmaSolverBase):
     def coupling_interface(self) -> CouplingState:  # pragma: no cover - trivial
         """Return circuit coupling terms."""
 
-        return CouplingState(back_reaction=self.circuit_feedback.back_reaction)
+        return self.circuit_feedback
 
 
 __all__ = ["AMRGrid", "RadiationMHDState", "RadiationMHDSolver"]

--- a/tests/physics/test_em_circuit_coupling.py
+++ b/tests/physics/test_em_circuit_coupling.py
@@ -39,5 +39,5 @@ def test_circuit_em_coupling_back_reaction():
     em = FDTDSolver([1.0])
     dt = 1e-9
     res = solve_distributed_circuit([seg], [], V0=1.0, t_end=dt, dt=dt, em_solver=em)
-    feedback = em.coupling_interface().back_reaction
-    assert np.isclose(res.current[-1], feedback)
+    feedback = em.coupling_interface()
+    assert np.isclose(res.current[-1], feedback.back_reaction)

--- a/tests/physics/test_radiation_mhd_amr.py
+++ b/tests/physics/test_radiation_mhd_amr.py
@@ -20,7 +20,8 @@ def test_circuit_coupling_back_reaction():
     solver = RadiationMHDSolver()
     dt = 1e-9
     res = solve_distributed_circuit([seg], [], V0=1.0, t_end=dt, dt=dt, em_solver=solver)
-    br = solver.coupling_interface().back_reaction
+    iface = solver.coupling_interface()
+    br = iface.back_reaction
     expected = dt * 1.0 / (seg.L_per_m * seg.length) + br
     assert np.isclose(res.current[-1], expected, rtol=1e-3)
     assert br != 0.0

--- a/tests/physics/test_radiation_mhd_coupling.py
+++ b/tests/physics/test_radiation_mhd_coupling.py
@@ -31,5 +31,6 @@ def test_frequency_domain_coupling_zero_back_reaction():
     ref = solve_distributed_circuit([seg], [], V0=1.0, t_end=t_end, dt=dt, frequency=freq)
     assert np.allclose(res.current, ref.current)
     assert np.allclose(res.voltage, ref.voltage)
-    assert solver.coupling_interface().back_reaction == 0.0
+    iface = solver.coupling_interface()
+    assert iface.back_reaction == 0.0
 


### PR DESCRIPTION
## Summary
- Return stored `CouplingState` from `RadiationMHDSolver.coupling_interface` instead of constructing a new object
- Update electromagnetic coupling tests to use the returned coupling object

## Testing
- `pytest tests/physics/test_em_circuit_coupling.py tests/physics/test_radiation_mhd_amr.py -q`
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/workspace/dpf2/dpf2/ionization....')*


------
https://chatgpt.com/codex/tasks/task_e_68b8a057955c832abf76a17c7121f0e6