### PR TITLE
Add sweep metrics overlay plotting utilities

### DIFF
--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -25,6 +25,12 @@ from dpf2.diagnostics.synthetic_signals import (
 )
 from dpf2.synthetic_diagnostics import SyntheticDiagnostics
 from dpf2.exceptions import ConfigurationError, SimulationRuntimeError
+from dpf2.optimization.param_sweep import (
+    run_parametric_sweep,
+    plot_sweep_results,
+    compute_sweep_metrics,
+    plot_metric_overlay,
+)
 from .errors import format_error
 
 
@@ -614,6 +620,28 @@ def plot_run(run_dir: str, output: str) -> None:
     plt.tight_layout()
     plt.savefig(output)
     click.echo(f"Plot written to {output}")
+
+
+@main.command("param-sweep")
+@click.option("--config", type=click.Path(exists=True, dir_okay=False), required=True)
+@click.option("--parameter", type=str, required=True)
+@click.option("--values", type=float, multiple=True, required=True, help="Values to sweep")
+@click.option("--output", type=click.Path(file_okay=False), default="sweep_output")
+def param_sweep_cmd(
+    config: str, parameter: str, values: tuple[float, ...], output: str
+) -> None:
+    """Run a parameter sweep and plot current, yield and efficiency overlays."""
+
+    try:
+        cfg = DPFConfig.from_file(config)
+        results = run_parametric_sweep(cfg, parameter, values, output_dir=output)
+        plot_sweep_results(parameter, results, Path(output) / "sweep_plot.png")
+        metrics = compute_sweep_metrics(cfg, results)
+        plot_metric_overlay(parameter, metrics, Path(output) / "sweep_metrics.png")
+    except Exception as e:
+        raise click.ClickException(format_error("SWEEP", str(e)))
+
+    click.echo(f"Sweep complete. Results written to {output}")
 
 
 @main.command()

