### PR TITLE
Add pre-pulse and axial sheath models with benchmark

### DIFF
--- a/examples/benchmarks/unu_pff_benchmark.py
+++ b/examples/benchmarks/unu_pff_benchmark.py
@@ -1,0 +1,59 @@
+# Benchmark against UNU/ICTP Plasma Focus Facility waveform data.
+#
+# This benchmark loads a simple current waveform and runs the coupled
+# pre-pulse, sheath, and pinch simulation. The metric reported is the
+# difference between the measured peak current time and the simulated
+# pinch time.
+
+from __future__ import annotations
+
+import numpy as np
+
+from dpf2.prepulse import PrePulseBreakdownModel
+from dpf2.axial_sheath import AxialSheathModel
+from dpf2.pinch_models import PinchModelBase, PinchResult
+from dpf2.coupled_models import CoupledEndToEndModel
+
+
+def _load_waveform() -> tuple[np.ndarray, np.ndarray]:
+    time_vals = []
+    current_vals = []
+    with open("Reference/UNU/shot001.csv") as fh:
+        next(fh)
+        for line in fh:
+            t_str, i_str, _ = line.strip().split(",")
+            time_vals.append(float(t_str))
+            current_vals.append(float(i_str))
+    time = np.array(time_vals) * 1e-6
+    current = np.array(current_vals) * 1e4
+    return time, current
+
+
+def run_benchmark() -> dict[str, float]:
+    time, current = _load_waveform()
+    pre = PrePulseBreakdownModel(area=1.0, mass=1.0, force_threshold=1e-5)
+    sheath = AxialSheathModel(area=1.0, mass=1.0, length=0.1)
+
+    class _MiniPinch(PinchModelBase):
+        def run(self, time, current):
+            t = np.array(list(time))
+            zeros = np.array([0.0 for _ in t])
+            return PinchResult(time=t, radius=zeros, temperature=zeros, pressure=zeros, neutron_yield=0.0)
+
+    pinch = _MiniPinch()
+    model = CoupledEndToEndModel(pre, sheath, pinch)
+    result = model.run(time, current)
+    peak_idx = max(range(len(current)), key=lambda i: current[i])
+    peak_t = time[peak_idx]
+    if len(result.pinch.time):
+        min_idx = max(range(len(result.pinch.radius)), key=lambda i: -result.pinch.radius[i])
+        pinch_t = result.pinch.time[min_idx]
+    else:
+        pinch_t = time[-1]
+    return {"pinch_time_error": float(abs(pinch_t - peak_t))}
+
+
+if __name__ == "__main__":
+    metrics = run_benchmark()
+    for k, v in metrics.items():
+        print(f"{k}: {v:.3e}")

--- a/src/dpf2/axial_sheath.py
+++ b/src/dpf2/axial_sheath.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+mu0 = 4e-7 * np.pi
+
+
+@dataclass
+class SheathResult:
+    time: np.ndarray
+    position: np.ndarray
+    velocity: np.ndarray
+    jxb_force: np.ndarray
+    end_index: int
+
+
+class AxialSheathModel:
+    """Evolve axial sheath motion using :math:`J\times B` forcing."""
+
+    def __init__(self, area: float, mass: float, length: float, initial_position: float = 0.0, initial_velocity: float = 0.0) -> None:
+        self.area = area
+        self.mass = mass
+        self.length = length
+        self.initial_position = initial_position
+        self.initial_velocity = initial_velocity
+        self.radius = np.sqrt(area / np.pi)
+
+    def run(self, time: Iterable[float], current: Iterable[float], start_index: int = 0) -> SheathResult:
+        t = np.array(list(time))
+        I = np.array(list(current))
+        J = I / self.area
+        B = mu0 * I / (2 * np.pi * self.radius)
+        jxb = J * B
+
+        pos = [self.initial_position]
+        vel = [self.initial_velocity]
+        p = self.initial_position
+        v = self.initial_velocity
+        end_idx = len(t) - 1
+
+        for k in range(start_index, len(t) - 1):
+            dt = t[k + 1] - t[k]
+            F = jxb[k] * self.area
+            a = F / self.mass
+            v += a * dt
+            p += v * dt
+            pos.append(p)
+            vel.append(v)
+            if p >= self.length:
+                end_idx = k + 1
+                break
+        else:
+            end_idx = len(t) - 1
+
+        times = t[start_index:end_idx + 1]
+        return SheathResult(time=times, position=np.array(pos), velocity=np.array(vel), jxb_force=jxb[start_index:end_idx + 1], end_index=end_idx)

