### PR TITLE
Enable AMReX MPI grids and PF-1000 instability test

### DIFF
--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -289,6 +289,17 @@ class HallMHDSolver(PlasmaSolverBase):
     last_E: np.ndarray | None = field(init=False, default=None)
     last_opacity: np.ndarray | None = field(init=False, default=None)
     last_emissivity: np.ndarray | None = field(init=False, default=None)
+    cart_comm: Any | None = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        """Initialise MPI cartesian communicator for domain decomposition."""
+        if self.comm is not None and MPI is not None:
+            try:
+                size = self.comm.Get_size()
+                dims = MPI.Compute_dims(size, [0, 0, 0])
+                self.cart_comm = self.comm.Create_cart(dims, periods=[True, True, True])
+            except Exception:  # pragma: no cover - fall back to original comm
+                self.cart_comm = self.comm
 
     def apply_boundary_conditions(self, state: MHDState) -> None:
         """Invoke the boundary-condition hook if provided."""
@@ -316,13 +327,33 @@ class HallMHDSolver(PlasmaSolverBase):
         if self.refine is not None:
             self.refine(state)
 
+    def _exchange_array(self, arr: np.ndarray) -> None:
+        """Exchange ghost cells of ``arr`` with neighbouring MPI ranks."""
+        cart = self.cart_comm
+        if cart is None:
+            return
+        spatial_dims = min(3, arr.ndim)
+        for axis in range(spatial_dims):
+            src, dest = cart.Shift(axis, 1)
+            if dest == MPI.PROC_NULL and src == MPI.PROC_NULL:
+                continue
+            send_hi = [slice(None)] * arr.ndim
+            recv_hi = [slice(None)] * arr.ndim
+            send_lo = [slice(None)] * arr.ndim
+            recv_lo = [slice(None)] * arr.ndim
+            send_hi[axis] = slice(-2, -1)
+            recv_hi[axis] = slice(-1, None)
+            send_lo[axis] = slice(1, 2)
+            recv_lo[axis] = slice(0, 1)
+            cart.Sendrecv(arr[tuple(send_hi)], dest=dest, recvbuf=arr[tuple(recv_hi)], source=src)
+            cart.Sendrecv(arr[tuple(send_lo)], dest=src, recvbuf=arr[tuple(recv_lo)], source=dest)
+
     def exchange_boundaries(self, state: MHDState) -> None:
         """Synchronise ghost zones across MPI ranks if a communicator is set."""
         if self.comm is None or MPI is None:
             return
-        arrays = [state.rho, state.mom, state.energy, state.B]
-        for arr in arrays:
-            self.comm.Allreduce(MPI.IN_PLACE, arr, op=MPI.SUM)
+        for arr in [state.rho, state.mom, state.energy, state.B]:
+            self._exchange_array(arr)
 
     def amr_sync(self, state: MHDState) -> None:
         """Invoke AMReX mesh synchronisation if available."""

--- a/src/dpf2/physics/m0_instability.py
+++ b/src/dpf2/physics/m0_instability.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
+
 import numpy as np
 
 try:  # pragma: no cover - allow running without SciPy
@@ -9,20 +11,33 @@ except Exception:  # pragma: no cover
     mu_0 = 4e-7 * np.pi
     pi = np.pi
 
+try:  # pragma: no cover - MPI optional
+    from mpi4py import MPI  # type: ignore
+except Exception:  # pragma: no cover
+    MPI = None
+
 
 @dataclass
 class MZeroInstability:
     """Very simple ``m=0`` (sausage) instability growth model."""
 
-    current: float  # Discharge current [A]
-    radius: float  # Pinch radius [m]
-    density: float  # Mass density [kg/m^3]
+    current: np.ndarray | float  # Discharge current [A]
+    radius: np.ndarray | float  # Pinch radius [m]
+    density: np.ndarray | float  # Mass density [kg/m^3]
+    comm: Any | None = None  # MPI communicator
 
-    def growth_rate(self) -> float:
+    def growth_rate(self) -> np.ndarray | float:
         """Return an order-of-magnitude ``m=0`` growth rate [1/s]."""
 
-        B_theta = mu_0 * self.current / (2 * pi * self.radius)
-        return float(abs(B_theta) / np.sqrt(mu_0 * self.density))
+        current = np.asarray(self.current)
+        radius = np.asarray(self.radius)
+        density = np.asarray(self.density)
+        B_theta = mu_0 * current / (2 * pi * radius)
+        rate = np.abs(B_theta) / np.sqrt(mu_0 * density)
+        if self.comm is not None and MPI is not None:
+            gathered = self.comm.allgather(rate)
+            rate = np.concatenate([np.atleast_1d(g) for g in gathered], axis=0)
+        return rate if rate.ndim > 0 else float(rate)
 
 
 __all__ = ["MZeroInstability"]

--- a/tests/physics/test_instability_models.py
+++ b/tests/physics/test_instability_models.py
@@ -1,3 +1,8 @@
+from pathlib import Path
+import csv
+import numpy as np
+from scipy.constants import mu_0, pi
+
 from dpf2.physics import LowerHybridDrift, MZeroInstability
 
 
@@ -13,3 +18,21 @@ def test_m0_instability_growth():
     instab = MZeroInstability(current=1e5, radius=0.01, density=1e-3)
     rate = instab.growth_rate()
     assert rate > 0
+
+
+def _load_pf1000(field: str) -> np.ndarray:
+    base = Path("data/benchmarks/PF1000")
+    with open(base / f"{field}.csv") as f:
+        reader = csv.DictReader(f)
+        return np.array([float(row["value"]) for row in reader])
+
+
+def test_m0_instability_pf1000_growth_rates():
+    current = _load_pf1000("current")
+    radius = _load_pf1000("radius") / 100.0  # cm -> m
+    density = np.full_like(current, 1e-3)
+    instab = MZeroInstability(current=current, radius=radius, density=density)
+    rates = instab.growth_rate()
+    expected = np.abs(mu_0 * current / (2 * pi * radius)) / np.sqrt(mu_0 * density)
+    assert np.allclose(rates, expected)
+    assert np.all(rates >= 0)


### PR DESCRIPTION
## Summary
- support MPI domain decomposition with AMReX grids in HallMHDSolver
- vectorize MZeroInstability for grid arrays and MPI reduction
- add PF-1000 benchmark growth-rate test

## Testing
- `venv/bin/python -m pytest tests/physics/test_instability_models.py -q`
- `venv/bin/python -m pytest tests/physics/test_hall_mhd.py -q` *(fails: ValueError: Shape of array too small to calculate a numerical gradient, at least (edge_order + 1) elements are required.)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b50ac228832ab1629dbd139d4afa