--- a/src/dpf2/optimization/param_sweep.py
+++ b/src/dpf2/optimization/param_sweep.py
@@ -74,4 +74,83 @@ def plot_sweep_results(
     return path
 
 
-__all__ = ["run_parametric_sweep", "plot_sweep_results", "SweepResult"]
+def compute_sweep_metrics(
+    base_config: DPFConfig, results: Dict[float, SweepResult]
+) -> Dict[float, Dict[str, float]]:
+    """Compute simple yield and efficiency estimates for sweep results.
+
+    Parameters
+    ----------
+    base_config:
+        Configuration used for the sweep.  The capacitance and charging
+        voltage are used to estimate the initial energy in the circuit.
+    results:
+        Output of :func:`run_parametric_sweep`.
+
+    Returns
+    -------
+    Dict[float, Dict[str, float]]
+        Mapping of parameter value to metrics ``{"yield", "efficiency"}``.
+        Yield is estimated as the peak current, while efficiency is the ratio
+        of the time-integrated ``I*V`` product to the initial stored energy.
+    """
+
+    import numpy as np
+
+    metrics: Dict[float, Dict[str, float]] = {}
+    energy_in = 0.5 * base_config.capacitance * base_config.charging_voltage**2
+
+    for val, (t, current, voltage) in results.items():
+        t_arr = np.array(t)
+        i_arr = np.array(current)
+        v_arr = np.array(voltage)
+        power = i_arr * v_arr
+        energy_out = float(np.trapz(power, t_arr))
+        efficiency = energy_out / energy_in if energy_in else 0.0
+        yield_est = float(i_arr.max())
+        metrics[val] = {"yield": yield_est, "efficiency": efficiency}
+
+    return metrics
+
+
+def plot_metric_overlay(
+    parameter: str,
+    metrics: Dict[float, Dict[str, float]],
+    path: str | Path,
+) -> Path:
+    """Plot yield and efficiency against the swept parameter on shared axes."""
+
+    import matplotlib.pyplot as plt
+
+    vals = sorted(metrics.keys())
+    yields = [metrics[v]["yield"] for v in vals]
+    effs = [metrics[v]["efficiency"] for v in vals]
+
+    fig, ax1 = plt.subplots()
+    color1 = "tab:blue"
+    ax1.set_xlabel(parameter)
+    ax1.set_ylabel("Yield", color=color1)
+    ax1.plot(vals, yields, color=color1, marker="o", label="yield")
+    ax1.tick_params(axis="y", labelcolor=color1)
+
+    ax2 = ax1.twinx()
+    color2 = "tab:orange"
+    ax2.set_ylabel("Efficiency", color=color2)
+    ax2.plot(vals, effs, color=color2, marker="s", label="efficiency")
+    ax2.tick_params(axis="y", labelcolor=color2)
+
+    fig.tight_layout()
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(path)
+    plt.close(fig)
+    return path
+
+
+__all__ = [
+    "run_parametric_sweep",
+    "plot_sweep_results",
+    "compute_sweep_metrics",
+    "plot_metric_overlay",
+    "SweepResult",
+]

--- a/src/dpf2/web/app.py
+++ b/src/dpf2/web/app.py
@@ -12,7 +12,12 @@ from ..core.config import DPFConfig
 from ..core.simulation import DPFSimulation
 from ..device_profiles import DeviceProfiles
 from ..exceptions import ConfigurationError, SimulationRuntimeError
-from ..optimization.param_sweep import plot_sweep_results, run_parametric_sweep
+from ..optimization.param_sweep import (
+    plot_sweep_results,
+    run_parametric_sweep,
+    compute_sweep_metrics,
+    plot_metric_overlay,
+)
 
 # HTML templates rendered with simple ``render_template_string`` calls.  The
 # templates expose a subset of configuration parameters and allow users to run
@@ -37,6 +42,7 @@ INDEX_HTML = """
   Output directory: <input name=output value="{{ output }}"><br>
   <button name=action value=run>Run</button>
   <button name=action value=sweep>Run Sweep</button>
+  <button name=action value=sweep_metrics>Sweep Metrics</button>
   <button name=action value=export>Export Config</button>
 </form>
 <p><a href="{{ url_for('diagnostics', output=output) }}">View diagnostics</a></p>
@@ -47,6 +53,7 @@ DIAG_HTML = """
 <title>Diagnostics</title>
 <h1>Diagnostics</h1>
 {% if plot %}<img src="{{ plot }}" alt="sweep plot"><br>{% endif %}
+{% if metrics_plot %}<img src="{{ metrics_plot }}" alt="metrics plot"><br>{% endif %}
 <ul>
 {% for f in files %}<li>{{ f }}</li>{% endfor %}
 </ul>
@@ -105,6 +112,15 @@ def create_app() -> Flask:
                         results = run_parametric_sweep(cfg, param, vals, output_dir=output)
                         plot_path = Path(output) / "sweep_plot.png"
                         plot_sweep_results(param, results, plot_path)
+                elif action == "sweep_metrics":
+                    param = request.form.get("sweep_param")
+                    values = request.form.get("sweep_values", "")
+                    if param and values:
+                        vals = list(_parse_sweep_values(values))
+                        results = run_parametric_sweep(cfg, param, vals, output_dir=output)
+                        plot_sweep_results(param, results, Path(output) / "sweep_plot.png")
+                        metrics = compute_sweep_metrics(cfg, results)
+                        plot_metric_overlay(param, metrics, Path(output) / "sweep_metrics.png")
                 else:
                     sim = DPFSimulation(cfg)
                     sim.run(output_dir=output)
@@ -125,7 +141,11 @@ def create_app() -> Flask:
         plot_path = Path(output) / "sweep_plot.png"
         if plot_path.exists():
             plot = "data:image/png;base64," + base64.b64encode(plot_path.read_bytes()).decode("ascii")
-        return render_template_string(DIAG_HTML, files=files, plot=plot)
+        metrics_plot = None
+        metrics_path = Path(output) / "sweep_metrics.png"
+        if metrics_path.exists():
+            metrics_plot = "data:image/png;base64," + base64.b64encode(metrics_path.read_bytes()).decode("ascii")
+        return render_template_string(DIAG_HTML, files=files, plot=plot, metrics_plot=metrics_plot)
 
     return app
 


### PR DESCRIPTION
## Summary
- add yield/efficiency metric computation and overlay plotting utilities
- expose parameter sweep plotting via new `param-sweep` CLI command
- extend web dashboard with Sweep Metrics button and diagnostics view

## Testing
- `pytest` *(fails: tests require assets and dependencies; 28 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b5122110832ab8716d3e0fdc6923