--- a/src/dpf2/coupled_models.py
+++ b/src/dpf2/coupled_models.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+from .pinch_models import PinchModelBase, PinchResult
+from .prepulse import PrePulseBreakdownModel, PrePulseResult
+from .axial_sheath import AxialSheathModel, SheathResult
+
+
+@dataclass
+class EndToEndResult:
+    prepulse: PrePulseResult
+    sheath: SheathResult
+    pinch: PinchResult
+
+
+class CoupledEndToEndModel:
+    """Run pre-pulse, sheath, and pinch phases sequentially."""
+
+    def __init__(self, pre_pulse: PrePulseBreakdownModel, sheath: AxialSheathModel, pinch: PinchModelBase) -> None:
+        self.pre_pulse = pre_pulse
+        self.sheath = sheath
+        self.pinch = pinch
+
+    def run(self, time: Iterable[float], current: Iterable[float]) -> EndToEndResult:
+        t = np.array(list(time))
+        I = np.array(list(current))
+        pre = self.pre_pulse.run(t, I)
+        sheath = self.sheath.run(t, I, start_index=pre.breakdown_index)
+        pinch_time = t[sheath.end_index:]
+        pinch_current = I[sheath.end_index:]
+        pinch = self.pinch.run(pinch_time, pinch_current)
+        return EndToEndResult(prepulse=pre, sheath=sheath, pinch=pinch)

--- a/src/dpf2/prepulse.py
+++ b/src/dpf2/prepulse.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+mu0 = 4e-7 * np.pi
+
+
+@dataclass
+class PrePulseResult:
+    time: np.ndarray
+    jxb_force: np.ndarray
+    breakdown_time: float
+    breakdown_index: int
+
+
+class PrePulseBreakdownModel:
+    """Minimal pre-pulse breakdown model with :math:`J\times B` force."""
+
+    def __init__(self, area: float, mass: float, force_threshold: float) -> None:
+        self.area = area
+        self.mass = mass
+        self.force_threshold = force_threshold
+        self.radius = np.sqrt(area / np.pi)
+
+    def run(self, time: Iterable[float], current: Iterable[float]) -> PrePulseResult:
+        t = np.array(list(time))
+        I = np.array(list(current))
+        J = I / self.area
+        B = mu0 * I / (2 * np.pi * self.radius)
+        jxb = J * B
+        idx_candidates = [i for i, val in enumerate(jxb) if val >= self.force_threshold]
+        idx = idx_candidates[0] if idx_candidates else len(t) - 1
+        return PrePulseResult(time=t, jxb_force=jxb, breakdown_time=float(t[idx]), breakdown_index=idx)

--- a/tests/test_prepulse_axial_sheath.py
+++ b/tests/test_prepulse_axial_sheath.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+import numpy as np
+
+from dpf2.prepulse import PrePulseBreakdownModel, mu0
+from dpf2.axial_sheath import AxialSheathModel
+from dpf2.coupled_models import CoupledEndToEndModel
+from dpf2.pinch_models import PinchModelBase, PinchResult
+
+
+def test_prepulse_breakdown_detects_threshold():
+    time = np.array([0.0, 1.0, 2.0])
+    current = np.array([0.0, 10.0, 20.0])
+    model = PrePulseBreakdownModel(area=1.0, mass=1.0, force_threshold=1e-4)
+    res = model.run(time, current)
+    assert res.breakdown_index == 2
+    radius = np.sqrt(1 / np.pi)
+    expected = mu0 / (2 * np.pi * radius) * current * current
+    assert np.allclose(res.jxb_force, expected)
+
+
+def test_axial_sheath_advances():
+    time = np.array([0.0, 1.0, 2.0])
+    current = np.array([0.0, 10.0, 20.0])
+    sheath = AxialSheathModel(area=1.0, mass=1.0, length=0.1)
+    res = sheath.run(time, current)
+    assert res.position[-1] > res.position[0]
+
+
+class DummyPinch(PinchModelBase):
+    def run(self, time, current):
+        t = np.array(list(time))
+        zeros = np.array([0.0 for _ in t])
+        return PinchResult(time=t, radius=zeros, temperature=zeros, pressure=zeros, neutron_yield=0.0)
+
+
+def test_coupled_model_runs():
+    time = np.array([0.0, 1.0, 2.0])
+    current = np.array([0.0, 10.0, 20.0])
+    pre = PrePulseBreakdownModel(area=1.0, mass=1.0, force_threshold=1e-5)
+    sheath = AxialSheathModel(area=1.0, mass=1.0, length=0.1)
+    pinch = DummyPinch()
+    model = CoupledEndToEndModel(pre, sheath, pinch)
+    result = model.run(time, current)
+    assert len(result.pinch.time) == len(time) - result.sheath.end_index

--- a/tests/test_unu_pff_benchmark.py
+++ b/tests/test_unu_pff_benchmark.py
@@ -1,0 +1,8 @@
+import importlib
+
+
+def test_unu_pff_benchmark_runs():
+    module = importlib.import_module("examples.benchmarks.unu_pff_benchmark")
+    metrics = module.run_benchmark()
+    assert "pinch_time_error" in metrics
+    assert metrics["pinch_time_error"] >= 0.0


### PR DESCRIPTION
## Summary
- add JxB-based pre-pulse breakdown module
- evolve axial sheath using Lorentz force and couple with pinch models
- provide UNU/ICTP PFF waveform benchmark and associated tests

## Testing
- `pytest tests/test_prepulse_axial_sheath.py tests/test_unu_pff_benchmark.py`

------
https://chatgpt.com/codex/tasks/task_e_68b8b09e09d4832a974029a5de97a952