### PR TITLE
Add parametric sweep utilities and web interface

### DIFF
--- a/src/dpf2/optimization/__init__.py
+++ b/src/dpf2/optimization/__init__.py
@@ -1,6 +1,12 @@
 """Optimization utilities for parameter inference and control."""
 
 from .bayesian import BayesianParameterInference, ParameterEstimate
+from .param_sweep import plot_sweep_results, run_parametric_sweep
 
-__all__ = ["BayesianParameterInference", "ParameterEstimate"]
+__all__ = [
+    "BayesianParameterInference",
+    "ParameterEstimate",
+    "run_parametric_sweep",
+    "plot_sweep_results",
+]
 

--- a/src/dpf2/optimization/param_sweep.py
+++ b/src/dpf2/optimization/param_sweep.py
@@ -1,0 +1,77 @@
+"""Utilities for performing parametric sweeps of simulation parameters."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+from ..core.config import DPFConfig
+from ..core.simulation import DPFSimulation
+
+
+SweepResult = Tuple[List[float], List[float], List[float]]
+
+
+def run_parametric_sweep(
+    base_config: DPFConfig,
+    parameter: str,
+    values: Iterable[float],
+    *,
+    output_dir: str | Path = "sweep_output",
+) -> Dict[float, SweepResult]:
+    """Run a series of simulations while varying a single parameter.
+
+    Parameters
+    ----------
+    base_config:
+        Starting :class:`DPFConfig` for the sweep.
+    parameter:
+        Name of the configuration attribute to vary.
+    values:
+        Iterable of values for ``parameter``.
+    output_dir:
+        Directory where per-run results are written.
+
+    Returns
+    -------
+    Dict[float, SweepResult]
+        Mapping of parameter value to time history tuples ``(t, I, V)``.
+    """
+
+    out_root = Path(output_dir)
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    results: Dict[float, SweepResult] = {}
+    for val in values:
+        cfg_dict = base_config.__dict__.copy()
+        cfg_dict[parameter] = val
+        cfg = DPFConfig(**cfg_dict)
+        sim = DPFSimulation(cfg)
+        run_dir = out_root / f"{parameter}_{val}"
+        t, i, v = sim.run(output_dir=str(run_dir))
+        results[val] = (t, i, v)
+    return results
+
+
+def plot_sweep_results(
+    parameter: str,
+    results: Dict[float, SweepResult],
+    path: str | Path,
+) -> Path:
+    """Create an overlay plot of currents for a sweep."""
+
+    import matplotlib.pyplot as plt
+
+    for val, (t, current, _v) in results.items():
+        plt.plot(t, current, label=f"{parameter}={val:g}")
+
+    plt.xlabel("Time (s)")
+    plt.ylabel("Current (A)")
+    plt.legend()
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(path)
+    plt.close()
+    return path
+
+
+__all__ = ["run_parametric_sweep", "plot_sweep_results", "SweepResult"]

--- a/src/dpf2/web/app.py
+++ b/src/dpf2/web/app.py
@@ -1,37 +1,82 @@
 """Minimal Flask application for running DPF simulations."""
 from __future__ import annotations
 
-import json
+import base64
 import os
 from pathlib import Path
+from typing import Iterable
 
 from flask import Flask, redirect, render_template_string, request, url_for
 
 from ..core.config import DPFConfig
 from ..core.simulation import DPFSimulation
+from ..device_profiles import DeviceProfiles
 from ..exceptions import ConfigurationError, SimulationRuntimeError
+from ..optimization.param_sweep import plot_sweep_results, run_parametric_sweep
 
+# HTML templates rendered with simple ``render_template_string`` calls.  The
+# templates expose a subset of configuration parameters and allow users to run
+# single simulations, perform parametric sweeps and export configuration files
+# for later CLI/HPC execution.
 INDEX_HTML = """
 <!doctype html>
 <title>DPF2 Dashboard</title>
 <h1>Run Simulation</h1>
 <form method=post>
-  Config file path: <input name=config><br>
-  Output directory: <input name=output value="output"><br>
-  <input type=submit value="Run">
+  Charging voltage: <input name=charging_voltage value="{{ cfg.charging_voltage }}"><br>
+  Anode radius (m): <input name=anode_radius value="{{ cfg.anode_radius }}"><br>
+  Cathode radius (m): <input name=cathode_radius value="{{ cfg.cathode_radius }}"><br>
+  Electrode length (m): <input name=electrode_length value="{{ cfg.electrode_length }}"><br>
+  Geometry preset:
+  <select name=preset>
+    <option value=""></option>
+    {% for name in presets %}<option value="{{ name }}">{{ name }}</option>{% endfor %}
+  </select><br>
+  Sweep parameter: <input name=sweep_param><br>
+  Sweep values (comma separated): <input name=sweep_values><br>
+  Output directory: <input name=output value="{{ output }}"><br>
+  <button name=action value=run>Run</button>
+  <button name=action value=sweep>Run Sweep</button>
+  <button name=action value=export>Export Config</button>
 </form>
-<p><a href="{{ url_for('diagnostics') }}">View diagnostics</a></p>
+<p><a href="{{ url_for('diagnostics', output=output) }}">View diagnostics</a></p>
 """
 
 DIAG_HTML = """
 <!doctype html>
 <title>Diagnostics</title>
 <h1>Diagnostics</h1>
