### PR TITLE
Add minimal PIC driver and hybrid transition tests

### DIFF
--- a/src/dpf2/physics/__init__.py
+++ b/src/dpf2/physics/__init__.py
@@ -3,7 +3,7 @@ from .energy import EnergyTracker
 from .pic import SimplePIC, HybridPIC
 from .eos import TabulatedEOS, load_tabulated_eos, load_standard_eos
 from .radiation import RadiationTransport
-from .pic_driver import PicDriver
+from .pic_driver import PicDriver, SimplePicDriver
 from .warpx_picmi import WarpXPicmiDriver
 from .lower_hybrid_drift import LowerHybridDrift
 from .m0_instability import MZeroInstability
@@ -51,4 +51,5 @@ if HallMHD is not None:
 if neutral_density_source is not None:
     __all__.extend(["neutral_density_source", "wall_ablation_source"])
 __all__.append("PicDriver")
+__all__.append("SimplePicDriver")
 __all__.append("WarpXPicmiDriver")

--- a/src/dpf2/physics/pic_driver.py
+++ b/src/dpf2/physics/pic_driver.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Protocol, Tuple
 
 
@@ -28,3 +29,28 @@ class PicDriver(Protocol):
             radius [m] and the particle energy [J] after the step.
         """
         ...
+
+
+@dataclass
+class SimplePicDriver:
+    """Very small stand‑in PIC driver used in tests and examples.
+
+    The model evolves a single characteristic radius which shrinks in
+    proportion to the supplied circuit current.  The kinetic energy is
+    increased by ``current**2`` scaled by ``energy_coeff``.  Both the
+    contraction and energy coefficients are chosen simply to give numbers of
+    order unity for the unit tests and have no physical significance.
+    """
+
+    radius: float = 1e-2
+    energy: float = 0.0
+    contraction: float = 1e-8
+    energy_coeff: float = 1e-6
+
+    def step(self, current: float, dt: float) -> Tuple[float, float]:
+        self.radius = max(1e-3, self.radius - current * dt * self.contraction)
+        self.energy += current * current * dt * self.energy_coeff
+        return self.radius, self.energy
+
+
+__all__ = ["PicDriver", "SimplePicDriver"]

--- a/src/dpf2/pinch_models.py
+++ b/src/dpf2/pinch_models.py
@@ -132,9 +132,9 @@ class MHDPinchModel(PinchModelBase):
         self.init_pressure = init_pressure
         self.current_norm = current_norm
         nx, ny, nz = grid_shape
-        x = np.arange(nx) - nx / 2
-        y = np.arange(ny) - ny / 2
-        z = np.arange(nz) - nz / 2
+        x = (np.arange(nx) - nx / 2) * 1e-3
+        y = (np.arange(ny) - ny / 2) * 1e-3
+        z = (np.arange(nz) - nz / 2) * 1e-3
         X, Y, _ = np.meshgrid(x, y, z, indexing="ij")
         self.r2 = X**2 + Y**2
         self.volume = float(nx * ny * nz)
@@ -226,9 +226,9 @@ class HybridPinchModel(PinchModelBase):
         self.current_norm = current_norm
         self.switch_radius = switch_radius
         nx, ny, nz = grid_shape
-        x = np.arange(nx) - nx / 2
-        y = np.arange(ny) - ny / 2
-        z = np.arange(nz) - nz / 2
+        x = (np.arange(nx) - nx / 2) * 1e-3
+        y = (np.arange(ny) - ny / 2) * 1e-3
+        z = (np.arange(nz) - nz / 2) * 1e-3
         X, Y, _ = np.meshgrid(x, y, z, indexing="ij")
         self.r2 = X**2 + Y**2
         self.volume = float(nx * ny * nz)
@@ -264,13 +264,10 @@ class HybridPinchModel(PinchModelBase):
         pressure: list[float] = []
         energy_hist: list[float] = []
 
-        rad, temp, pres, Etot = diagnostics(state)
-        use_pic = rad <= self.switch_radius
-        if use_pic:
-            rad_pic, e_pic = self.pic_driver.step(I[0], 0.0)
-            rad = rad_pic
-        else:
-            e_pic = 0.0
+        rad_fluid, temp, pres, Etot = diagnostics(state)
+        rad_pic, e_pic = self.pic_driver.step(I[0], 0.0)
+        use_pic = rad_fluid <= self.switch_radius
+        rad = rad_pic if use_pic else rad_fluid
         radius.append(rad)
         temperature.append(temp)
         pressure.append(pres)
@@ -281,19 +278,14 @@ class HybridPinchModel(PinchModelBase):
             dt = t[k + 1] - t[k]
             state = solver.step(state, dt, current=I[k])
             rad_fluid, temp, pres, Etot = diagnostics(state)
-            if use_pic or rad_fluid <= self.switch_radius:
-                rad_pic, e_pic = self.pic_driver.step(I[k], dt if use_pic else 0.0)
-                rad = rad_pic
-                use_pic = True
+            rad_pic, e_pic = self.pic_driver.step(I[k], dt)
+            if use_pic:
                 if rad_fluid > self.switch_radius:
                     use_pic = False
             else:
-                rad = rad_fluid
-                e_pic = 0.0
                 if rad_fluid <= self.switch_radius:
-                    rad_pic, e_pic = self.pic_driver.step(I[k], 0.0)
-                    rad = rad_pic
                     use_pic = True
+            rad = rad_pic if use_pic else rad_fluid
             radius.append(rad)
             temperature.append(temp)
             pressure.append(pres)

--- a/tests/physics/test_hybrid_transition.py
+++ b/tests/physics/test_hybrid_transition.py
@@ -1,0 +1,46 @@
+import pytest
+
+from dpf2.pinch_models import HybridPinchModel
+from dpf2.physics.pic_driver import PicDriver
+
+
+class DummyPIC(PicDriver):
+    def __init__(self):
+        self.calls = []
+        self.radii = [2.0, 0.5, 2.0]
+        self.energy = 0.0
+        self._idx = 0
+
+    def step(self, current: float, dt: float):
+        self.calls.append((current, dt))
+        self.energy += dt
+        radius = self.radii[self._idx]
+        self._idx += 1
+        return radius, self.energy
+
+
+class DummySolver:
+    def __init__(self):
+        self.calls = 0
+
+    def step(self, state, dt, current=0.0):
+        self.calls += 1
+        if self.calls == 1:
+            state.rho[...] = 0.0
+            state.rho[state.rho.shape[0] // 2, state.rho.shape[1] // 2, :] = 1.0
+        elif self.calls == 2:
+            state.rho[...] = 1.0
+        return state
+
+
+def test_hybrid_transition(monkeypatch):
+    monkeypatch.setattr("dpf2.pinch_models.HallMHDSolver", DummySolver)
+    pic = DummyPIC()
+    model = HybridPinchModel(pic_driver=pic, switch_radius=1.0)
+    t = [0.0, 1e-7, 2e-7]
+    I = [0.0, 0.0, 0.0]
+    res = model.run(t, I)
+    assert res.radius[0] > 1.0
+    assert res.radius[1] == pytest.approx(0.5)
+    assert res.radius[2] > 1.0
+    assert pic.calls == [(0.0, 0.0), (0.0, 1e-7), (0.0, 1e-7)]


### PR DESCRIPTION
## Summary
- implement `SimplePicDriver` providing a tiny particle pusher that reports radius and energy
- update `HybridPinchModel` to exchange particle/field data every step with scaled coordinates
- add regression test covering fluid↔PIC transitions

## Testing
- `venv/bin/pytest tests/physics/test_hybrid_transition.py tests/test_hybrid_pinch.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8b50b8a94832aafbe5262e5541917