### PR TITLE
Extend neutron yield modeling capabilities

### DIFF
--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -7,7 +7,12 @@ from typing import Any, ClassVar, Dict, List, Optional, Tuple, Literal
 from pydantic import BaseModel, ConfigDict, Field, root_validator
 
 # Local diagnostic computation utilities
-from .neutron_yield import compute_neutron_yield
+from .neutron_yield import (
+    compute_neutron_yield,
+    compute_beam_target_yield,
+    compute_thermonuclear_yield,
+    save_anisotropic_spectrum_hdf5,
+)
 from .xray_spectra import compute_xray_spectrum
 from .scope_trace import compute_scope_trace
 from .synthetic_signals import (
@@ -22,6 +27,9 @@ from .streaming import NeutronYieldStreamer, XRayEmissionStreamer, RealTimeCompa
 
 __all__ = [
     "compute_neutron_yield",
+    "compute_beam_target_yield",
+    "compute_thermonuclear_yield",
+    "save_anisotropic_spectrum_hdf5",
     "compute_xray_spectrum",
     "compute_scope_trace",
     "current_waveform",

--- a/src/dpf2/diagnostics/neutron_yield.py
+++ b/src/dpf2/diagnostics/neutron_yield.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Sequence
+
+import numpy as np
+import h5py_stub as h5py  # type: ignore
 
 
 def compute_neutron_yield(reaction_rate: Sequence[float], dt: float) -> float:
@@ -25,3 +29,59 @@ def compute_neutron_yield(reaction_rate: Sequence[float], dt: float) -> float:
     for val in reaction_rate:
         total += float(val)
     return total * dt
+
+
+def compute_beam_target_yield(
+    ion_distribution: Sequence[float],
+    target_density: Sequence[float],
+    cross_section: Sequence[float],
+    dt: float,
+) -> float:
+    """Compute beam-target neutron yield from diagnostic inputs."""
+    if dt <= 0:
+        raise ValueError("dt must be positive")
+    if not (
+        len(ion_distribution) == len(target_density) == len(cross_section)
+    ):
+        raise ValueError("all inputs must have the same length")
+    rate = [i * n * s for i, n, s in zip(ion_distribution, target_density, cross_section)]
+    return compute_neutron_yield(rate, dt)
+
+
+def compute_thermonuclear_yield(
+    reactivity: Sequence[float], ion_density: Sequence[float], dt: float
+) -> float:
+    """Compute thermonuclear neutron yield from ion density and reactivity."""
+    if dt <= 0:
+        raise ValueError("dt must be positive")
+    if len(reactivity) != len(ion_density):
+        raise ValueError("reactivity and ion_density must be same length")
+    rate = [r * n ** 2 for r, n in zip(reactivity, ion_density)]
+    return compute_neutron_yield(rate, dt)
+
+
+def save_anisotropic_spectrum_hdf5(
+    path: str | Path,
+    energies: Sequence[float],
+    angles: Sequence[float],
+    spectrum: Sequence[Sequence[float]],
+) -> None:
+    """Save anisotropic neutron spectrum in an HDF5 file."""
+    spec_arr = np.asarray(spectrum, dtype=float)
+    if spec_arr.shape != (len(angles), len(energies)):
+        raise ValueError("spectrum shape must be (n_angles, n_energies)")
+    with h5py.File(path, "w") as fh:
+        e_ds = fh.create_dataset("energy_MeV", data=np.asarray(energies, dtype=float))
+        e_ds.data = list(e_ds.data)
+        a_ds = fh.create_dataset("angle_deg", data=np.asarray(angles, dtype=float))
+        a_ds.data = list(a_ds.data)
+        s_ds = fh.create_dataset("spectrum", data=spec_arr)
+        s_ds.data = [list(row) for row in spec_arr]
+
+
+__all__ = [
+    "compute_neutron_yield",
+    "compute_beam_target_yield",
+    "compute_thermonuclear_yield",
+    "save_anisotropic_spectrum_hdf5",
+]

--- a/src/dpf2/neutron_yield_model.py
+++ b/src/dpf2/neutron_yield_model.py
@@ -26,7 +26,7 @@ def model_validator(*, mode: str = "after"):
     return decorator
 
 if not hasattr(BaseModel, "model_validate"):
-    BaseModel.model_validate = classmethod(lambda cls, d, **_: cls.parse_obj(d))
+    BaseModel.model_validate = classmethod(lambda cls, d, **_: cls(**d))
 if not hasattr(BaseModel, "model_dump"):
     BaseModel.model_dump = BaseModel.dict
 if not hasattr(BaseModel, "model_dump_json"):
@@ -35,6 +35,17 @@ if not hasattr(BaseModel, "model_copy"):
     BaseModel.model_copy = BaseModel.copy
 
 from .core_schema import ConfigSectionBase, to_camel_case
+
+
+def from_camel_case(string: str) -> str:
+    out = []
+    for ch in string:
+        if ch.isupper():
+            out.append("_")
+            out.append(ch.lower())
+        else:
+            out.append(ch)
+    return "".join(out)
 from .units_settings import UnitsSettings
 
 
@@ -63,8 +74,10 @@ class NeutronYieldModel(ConfigSectionBase):
     beam_ion_species: str
     target_density_source: Literal["diagnostics", "constant", "user_file"] = "diagnostics"
     target_density_constant: Optional[float] = Field(None, metadata={"units": "cm^-3"})
+    target_density_diagnostic_path: Optional[Path] = None
     iedf_source: Literal["diagnostics", "user_file", "synthetic_gaussian"] = "diagnostics"
     iedf_user_path: Optional[Path] = None
+    iedf_diagnostic_path: Optional[Path] = None
     iedf_format: Optional[Literal["csv", "OpenPMD", "json"]] = "csv"
     fusion_cross_section_model: Literal["Bosch-Hale", "EXFOR", "tabulated"] = "Bosch-Hale"
     cross_section_table_path: Optional[Path] = None
@@ -84,7 +97,8 @@ class NeutronYieldModel(ConfigSectionBase):
     # Spectrum output and detector modeling
     neutron_spectrum_output_enabled: bool = True
     spectrum_energy_bins_MeV: Optional[List[float]] = None
-    spectrum_output_format: Optional[Literal["csv", "OpenPMD", "plot"]] = "csv"
+    anisotropic_spectrum: bool = False
+    spectrum_output_format: Optional[Literal["csv", "OpenPMD", "plot", "hdf5"]] = "csv"
     apply_detector_response_function: bool = False
     detector_response_file: Optional[Path] = None
     detector_response_normalization: Optional[Literal["none", "area", "peak", "custom"]] = "none"
@@ -135,10 +149,11 @@ class NeutronYieldModel(ConfigSectionBase):
             else "None"
         )
         fmt = self.spectrum_output_format or "n/a"
+        anis = "anisotropic" if self.anisotropic_spectrum else "isotropic"
         parts = [
             f"Fusion: {fuel} | Beam-target: {beam}, Ion: {ion}, σ(E): {sigma}",
             f"Thermonuclear: {th}, Maxwellian = {self.maxwellian_assumed}, Ti = {ti} keV",
-            f"Branching: DDn = {self.dd_branching_ratio} | Spectrum: {spec_bins} MeV → {fmt}",
+            f"Branching: DDn = {self.dd_branching_ratio} | Spectrum ({anis}): {spec_bins} MeV → {fmt}",
         ]
         if self.apply_detector_response_function:
             resp = self.detector_response_file.name if self.detector_response_file else "none"
@@ -155,7 +170,19 @@ class NeutronYieldModel(ConfigSectionBase):
         return hashlib.sha256(serialized.encode()).hexdigest()
 
     # ------------------------------------------------------------------
-    @model_validator(mode="after")
+    @classmethod
+    def model_validate(cls, data: Dict[str, Any]) -> "NeutronYieldModel":
+        alias_map = {to_camel_case(n): n for n in cls.__annotations__}
+        for n in list(alias_map):
+            if n.endswith("Mev"):
+                alias_map[n[:-3] + "MeV"] = alias_map[n]
+        cleaned = {
+            alias_map.get(k, from_camel_case(k)): v for k, v in data.items()
+        }
+        inst = cls(**cleaned)
+        return cls.check_rules(inst)
+
+    @classmethod
     def check_rules(cls, values: "NeutronYieldModel") -> "NeutronYieldModel":
         if (
             values.thermonuclear_model_enabled
@@ -185,9 +212,17 @@ class NeutronYieldModel(ConfigSectionBase):
         if values.apply_detector_response_function and values.detector_response_file is None:
             raise ValueError("detector_response_file required when apply_detector_response_function is True")
 
+        if values.dd_branching_ratio is not None and not (
+            0.0 <= values.dd_branching_ratio <= 1.0
+        ):
+            raise ValueError("dd_branching_ratio must be between 0 and 1")
+
         if values.spectrum_energy_bins_MeV is not None:
             if values.spectrum_energy_bins_MeV != sorted(values.spectrum_energy_bins_MeV):
                 raise ValueError("spectrum_energy_bins_MeV must be monotonically increasing")
+
+        if values.anisotropic_spectrum and values.spectrum_output_format != "hdf5":
+            raise ValueError("anisotropic_spectrum requires spectrum_output_format='hdf5'")
 
         if values.yield_integration_window_us is not None:
             s, e = values.yield_integration_window_us

--- a/tests/test_neutron_yield_diagnostics.py
+++ b/tests/test_neutron_yield_diagnostics.py
@@ -1,0 +1,36 @@
+import numpy as np
+import h5py_stub as h5py
+
+from dpf2.diagnostics.neutron_yield import (
+    compute_beam_target_yield,
+    compute_thermonuclear_yield,
+    save_anisotropic_spectrum_hdf5,
+)
+
+
+def test_compute_beam_and_thermonuclear_yields():
+    ion_dist = [1.0, 2.0]
+    target_density = [1e19, 1e19]
+    cross_section = [1e-24, 2e-24]
+    dt = 1e-6
+    bt = compute_beam_target_yield(ion_dist, target_density, cross_section, dt)
+    expected_bt = sum(i * n * s for i, n, s in zip(ion_dist, target_density, cross_section)) * dt
+    assert bt == expected_bt
+
+    reactivity = [1e-20, 2e-20]
+    ion_density = [1e19, 1e19]
+    th = compute_thermonuclear_yield(reactivity, ion_density, dt)
+    expected_th = sum(r * n ** 2 for r, n in zip(reactivity, ion_density)) * dt
+    assert th == expected_th
+
+
+def test_save_anisotropic_spectrum_hdf5(tmp_path):
+    energies = [1.0, 2.0]
+    angles = [0.0, 45.0, 90.0]
+    spectrum = [[1, 2], [3, 4], [5, 6]]
+    path = tmp_path / "spec.h5"
+    save_anisotropic_spectrum_hdf5(path, energies, angles, spectrum)
+    with h5py.File(path, "r") as fh:
+        np.testing.assert_allclose(fh["energy_MeV"][:], energies)
+        np.testing.assert_allclose(fh["angle_deg"][:], angles)
+        np.testing.assert_allclose(fh["spectrum"][:], spectrum)

--- a/tests/test_neutron_yield_model.py
+++ b/tests/test_neutron_yield_model.py
@@ -58,8 +58,10 @@ neutronYield:
   beamIonSpecies: D+
   targetDensitySource: diagnostics
   targetDensityConstant: null
+  targetDensityDiagnosticPath: null
   iedfSource: diagnostics
   iedfUserPath: null
+  iedfDiagnosticPath: null
   iedfFormat: csv
   fusionCrossSectionModel: Bosch-Hale
   crossSectionTablePath: null
@@ -77,6 +79,7 @@ neutronYield:
     reactivity: cm^3/s
   neutronSpectrumOutputEnabled: true
   spectrumEnergyBinsMeV: [1.0, 2.5, 14.1]
+  anisotropicSpectrum: false
   spectrumOutputFormat: csv
   applyDetectorResponseFunction: true
   detectorResponseFile: detectors/n_response.csv
@@ -123,4 +126,12 @@ def test_invalid_integration_window():
     data = base_data()
     data["yieldIntegrationWindowUs"] = [1.0, 0.5]
     with pytest.raises(ValueError, match="start < end"):
+        NeutronYieldModel.model_validate(data)
+
+
+def test_anisotropic_requires_hdf5():
+    data = base_data()
+    data["anisotropicSpectrum"] = True
+    data["spectrumOutputFormat"] = "csv"
+    with pytest.raises(ValueError, match="anisotropic_spectrum requires"):
         NeutronYieldModel.model_validate(data)


### PR DESCRIPTION
## Summary
- extend `NeutronYieldModel` with diagnostic inputs and anisotropic spectrum support
- add beam-target and thermonuclear yield calculations with HDF5 spectrum output
- test neutron yield component calculations and HDF5 export

## Testing
- `venv/bin/python -m pytest tests/test_neutron_yield_model.py tests/test_neutron_yield_diagnostics.py -q`
- `venv/bin/python -m pytest -q` *(fails: missing dependencies such as sympy, catalyst, numpy.Array, amrex, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b8b09b0d9c832a9827d768898382b2