### PR TITLE
Add geometry presets and CLI examples

### DIFF
--- a/config_templates/filippov.json
+++ b/config_templates/filippov.json
@@ -1,0 +1,11 @@
+{
+  "cathode_radius": 0.03,
+  "anode_radius": 0.05,
+  "electrode_length": 0.08,
+  "gas_type": "deuterium",
+  "initial_pressure": 133.3,
+  "capacitance": 3e-5,
+  "inductance": 2e-8,
+  "resistance": 0.01,
+  "charging_voltage": 15000.0
+}

--- a/config_templates/mather.json
+++ b/config_templates/mather.json
@@ -1,0 +1,11 @@
+{
+  "cathode_radius": 0.02,
+  "anode_radius": 0.04,
+  "electrode_length": 0.1,
+  "gas_type": "deuterium",
+  "initial_pressure": 133.3,
+  "capacitance": 3e-5,
+  "inductance": 2e-8,
+  "resistance": 0.01,
+  "charging_voltage": 15000.0
+}

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -98,6 +98,21 @@ def build_config_wizard() -> DPFConfig:
 
     click.echo("DPF2 configuration wizard\n")
     defaults = DPFConfig()
+    click.echo("Geometry presets: mather, filippov or custom.")
+    preset = click.prompt(
+        "Select geometry preset",
+        type=click.Choice(["mather", "filippov", "custom"]),
+        default="mather",
+        show_choices=True,
+    )
+    if preset == "filippov":
+        defaults = dataclasses.replace(
+            defaults, cathode_radius=0.03, anode_radius=0.05, electrode_length=0.08
+        )
+    elif preset == "mather":
+        defaults = dataclasses.replace(
+            defaults, cathode_radius=0.02, anode_radius=0.04, electrode_length=0.1
+        )
 
     # --- Device size -------------------------------------------------
     click.echo("Device geometry:")

--- a/src/dpf2/dpf_config.py
+++ b/src/dpf2/dpf_config.py
@@ -177,6 +177,7 @@ class CircuitConfig(BaseModel):
         )
 
 class ElectrodeGeometry(BaseModel):
+    geometry_preset: Optional[Literal["mather", "filippov"]] = None
     cathode_type: str
     cathode_bar_count: int
     cathode_gap_degrees: float
@@ -190,12 +191,22 @@ class ElectrodeGeometry(BaseModel):
     inner_radius: Optional[float] = None
 
     @classmethod
-    def with_defaults(cls):
+    def with_defaults(cls, geometry_preset: Optional[str] = None):
+        if geometry_preset == "filippov":
+            return cls(
+                geometry_preset="filippov",
+                cathode_type="ring",
+                cathode_bar_count=0,
+                cathode_gap_degrees=0.0,
+                anode_shape="cylinder",
+            )
+        # default to mather-style geometry
         return cls(
+            geometry_preset="mather",
             cathode_type="bar",
             cathode_bar_count=10,
             cathode_gap_degrees=36.0,
-            anode_shape="cylinder"
+            anode_shape="cylinder",
         )
 
 class AmrexSettings(BaseModel):


### PR DESCRIPTION
## Summary
- add `geometry_preset` field with `mather`/`filippov` defaults in ElectrodeGeometry
- provide JSON templates for the two presets
- extend CLI wizard with preset selection examples

## Testing
- `pytest` *(fails: cannot import name 'HallMHD' and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b50f1104832aaf0097f19d2adf1a