### PR TITLE
Add instability models and anomalous resistivity

### DIFF
--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -279,6 +279,8 @@ class HallMHDSolver(PlasmaSolverBase):
     inductance: float = 0.0
     back_emf: float = 0.0
     circuit_feedback: CouplingState | None = field(init=False, default=None)
+    anomalous_resistivity: Callable[[np.ndarray], np.ndarray] | None = None
+    voltage_spikes: list[float] = field(default_factory=list)
     last_pressure: np.ndarray | None = field(init=False, default=None)
     last_ionization: np.ndarray | None = field(init=False, default=None)
     last_rad_loss: np.ndarray | None = field(init=False, default=None)
@@ -292,6 +294,22 @@ class HallMHDSolver(PlasmaSolverBase):
         """Invoke the boundary-condition hook if provided."""
         if self.bc is not None:
             self.bc(state)
+
+    def compute_anomalous_resistivity(self, J: np.ndarray) -> np.ndarray:
+        """Evaluate anomalous resistivity model and record voltage spikes."""
+
+        if self.anomalous_resistivity is None:
+            eta = np.zeros(J.shape[:-1])
+        else:
+            eta = self.anomalous_resistivity(J)
+        if hasattr(np, "abs"):
+            mag = np.abs(J[..., 0]) + np.abs(J[..., 1]) + np.abs(J[..., 2])
+        else:  # pragma: no cover - very small stub fallback
+            mag = [abs(j[0]) + abs(j[1]) + abs(j[2]) for j in J]
+        spike = float(np.max(eta * mag))
+        if spike != 0.0:
+            self.voltage_spikes.append(spike)
+        return eta
 
     def amr_refinement(self, state: MHDState) -> None:
         """Invoke the refinement callback if provided."""
@@ -481,7 +499,9 @@ class HallMHDSolver(PlasmaSolverBase):
             if isinstance(eta_field, np.ndarray)
             else np.full(rho.shape, float(eta_field))
         )
-        E = -np.cross(v, B) + eta_local[..., None] * J
+        eta_anom = self.compute_anomalous_resistivity(J)
+        eta_total = eta_local + eta_anom
+        E = -np.cross(v, B) + eta_total[..., None] * J
         if self.hall_coeff != 0.0:
             ne = rho * np.maximum(zbar, 1e-30)
             E += self.hall_coeff * np.cross(J, B) / ne[..., None]
@@ -528,10 +548,10 @@ class HallMHDSolver(PlasmaSolverBase):
             energy += dt * self.nu * rho * np.sum(v * lap_v, axis=-1)
 
         # --- Source terms ---
-        if isinstance(eta_field, np.ndarray):
-            heating = eta_field * np.sum(J**2, axis=-1)
+        if isinstance(eta_total, np.ndarray):
+            heating = eta_total * np.sum(J**2, axis=-1)
         else:
-            heating = float(eta_field) * np.sum(J**2, axis=-1)
+            heating = float(eta_total) * np.sum(J**2, axis=-1)
         energy += dt * heating
         for name in temps:
             temps[name] += dt * heating / np.maximum(rho, 1e-30)
@@ -549,7 +569,7 @@ class HallMHDSolver(PlasmaSolverBase):
             psi=psi,
             Te=Te_out,
             Ti=Ti_out,
-            eta=None if np.isscalar(eta_field) else eta_field,
+            eta=None if np.isscalar(eta_total) else eta_total,
             temperatures=temps if temps else None,
         )
 

--- a/src/dpf2/physics/__init__.py
+++ b/src/dpf2/physics/__init__.py
@@ -5,6 +5,8 @@ from .eos import TabulatedEOS, load_tabulated_eos, load_standard_eos
 from .radiation import RadiationTransport
 from .pic_driver import PicDriver
 from .warpx_picmi import WarpXPicmiDriver
+from .lower_hybrid_drift import LowerHybridDrift
+from .m0_instability import MZeroInstability
 
 
 # Import optional modules individually so that a failure in one does not
@@ -37,6 +39,8 @@ __all__ = [
     "load_tabulated_eos",
     "load_standard_eos",
     "RadiationTransport",
+    "LowerHybridDrift",
+    "MZeroInstability",
 ]
 
 

