### PR TITLE
Add interferometry and pinhole diagnostics with noise utilities

### DIFF
--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 from enum import Enum
-from typing import Any, ClassVar, Dict, List, Optional, Tuple, Literal
+import random
+from typing import Any, ClassVar, Dict, List, Optional, Tuple, Literal, Sequence, Callable
 
 from pydantic import BaseModel, ConfigDict, Field, root_validator
 
@@ -24,6 +25,29 @@ from .synthetic_signals import (
     bdot_signal,
 )
 from .streaming import NeutronYieldStreamer, XRayEmissionStreamer, RealTimeComparator
+from .interferometry import interferometer_phase_shift
+from .pinhole_imaging import pinhole_image
+
+
+def apply_noise(
+    signal: Sequence[float], noise_fn: Callable[[], float] | None = None
+) -> List[float]:
+    """Apply a noise model to a signal sequence."""
+
+    rng = random.Random()
+    if noise_fn is None:
+        noise_fn = lambda: rng.gauss(0.0, 1.0)
+    return [float(v) + float(noise_fn()) for v in signal]
+
+
+def apply_detector_response(
+    signal: Sequence[float], response_fn: Callable[[float], float] | None = None
+) -> List[float]:
+    """Apply detector response mapping to a signal sequence."""
+
+    if response_fn is None:
+        return [float(v) for v in signal]
+    return [float(response_fn(v)) for v in signal]
 
 __all__ = [
     "compute_neutron_yield",
@@ -41,6 +65,13 @@ __all__ = [
     "NeutronYieldStreamer",
     "XRayEmissionStreamer",
     "RealTimeComparator",
+    "apply_noise",
+    "apply_detector_response",
+    "interferometer_phase_shift",
+    "pinhole_image",
+    "Diagnostics",
+    "DetectorArrayGenerator",
+    "OutputField",
 ]
 
 # Compatibility helpers -------------------------------------------------------
@@ -49,22 +80,26 @@ def model_validator(*, mode: str = "after"):
     def decorator(func):
         if mode == "after":
             def wrapper(cls, values):
-                inst = cls.construct(**values)
+                inst = cls(**values)
                 result = func(cls, inst)
                 return result.__dict__ if isinstance(result, cls) else values
 
-            return root_validator(pre=False, skip_on_failure=True, allow_reuse=True)(wrapper)
+            return classmethod(
+                root_validator(pre=False, skip_on_failure=True, allow_reuse=True)(wrapper)
+            )
         else:
             def wrapper(cls, values):
                 out = func(values)
                 return out if out is not None else values
 
-            return root_validator(pre=True, skip_on_failure=True, allow_reuse=True)(wrapper)
+            return classmethod(
+                root_validator(pre=True, skip_on_failure=True, allow_reuse=True)(wrapper)
+            )
 
     return decorator
 
 if not hasattr(BaseModel, "model_validate"):
-    BaseModel.model_validate = classmethod(lambda cls, d, **_: cls.parse_obj(d))
+    BaseModel.model_validate = classmethod(lambda cls, d, **_: cls(**d))
 if not hasattr(BaseModel, "model_dump"):
     BaseModel.model_dump = BaseModel.dict
 if not hasattr(BaseModel, "model_dump_json"):
@@ -332,16 +367,9 @@ class Diagnostics(ConfigSectionBase):
         context = kwargs.get("context") or {}
         obj = super().model_validate(data)
         setattr(obj, "_context", context)
-        # Re-run validation with context aware rules
-        obj = cls.check_flags(obj)
+        validated = cls.check_flags(obj.__dict__)
+        obj = cls(**validated)
+        setattr(obj, "_context", context)
         return obj
 
 
-__all__ = [
-    "Diagnostics",
-    "DetectorArrayGenerator",
-    "OutputField",
-    "compute_neutron_yield",
-    "compute_xray_spectrum",
-    "compute_scope_trace",
-]

--- a/src/dpf2/diagnostics/interferometry.py
+++ b/src/dpf2/diagnostics/interferometry.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+
+def interferometer_phase_shift(
+    electron_density: Sequence[float],
+    path_lengths: Sequence[float],
+    wavelength: float,
+) -> float:
+    """Compute optical phase shift from line-integrated electron density.
+
+    Parameters
+    ----------
+    electron_density:
+        Electron density along the interferometer line of sight in m^-3.
+    path_lengths:
+        Path length segments corresponding to each density sample in meters.
+    wavelength:
+        Probe wavelength in meters.
+
+    Returns
+    -------
+    float
+        The accumulated phase shift in radians.
+    """
+    if len(electron_density) != len(path_lengths):
+        raise ValueError("electron_density and path_lengths must be the same length")
+    if wavelength <= 0:
+        raise ValueError("wavelength must be positive")
+    r_e = 2.8179403262e-15  # Classical electron radius in meters
+    line_integral = 0.0
+    for ne, dl in zip(electron_density, path_lengths):
+        line_integral += float(ne) * float(dl)
+    return -r_e * wavelength * line_integral
+
+
+__all__ = ["interferometer_phase_shift"]

--- a/src/dpf2/diagnostics/neutron_yield.py
+++ b/src/dpf2/diagnostics/neutron_yield.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Sequence
 
-import numpy as np
 import h5py_stub as h5py  # type: ignore
 
 
@@ -65,18 +64,24 @@ def save_anisotropic_spectrum_hdf5(
     energies: Sequence[float],
     angles: Sequence[float],
     spectrum: Sequence[Sequence[float]],
+    detector_names: Sequence[str] | None = None,
 ) -> None:
-    """Save anisotropic neutron spectrum in an HDF5 file."""
-    spec_arr = np.asarray(spectrum, dtype=float)
-    if spec_arr.shape != (len(angles), len(energies)):
+    """Save anisotropic neutron spectrum in an HDF5 file with per-detector datasets."""
+    spec_arr = [[float(v) for v in row] for row in spectrum]
+    if len(spec_arr) != len(angles) or any(len(row) != len(energies) for row in spec_arr):
         raise ValueError("spectrum shape must be (n_angles, n_energies)")
+    if detector_names is not None and len(detector_names) != len(angles):
+        raise ValueError("detector_names must match number of angles")
     with h5py.File(path, "w") as fh:
-        e_ds = fh.create_dataset("energy_MeV", data=np.asarray(energies, dtype=float))
+        e_ds = fh.create_dataset("energy_MeV", data=[float(e) for e in energies])
         e_ds.data = list(e_ds.data)
-        a_ds = fh.create_dataset("angle_deg", data=np.asarray(angles, dtype=float))
+        a_ds = fh.create_dataset("angle_deg", data=[float(a) for a in angles])
         a_ds.data = list(a_ds.data)
-        s_ds = fh.create_dataset("spectrum", data=spec_arr)
-        s_ds.data = [list(row) for row in spec_arr]
+        grp = fh.require_group("detectors")
+        for i, row in enumerate(spec_arr):
+            name = detector_names[i] if detector_names else f"detector_{i}"
+            ds = grp.create_dataset(name, data=row)
+            ds.data = list(row)
 
 
 __all__ = [

--- a/src/dpf2/diagnostics/pinhole_imaging.py
+++ b/src/dpf2/diagnostics/pinhole_imaging.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import math
+from typing import List, Sequence, Tuple
+
+
+def pinhole_image(
+    source_positions: Sequence[Tuple[float, float, float]],
+    source_intensities: Sequence[float],
+    detector_distance: float,
+    detector_pixels: Tuple[int, int],
+    pixel_size: float,
+) -> List[List[float]]:
+    """Generate a simple pinhole camera image from point sources.
+
+    Parameters
+    ----------
+    source_positions:
+        Sequence of ``(x, y, z)`` source positions in meters.
+    source_intensities:
+        Corresponding source strengths (arbitrary units).
+    detector_distance:
+        Distance from pinhole to detector plane in meters.
+    detector_pixels:
+        Number of pixels ``(nx, ny)`` on the detector plane.
+    pixel_size:
+        Physical size of each pixel in meters.
+
+    Returns
+    -------
+    List[List[float]]
+        2D image array with intensity accumulated per pixel.
+    """
+    if len(source_positions) != len(source_intensities):
+        raise ValueError("source_positions and source_intensities must be the same length")
+    if detector_distance <= 0 or pixel_size <= 0:
+        raise ValueError("detector_distance and pixel_size must be positive")
+    nx, ny = detector_pixels
+    image: List[List[float]] = [[0.0 for _ in range(nx)] for _ in range(ny)]
+    half_x = nx * pixel_size / 2.0
+    half_y = ny * pixel_size / 2.0
+    for (x, y, z), I in zip(source_positions, source_intensities):
+        if z == 0.0:
+            continue  # avoid divide-by-zero
+        scale = detector_distance / z
+        x_det = x * scale
+        y_det = y * scale
+        i = int((x_det + half_x) / pixel_size)
+        j = int((y_det + half_y) / pixel_size)
+        if 0 <= i < nx and 0 <= j < ny:
+            r2 = x_det * x_det + y_det * y_det + detector_distance * detector_distance
+            image[j][i] += I / (4.0 * math.pi * r2)
+    return image
+
+
+__all__ = ["pinhole_image"]

--- a/src/dpf2/io/data_writer.py
+++ b/src/dpf2/io/data_writer.py
@@ -56,8 +56,9 @@ class DataWriter:
         fname = self.output_dir / f"data_{time:.6e}.h5"
         with h5py.File(fname, "w") as f:
             f.create_dataset("time", data=time)
+            det_grp = f.require_group("detectors")
             for key, value in data.items():
-                f.create_dataset(key, data=value)
+                det_grp.create_dataset(key, data=value)
             f.create_dataset("metadata", data=json.dumps(self.metadata))
         return fname
 

--- a/tests/test_new_diagnostics.py
+++ b/tests/test_new_diagnostics.py
@@ -1,0 +1,53 @@
+import math
+import math
+from pathlib import Path
+
+import h5py_stub as h5py  # type: ignore
+
+from dpf2.diagnostics import (
+    apply_detector_response,
+    apply_noise,
+    interferometer_phase_shift,
+    pinhole_image,
+    save_anisotropic_spectrum_hdf5,
+)
+
+
+def test_interferometer_phase_shift():
+    ne = [1e19, 2e19]
+    dl = [0.01, 0.01]
+    wavelength = 1e-6
+    r_e = 2.8179403262e-15
+    expected = -r_e * wavelength * (1e19 * 0.01 + 2e19 * 0.01)
+    result = interferometer_phase_shift(ne, dl, wavelength)
+    assert math.isclose(result, expected)
+
+
+def test_pinhole_image_single_source():
+    positions = [(0.0, 0.0, 1.0)]
+    intensities = [1.0]
+    img = pinhole_image(positions, intensities, 1.0, (10, 10), 0.1)
+    assert img[5][5] > 0.0
+    assert all(img[j][i] == 0.0 for j in range(10) for i in range(10) if (i, j) != (5, 5))
+
+
+def test_noise_and_response_functions():
+    signal = [0.0, 0.0]
+    noisy = apply_noise(signal, noise_fn=lambda: 1.0)
+    assert noisy == [1.0, 1.0]
+    responded = apply_detector_response(signal, response_fn=lambda x: x * 2.0)
+    assert responded == [0.0, 0.0]
+    responded = apply_detector_response([1.0], response_fn=lambda x: x * 2.0)
+    assert responded == [2.0]
+
+
+def test_save_anisotropic_spectrum_hdf5(tmp_path: Path):
+    energies = [1.0, 2.0]
+    angles = [0.0, 90.0]
+    spectrum = [[1.0, 0.5], [0.2, 0.1]]
+    fname = tmp_path / "spec.h5"
+    save_anisotropic_spectrum_hdf5(fname, energies, angles, spectrum, ["d1", "d2"])
+    with h5py.File(fname, "r") as fh:
+        assert "detectors" in fh._items
+        grp = fh["detectors"]
+        assert "d1" in grp._items and "d2" in grp._items


### PR DESCRIPTION
## Summary
- add simplified interferometer phase shift and pinhole imaging diagnostic models
- expose configurable noise and detector response helpers in diagnostics package
- write per-detector datasets in HDF5 export routines

## Testing
- `pytest tests/test_new_diagnostics.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'HallMHD' and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b5107e30832abe4bb34450ae96b0