### PR TITLE
feat: extend HPC job handling

### DIFF
--- a/examples/job_scripts/slurm_cpu.sh
+++ b/examples/job_scripts/slurm_cpu.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Example SLURM job script for a CPU-only cluster
+#SBATCH -J dpf2_cpu_example
+#SBATCH -N 1
+#SBATCH -n 4
+#SBATCH -o dpf2_cpu_%j.log
+
+module load python mpi
+srun python examples/run_simulation.py --config examples/config.json

--- a/examples/job_scripts/slurm_gpu.sh
+++ b/examples/job_scripts/slurm_gpu.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Example SLURM job script for a GPU-enabled cluster
+#SBATCH -J dpf2_gpu_example
+#SBATCH -N 1
+#SBATCH -n 4
+#SBATCH --gpus=1
+#SBATCH -o dpf2_gpu_%j.log
+
+module load python cuda mpi
+srun python examples/run_simulation.py --config examples/config.json --use-gpu

--- a/scripts/batch_submit.py
+++ b/scripts/batch_submit.py
@@ -15,6 +15,12 @@ def main() -> None:
     )
     parser.add_argument("--outfile", type=Path, default=Path("submit.sh"), help="Output script path")
     parser.add_argument("--nprocs", type=int, default=1, help="Number of MPI ranks")
+    parser.add_argument("--nodes", type=int, default=1, help="Number of nodes")
+    parser.add_argument("--gpus", type=int, default=0, help="GPUs per node")
+    parser.add_argument("--dependency", help="SLURM dependency specification")
+    parser.add_argument("--job-name", default="dpf2-sweep", help="Job name")
+    parser.add_argument("--output", default="slurm-%j.out", help="SLURM output file")
+    parser.add_argument("--stage", help="Directory to stage results after completion")
     args = parser.parse_args()
 
     cmd = (
@@ -25,10 +31,24 @@ def main() -> None:
     script = textwrap.dedent(
         f"""
         #!/bin/bash
+        #SBATCH -J {args.job_name}
+        #SBATCH -N {args.nodes}
         #SBATCH -n {args.nprocs}
-        {cmd}
+        #SBATCH -o {args.output}
         """
     )
+    if args.gpus:
+        script += f"#SBATCH --gpus={args.gpus}\n"
+    if args.dependency:
+        script += f"#SBATCH --dependency={args.dependency}\n"
+    script += f"\n{cmd}\n"
+    if args.stage:
+        script += textwrap.dedent(
+            f"""
+            mkdir -p {args.stage}
+            rsync -a results/ {args.stage}/
+            """
+        )
     args.outfile.write_text(script)
     print(f"Wrote batch script to {args.outfile}")
 

--- a/src/dpf2/hpc/manager.py
+++ b/src/dpf2/hpc/manager.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import subprocess
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 
 @dataclass
@@ -18,6 +18,27 @@ class JobManager:
     """Dispatch simulation jobs to different backends."""
 
     scheduler: str = "slurm"
+
+    def _extend_cmd(self, cmd: list[str], opts: Dict[str, Any], flag_map: Dict[str, Iterable[str]]) -> None:
+        """Append CLI options from ``opts`` to ``cmd`` using ``flag_map``.
+
+        Parameters
+        ----------
+        cmd:
+            Mutable command list to extend.
+        opts:
+            User supplied options.
+        flag_map:
+            Mapping of option keys to one or more flags understood by the
+            underlying scheduler command.
+        """
+
+        for key, flags in flag_map.items():
+            if key in opts and opts[key] is not None:
+                value = str(opts[key])
+                if isinstance(flags, str):
+                    flags = [flags]
+                cmd.extend(list(flags) + [value])
 
     def submit(self, job_script: str, **kwargs: Any) -> Any:
         """Submit ``job_script`` to the configured scheduler.
@@ -36,7 +57,19 @@ class JobManager:
         """
 
         if self.scheduler == "slurm":
-            cmd = ["sbatch", job_script]
+            cmd = ["sbatch"]
+            self._extend_cmd(
+                cmd,
+                kwargs,
+                {
+                    "nodes": "-N",
+                    "gpus": "--gpus",
+                    "dependency": "--dependency",
+                    "output": "-o",
+                    "error": "-e",
+                },
+            )
+            cmd.append(job_script)
             return subprocess.run(cmd, capture_output=True, text=True, check=False)
         if self.scheduler == "awsbatch":
             try:
@@ -53,9 +86,36 @@ class JobManager:
                 params["parameters"] = kwargs["parameters"]
             return batch.submit_job(**params)
         if self.scheduler == "mpi":
-            cmd = ["mpirun", job_script]
+            cmd = ["mpirun"]
+            self._extend_cmd(
+                cmd,
+                kwargs,
+                {
+                    "nprocs": "-n",
+                },
+            )
+            # Domain decomposition parameters, passed as --decomp-x 2 etc.
+            decomp: Dict[str, Any] | None = kwargs.get("decomp")
+            if decomp:
+                for axis, cnt in decomp.items():
+                    cmd.extend([f"--decomp-{axis}", str(cnt)])
+            if "restart" in kwargs:
+                cmd.extend(["--restart", str(kwargs["restart"])])
+            cmd.append(job_script)
             return subprocess.run(cmd, capture_output=True, text=True, check=False)
         raise ValueError(f"Unsupported scheduler: {self.scheduler}")
+
+    # ------------------------------------------------------------------
+    def restart(self, job_script: str, checkpoint: str, **kwargs: Any) -> Any:
+        """Convenience wrapper to restart a job from ``checkpoint``.
+
+        The checkpoint path is passed through to the underlying scheduler
+        submission so that job scripts can act accordingly.
+        """
+
+        kwargs = dict(kwargs)
+        kwargs["restart"] = checkpoint
+        return self.submit(job_script, **kwargs)
 
 
 __all__ = ["JobManager"]


### PR DESCRIPTION
## Summary
- expand JobManager with domain decomposition hooks, restart support, and common SLURM options
- add staging and GPU/node options to batch_submit helper
- provide sample SLURM job scripts for CPU and GPU clusters

## Testing
- `pytest` *(fails: ModuleNotFoundError and missing optional dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68b8b0a4d864832abb488bb8f06120e8