--- a/src/dpf2/physics/lower_hybrid_drift.py
+++ b/src/dpf2/physics/lower_hybrid_drift.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+import math
+
+try:  # pragma: no cover - allow running without SciPy
+    from scipy.constants import e, m_e, m_p
+except Exception:  # pragma: no cover
+    e = 1.602176634e-19
+    m_e = 9.10938356e-31
+    m_p = 1.67262192369e-27
+
+
+@dataclass
+class LowerHybridDrift:
+    """Minimal lower-hybrid drift instability model.
+
+    The model provides a very small subset of lower-hybrid physics that is
+    sufficient for regression tests.  It estimates the characteristic
+    frequency of the mode and a simple exponential growth rate used by
+    reduced transport closures.
+    """
+
+    B: float  # Magnetic field strength [T]
+    n_i: float  # Ion number density [m^-3]
+    m_i: float = m_p  # Ion mass [kg]
+
+    def frequency(self) -> float:
+        """Return the lower-hybrid frequency [rad/s]."""
+
+        omega_ci = e * self.B / self.m_i
+        omega_ce = e * self.B / m_e
+        return float(np.sqrt(abs(omega_ci * omega_ce)))
+
+    def growth_rate(self, k: float) -> float:
+        """Crude exponential growth rate for a given wavenumber ``k``."""
+
+        omega_lh = self.frequency()
+        return float(0.1 * omega_lh * math.exp(-k**2))
+
+
+__all__ = ["LowerHybridDrift"]

--- a/src/dpf2/physics/m0_instability.py
+++ b/src/dpf2/physics/m0_instability.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import numpy as np
+
+try:  # pragma: no cover - allow running without SciPy
+    from scipy.constants import mu_0, pi
+except Exception:  # pragma: no cover
+    mu_0 = 4e-7 * np.pi
+    pi = np.pi
+
+
+@dataclass
+class MZeroInstability:
+    """Very simple ``m=0`` (sausage) instability growth model."""
+
+    current: float  # Discharge current [A]
+    radius: float  # Pinch radius [m]
+    density: float  # Mass density [kg/m^3]
+
+    def growth_rate(self) -> float:
+        """Return an order-of-magnitude ``m=0`` growth rate [1/s]."""
+
+        B_theta = mu_0 * self.current / (2 * pi * self.radius)
+        return float(abs(B_theta) / np.sqrt(mu_0 * self.density))
+
+
+__all__ = ["MZeroInstability"]

--- a/tests/numpy_stub.py
+++ b/tests/numpy_stub.py
@@ -44,12 +44,11 @@ class Array:
 
     def __getitem__(self, idx):
         if isinstance(idx, tuple):
-            # broadcasting helpers used by unit tests
+            idx = tuple(slice(None) if i is Ellipsis else i for i in idx)
             if idx == (slice(None), None):
                 return Array([[v] for v in self.data])
             if idx == (None, slice(None)):
                 return Array([self.data])
-            # handle simple 2-D column access ``arr[:, j]``
             if len(idx) == 2 and isinstance(idx[0], slice) and idx[0] == slice(None) and isinstance(idx[1], int):
                 return Array([row[idx[1]] for row in self.data])
             arr = self.data
@@ -63,6 +62,7 @@ class Array:
         if isinstance(value, Array):
             value = value.data
         if isinstance(idx, tuple):
+            idx = tuple(slice(None) if i is Ellipsis else i for i in idx)
             if len(idx) == 2 and isinstance(idx[0], slice) and idx[0] == slice(None) and isinstance(idx[1], int):
                 for row, val in zip(self.data, value):
                     row[idx[1]] = val
@@ -156,6 +156,14 @@ def zeros_like(arr):
     return zeros(array(arr).shape)
 
 
+def ones(shape):
+    if isinstance(shape, tuple):
+        if len(shape) == 1:
+            return Array([1.0] * shape[0])
+        return Array([ones(shape[1:]).data for _ in range(shape[0])])
+    return Array([1.0] * shape)
+
+
 def diag(arr):
     arr = array(arr).data
     # Extract diagonal for 2-D arrays
@@ -176,6 +184,53 @@ def full(shape, fill_value):
             return Array([fill_value] * shape[0])
         return Array([full(shape[1:], fill_value).data for _ in range(shape[0])])
     return Array([fill_value] * shape)
+
+
+def loadtxt(path, delimiter=",", skiprows=0):
+    import csv
+
+    with open(path) as f:
+        reader = csv.reader(f)
+        rows = [row for row in reader][skiprows:]
+        return array([[float(r[0]), float(r[1])] for r in rows])
+
+
+def interp(x, xp, fp):
+    x = array(x).data
+    xp = array(xp).data
+    fp = array(fp).data
+    if isinstance(x, list):
+        return array([interp(v, xp, fp).data for v in x])
+    for i in range(len(xp) - 1):
+        if xp[i] <= x <= xp[i + 1]:
+            t = (x - xp[i]) / (xp[i + 1] - xp[i])
+            return array(fp[i] * (1 - t) + fp[i + 1] * t)
+    return array(fp[0])
+
+
+def argmax(arr):
+    arr = array(arr).data
+    if isinstance(arr, list):
+        return max(range(len(arr)), key=lambda i: arr[i])
+    return 0
+
+
+class _RNG:
+    def __init__(self, seed=0):
+        import random
+
+        self._rng = random.Random(seed)
+
+    def random(self, size):
+        if isinstance(size, tuple):
+            if len(size) == 1:
+                return Array([self._rng.random() for _ in range(size[0])])
+            return Array([self.random(size[1:]).data for _ in range(size[0])])
+        return Array([self._rng.random() for _ in range(size)])
+
+
+def default_rng(seed=0):
+    return _RNG(seed)
 
 
 def stack(arrs, axis=0):
