### PR TITLE
Add sheath visualization and frontend controls

### DIFF
--- a/examples/notebooks/sheath_animation.ipynb
+++ b/examples/notebooks/sheath_animation.ipynb
@@ -14,35 +14,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "from matplotlib import animation\n",
-    "from ipywidgets import interact, FloatSlider\n\n",
-    "# Simple mock sheath model\n",
-    "def simulate_sheath(voltage, pressure):\n",
-    "    t = np.linspace(0, 2*np.pi, 100)\n",
-    "    sheath = np.sin(t * voltage) * np.exp(-pressure * t)\n",
-    "    x = np.cos(t)\n",
-    "    y = np.sin(t)\n",
-    "    u = -y * sheath\n",
-    "    v = x * sheath\n",
-    "    return x, y, u, v, sheath\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "from ipywidgets import interact, FloatSlider\n",
+    "from dpf2.visualization import animate_sheath\n\n",
     "def plot_sheath(voltage=1.0, pressure=0.1):\n",
-    "    x, y, u, v, sheath = simulate_sheath(voltage, pressure)\n",
-    "    plt.figure()\n",
-    "    plt.quiver(x, y, u, v, sheath)\n",
-    "    plt.title('Sheath Vector Field')\n",
-    "    plt.xlabel('x')\n",
-    "    plt.ylabel('y')\n",
-    "    plt.show()\n\n",
+    "    anim = animate_sheath(voltage, pressure)\n",
+    "    return anim\n\n",
     "interact(plot_sheath,\n",
     "         voltage=FloatSlider(min=0.5, max=5.0, step=0.5, value=1.0, description='Voltage (kV)'),\n",
     "         pressure=FloatSlider(min=0.05, max=1.0, step=0.05, value=0.1, description='Pressure (bar)'))\n"
@@ -55,19 +32,8 @@
    "outputs": [],
    "source": [
     "# Matplotlib animation of sheath evolution\n",
-    "fig, ax = plt.subplots()\n",
-    "x, y, u, v, sheath = simulate_sheath(1.0, 0.1)\n",
-    "quiver = ax.quiver(x, y, u, v, sheath)\n",
-    "ax.set_title('Sheath Evolution (Pressure ramp)')\n",
-    "ax.set_xlabel('x')\n",
-    "ax.set_ylabel('y')\n\n",
-    "def update(frame):\n",
-    "    x, y, u, v, sheath = simulate_sheath(1.0, 0.1 + 0.05 * frame)\n",
-    "    quiver.set_UVC(u, v, sheath)\n",
-    "    return quiver,\n\n",
-    "ani = animation.FuncAnimation(fig, update, frames=20, blit=False)\n",
-    "plt.close(fig)\n",
-    "ani\n"
+    "anim = animate_sheath(1.0, 0.1)\n",
+    "anim\n"
    ]
   },
   {
@@ -76,19 +42,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Optional VTK/PyVista visualization\n",
-    "# If pyvista is installed, this cell will render a vector field using VTK.\n",
+    "# Optional VTK visualization\n",
     "try:\n",
-    "    import pyvista as pv\n\n",
-    "    x, y, u, v, sheath = simulate_sheath(1.0, 0.1)\n",
-    "    z = np.zeros_like(x)\n",
-    "    grid = pv.StructuredGrid(x, y, z)\n",
-    "    grid['vectors'] = np.column_stack((u, v, z))\n",
-    "    plotter = pv.Plotter()\n",
-    "    plotter.add_mesh(grid.arrows, scalars='vectors', lighting=False)\n",
-    "    plotter.show(jupyter_notebook=True)\n",
+    "    animate_sheath(1.0, 0.1, use_vtk=True)\n",
     "except Exception as exc:\n",
-    "    print('PyVista/VTK not available:', exc)\n"
+    "    print('VTK not available:', exc)\n"
    ]
   }
  ],
@@ -106,3 +64,4 @@
  "nbformat": 4,
  "nbformat_minor": 5
 }
+