+{% if plot %}<img src="{{ plot }}" alt="sweep plot"><br>{% endif %}
 <ul>
 {% for f in files %}<li>{{ f }}</li>{% endfor %}
 </ul>
-<p><a href="{{ url_for('index') }}">Back</a></p>
+<p><a href="{{ url_for('index', output=request.args.get('output', 'output')) }}">Back</a></p>
 """
+
+
+def _update_config_from_form(cfg: DPFConfig, form: dict, presets: dict[str, object]) -> DPFConfig:
+    """Populate a :class:`DPFConfig` instance from form fields."""
+
+    for field in ["charging_voltage", "anode_radius", "cathode_radius", "electrode_length"]:
+        if form.get(field):
+            setattr(cfg, field, float(form[field]))
+
+    preset = form.get("preset")
+    if preset and preset in presets:
+        dev = presets[preset]
+        cfg.anode_radius = dev.anode_radius_cm * 0.01
+        cfg.cathode_radius = dev.cathode_radius_cm * 0.01
+        cfg.electrode_length = dev.anode_length_cm * 0.01
+
+    return cfg
+
+
+def _parse_sweep_values(vals: str) -> Iterable[float]:
+    for v in vals.split(","):
+        v = v.strip()
+        if not v:
+            continue
+        yield float(v)
 
 
 def create_app() -> Flask:
@@ -39,17 +84,35 @@ def create_app() -> Flask:
 
     @app.route("/", methods=["GET", "POST"])
     def index():
+        cfg = DPFConfig()
+        presets = DeviceProfiles.with_defaults().devices
+        output = request.form.get("output", "output")
+
         if request.method == "POST":
-            cfg_path = request.form.get("config")
-            output = request.form.get("output", "output")
+            cfg = _update_config_from_form(cfg, request.form, presets)
+            action = request.form.get("action", "run")
             try:
-                cfg = DPFConfig.from_file(cfg_path) if cfg_path else DPFConfig()
-                sim = DPFSimulation(cfg)
-                sim.run(output_dir=output)
+                if action == "export":
+                    Path(output).mkdir(parents=True, exist_ok=True)
+                    cfg.to_file(Path(output) / "config.json")
+                    msg = f"Exported configuration to {output}/config.json"
+                    return render_template_string(INDEX_HTML + f"<p>{msg}</p>", cfg=cfg, presets=presets.keys(), output=output)
+                if action == "sweep":
+                    param = request.form.get("sweep_param")
+                    values = request.form.get("sweep_values", "")
+                    if param and values:
+                        vals = list(_parse_sweep_values(values))
+                        results = run_parametric_sweep(cfg, param, vals, output_dir=output)
+                        plot_path = Path(output) / "sweep_plot.png"
+                        plot_sweep_results(param, results, plot_path)
+                else:
+                    sim = DPFSimulation(cfg)
+                    sim.run(output_dir=output)
                 return redirect(url_for("diagnostics", output=output))
             except (ConfigurationError, SimulationRuntimeError, Exception) as exc:  # pragma: no cover - UI path
-                return render_template_string(INDEX_HTML + f"<p>Error: {exc}</p>")
-        return render_template_string(INDEX_HTML)
+                return render_template_string(INDEX_HTML + f"<p>Error: {exc}</p>", cfg=cfg, presets=presets.keys(), output=output)
+
+        return render_template_string(INDEX_HTML, cfg=cfg, presets=presets.keys(), output=output)
 
     @app.route("/diagnostics")
     def diagnostics():
@@ -58,7 +121,11 @@ def create_app() -> Flask:
             files = sorted(os.listdir(output))
         except FileNotFoundError:
             files = []
-        return render_template_string(DIAG_HTML, files=files)
+        plot = None
+        plot_path = Path(output) / "sweep_plot.png"
+        if plot_path.exists():
+            plot = "data:image/png;base64," + base64.b64encode(plot_path.read_bytes()).decode("ascii")
+        return render_template_string(DIAG_HTML, files=files, plot=plot)
 
     return app
 

--- a/tests/test_param_sweep.py
+++ b/tests/test_param_sweep.py
@@ -1,0 +1,21 @@
+"""Tests for parametric sweep utilities."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py_stub  # noqa: F401  ensures stub is registered before importing modules
+
+from dpf2.core.config import DPFConfig
+from dpf2.optimization.param_sweep import plot_sweep_results, run_parametric_sweep
+import pytest
+pytest.importorskip("matplotlib")
+
+
+def test_parametric_sweep(tmp_path: Path) -> None:
+    cfg = DPFConfig()
+    values = [10_000.0, 15_000.0]
+    results = run_parametric_sweep(cfg, "charging_voltage", values, output_dir=tmp_path)
+    assert set(results.keys()) == set(values)
+    plot_path = tmp_path / "plot.png"
+    plot_sweep_results("charging_voltage", results, plot_path)
+    assert plot_path.exists()


### PR DESCRIPTION
## Summary
- extend experimental Flask dashboard with form inputs for core parameters, geometry presets, parametric sweeps, and config export
- add reusable utilities to run parameter sweeps and create overlay plots
- provide basic test covering sweep execution

## Testing
- `pytest tests/test_param_sweep.py -q`
- `pytest -q` *(fails: 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b0a06014832a9b231f9539438f09