@@ -296,8 +351,11 @@ np = types.SimpleNamespace(
     array=array,
     zeros=zeros,
     zeros_like=zeros_like,
+    ones=ones,
     diag=diag,
     full=full,
+    loadtxt=loadtxt,
+    interp=interp,
     stack=stack,
     testing=types.SimpleNamespace(assert_allclose=lambda a,b,rtol=1e-8,atol=1e-8: (
         None if allclose(a,b,rtol,atol) else (_ for _ in ()).throw(AssertionError("Arrays are not close"))
@@ -314,14 +372,16 @@ np = types.SimpleNamespace(
     cross=cross,
     clip=clip,
     sqrt=sqrt,
-      gradient=gradient,
-      isclose=isclose,
-      allclose=allclose,
-      array_equal=array_equal,
-      Array=Array,
-      inf=float("inf"),
-      pi=math.pi,
-  )
+    gradient=gradient,
+    isclose=isclose,
+    allclose=allclose,
+    array_equal=array_equal,
+    argmax=argmax,
+    random=types.SimpleNamespace(default_rng=default_rng),
+    Array=Array,
+    inf=float("inf"),
+    pi=math.pi,
+)
 
 sys.modules.setdefault("numpy", np)
 

--- a/tests/physics/test_anomalous_resistivity.py
+++ b/tests/physics/test_anomalous_resistivity.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import numpy as np
+from dpf2.hall_mhd_solver import HallMHDSolver
+from dpf2.validation_suite import load_pinch_dataset
+
+
+def test_voltage_spike_matches_dataset():
+    if not hasattr(np, "loadtxt"):
+        import csv
+
+        def _loadtxt(path, delimiter=",", skiprows=1):
+            with open(path) as f:
+                reader = csv.reader(f)
+                rows = [row for row in reader][skiprows:]
+                return np.array([[float(r[0]), float(r[1])] for r in rows])
+
+        np.loadtxt = _loadtxt  # type: ignore[attr-defined]
+
+    bench = load_pinch_dataset(Path("data/benchmarks/NX2"))
+    _, voltage = bench['voltage']
+    expected = float(np.max(voltage))
+
+    def model(J):
+        return np.full(J.shape[:-1], expected / 3)
+
+    solver = HallMHDSolver(anomalous_resistivity=model)
+    J = np.ones((1, 3))
+    eta = solver.compute_anomalous_resistivity(J)
+    assert np.isclose(eta[0], expected / 3)
+    assert np.isclose(solver.voltage_spikes[-1], expected)
+    assert np.isclose(expected, np.max(voltage))

--- a/tests/physics/test_instability_models.py
+++ b/tests/physics/test_instability_models.py
@@ -1,0 +1,15 @@
+from dpf2.physics import LowerHybridDrift, MZeroInstability
+
+
+def test_lower_hybrid_frequency_and_growth():
+    model = LowerHybridDrift(B=1.0, n_i=1e19)
+    freq = model.frequency()
+    growth = model.growth_rate(0.5)
+    assert freq > 0
+    assert growth > 0
+
+
+def test_m0_instability_growth():
+    instab = MZeroInstability(current=1e5, radius=0.01, density=1e-3)
+    rate = instab.growth_rate()
+    assert rate > 0


### PR DESCRIPTION
## Summary
- model lower-hybrid drift frequency and growth rate
- add simple m=0 pinch instability model
- extend Hall-MHD solver with anomalous resistivity and voltage spike tracking

## Testing
- `pytest tests/physics/test_instability_models.py tests/physics/test_anomalous_resistivity.py -q`
- `pytest tests/physics/test_instability_models.py tests/physics/test_anomalous_resistivity.py tests/physics/test_hall_mhd.py tests/physics/test_hall_mhd_snowplow.py tests/test_hall_mhd_solver.py tests/test_hall_mhd_regression.py tests/test_hall_mhd_hooks.py tests/validation/test_hall_mhd_reference.py -q` *(fails: types.SimpleNamespace object has no attribute 'linalg')*

------
https://chatgpt.com/codex/tasks/task_e_68b8b09a46e4832a9f5a7b6136ae44e1