--- a/src/dpf2/visualization/__init__.py
+++ b/src/dpf2/visualization/__init__.py
@@ -1,1 +1,12 @@
+"""Visualization helpers for DPF2.
+
+Currently this subpackage exposes a small routine for animating
+plasma sheath evolution.  The functionality is intentionally light
+weight so it can be used in examples and tests without requiring the
+full simulation stack.
+"""
+
+from .sheath import animate_sheath
+
+__all__ = ["animate_sheath"]
 

--- a/src/dpf2/visualization/sheath.py
+++ b/src/dpf2/visualization/sheath.py
@@ -1,0 +1,120 @@
+"""Sheath visualization utilities.
+
+This module provides a very small helper for animating a synthetic
+plasma sheath using either Matplotlib or, if available, VTK.  The
+implementation is intentionally lightweight and purely illustrative;
+it is used by the example notebooks and can run without the heavy
+simulation dependencies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+try:  # pragma: no cover - matplotlib optional at runtime
+    import matplotlib.pyplot as plt
+    from matplotlib.animation import FuncAnimation
+except Exception:  # pragma: no cover - matplotlib may be absent
+    plt = None  # type: ignore
+    FuncAnimation = None  # type: ignore
+
+try:  # pragma: no cover - vtk is purely optional
+    import vtk  # type: ignore
+except Exception:  # pragma: no cover - vtk is optional
+    vtk = None  # type: ignore
+
+
+@dataclass
+class SheathField:
+    """Container for the vector field used in the animation."""
+
+    x: np.ndarray
+    y: np.ndarray
+    u: np.ndarray
+    v: np.ndarray
+
+
+def _sheath_field(voltage: float, pressure: float, t: float) -> SheathField:
+    """Generate a toy sheath vector field.
+
+    Parameters
+    ----------
+    voltage:
+        Driving voltage for the sheath.
+    pressure:
+        Background pressure affecting decay.
+    t:
+        Time-like parameter for the evolution.
+    """
+
+    grid = np.linspace(-1.0, 1.0, 20)
+    x, y = np.meshgrid(grid, grid)
+    sheath = np.sin(t * voltage) * np.exp(-pressure * t)
+    u = -y * sheath
+    v = x * sheath
+    return SheathField(x, y, u, v)
+
+
+def animate_sheath(voltage: float, pressure: float, *, use_vtk: bool = False):
+    """Animate a simple sheath evolution.
+
+    The function returns the underlying animation/renderer object so
+    that callers (e.g. notebooks) can display it directly.
+
+    Parameters
+    ----------
+    voltage:
+        Driving voltage.
+    pressure:
+        Background pressure.
+    use_vtk:
+        Use a VTK pipeline instead of Matplotlib when ``True`` and VTK
+        is installed.
+    """
+
+    if use_vtk and vtk is not None:
+        # Minimal VTK pipeline – render a coloured sphere that changes
+        # with the sheath evolution.  This avoids heavy dependencies
+        # while still exercising the rendering path.
+        sphere = vtk.vtkSphereSource()
+        mapper = vtk.vtkPolyDataMapper()
+        mapper.SetInputConnection(sphere.GetOutputPort())
+        actor = vtk.vtkActor()
+        actor.SetMapper(mapper)
+        renderer = vtk.vtkRenderer()
+        renderer.AddActor(actor)
+        window = vtk.vtkRenderWindow()
+        window.AddRenderer(renderer)
+
+        def _update(frame: int) -> None:
+            colour = 0.5 + 0.5 * np.sin(frame * voltage)
+            actor.GetProperty().SetColor(colour, 0.0, 1.0 - colour)
+            window.Render()
+
+        for i in range(20):
+            _update(i)
+        return window
+
+    # Fallback to Matplotlib
+    if plt is None or FuncAnimation is None:  # pragma: no cover - import guard
+        raise RuntimeError("matplotlib is required for animate_sheath")
+
+    fig, ax = plt.subplots()
+    field0 = _sheath_field(voltage, pressure, 0.0)
+    quiver = ax.quiver(field0.x, field0.y, field0.u, field0.v)
+    ax.set_title("Sheath evolution")
+
+    def _frame(i: int):
+        fld = _sheath_field(voltage, pressure, i * 0.1)
+        quiver.set_UVC(fld.u, fld.v)
+        return (quiver,)
+
+    anim = FuncAnimation(fig, _frame, frames=40, interval=50, blit=True)
+    return anim
+
+
+__all__ = ["animate_sheath"]
+

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+pytest.importorskip("matplotlib")
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+
+def test_animate_sheath_returns_animation():
+    from dpf2.visualization import animate_sheath
+
+    anim = animate_sheath(1.0, 0.1)
+    assert anim is not None
+

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -62,6 +62,11 @@ class RunRequest(BaseModel):
     config: Dict[str, Any]
 
 
+class UpdateRequest(BaseModel):
+    voltage: float
+    pressure: float
+
+
 async def broadcast_progress(run_id: str, progress: float) -> None:
     for ws in list(progress_clients.get(run_id, set())):
         await ws.send_json({"run_id": run_id, "progress": progress})
@@ -86,6 +91,20 @@ async def run_simulation(req: RunRequest, user=Depends(get_current_user)):
 
     asyncio.create_task(_mock_progress())
     return {"run_id": run_id}
+
+
+@app.post("/update/{run_id}")
+async def update_simulation(run_id: str, req: UpdateRequest, user=Depends(get_current_user)):
+    """Receive live parameter updates for a running simulation."""
+    logger.info(
+        "action=update user=%s run_id=%s voltage=%s pressure=%s",
+        user["username"],
+        run_id,
+        req.voltage,
+        req.pressure,
+    )
+    await broadcast_diagnostics(run_id, {"voltage": req.voltage, "pressure": req.pressure})
+    return {"status": "updated"}
 
 
 def dispatch_to_hpc(cfg: DPFConfig, username: str) -> str:

--- a/web/frontend/src/App.jsx
+++ b/web/frontend/src/App.jsx
@@ -5,6 +5,8 @@ export default function App() {
   const [token, setToken] = useState('');
   const [config, setConfig] = useState('{}');
   const [runId, setRunId] = useState('');
+  const [voltage, setVoltage] = useState(1.0);
+  const [pressure, setPressure] = useState(0.1);
 
   const login = async (e) => {
     e.preventDefault();
@@ -18,6 +20,11 @@ export default function App() {
     const cfg = JSON.parse(config);
     const { data } = await axios.post('/run', { config: cfg }, { headers: { Authorization: `Bearer ${token}` } });
     setRunId(data.run_id);
+  };
+
+  const updateSimulation = async (v, p) => {
+    if (!runId) return;
+    await axios.post(`/update/${runId}`, { voltage: v, pressure: p }, { headers: { Authorization: `Bearer ${token}` } });
   };
 
   return (
@@ -38,7 +45,45 @@ export default function App() {
           <button type="submit">Run</button>
         </form>
       )}
-      {runId && <p>Submitted run: {runId}</p>}
+      {runId && (
+        <div>
+          <p>Submitted run: {runId}</p>
+          <div>
+            <label>
+              Voltage: {voltage.toFixed(2)} kV
+              <input
+                type="range"
+                min="0"
+                max="5"
+                step="0.1"
+                value={voltage}
+                onChange={(e) => {
+                  const v = parseFloat(e.target.value);
+                  setVoltage(v);
+                  updateSimulation(v, pressure);
+                }}
+              />
+            </label>
+          </div>
+          <div>
+            <label>
+              Pressure: {pressure.toFixed(2)} bar
+              <input
+                type="range"
+                min="0"
+                max="1"
+                step="0.01"
+                value={pressure}
+                onChange={(e) => {
+                  const p = parseFloat(e.target.value);
+                  setPressure(p);
+                  updateSimulation(voltage, p);
+                }}
+              />
+            </label>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add Matplotlib/VTK-based sheath animation helper
- expose voltage and pressure sliders in the web frontend with backend endpoint
- bundle example notebook demonstrating sheath sandbox

## Testing
- `pytest` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/workspace/dpf2/dpf2/ionization...')*


------
https://chatgpt.com/codex/tasks/task_e_68b8b50e6af8832aacb9db967573d3b6