### PR TITLE
Add WarpX PIC driver and hybrid PIC feedback tests

### DIFF
--- a/src/dpf2/fusion.py
+++ b/src/dpf2/fusion.py
@@ -25,5 +25,8 @@ def bosch_hale_dd(T_keV: float | np.ndarray) -> float | np.ndarray:
     B = -19.94
     C = 0.0
     reactivity = A * T_keV ** (2.0 / 3.0) * np.exp(B / T_keV ** (1.0 / 3.0))
-    return reactivity
+    try:
+        return float(reactivity)
+    except Exception:  # pragma: no cover - array-like input
+        return reactivity
 

--- a/src/dpf2/physics/__init__.py
+++ b/src/dpf2/physics/__init__.py
@@ -3,8 +3,7 @@ from .energy import EnergyTracker
 from .pic import SimplePIC, HybridPIC
 from .eos import TabulatedEOS, load_tabulated_eos, load_standard_eos
 from .radiation import RadiationTransport
-from .pic_driver import PicDriver, SimplePicDriver
-from .warpx_picmi import WarpXPicmiDriver
+from .pic_driver import PicDriver, SimplePicDriver, WarpXPICDriver
 from .lower_hybrid_drift import LowerHybridDrift
 from .m0_instability import MZeroInstability
 
@@ -52,4 +51,4 @@ if neutral_density_source is not None:
     __all__.extend(["neutral_density_source", "wall_ablation_source"])
 __all__.append("PicDriver")
 __all__.append("SimplePicDriver")
-__all__.append("WarpXPicmiDriver")
+__all__.append("WarpXPICDriver")

--- a/src/dpf2/physics/pic_driver.py
+++ b/src/dpf2/physics/pic_driver.py
@@ -53,4 +53,54 @@ class SimplePicDriver:
         return self.radius, self.energy
 
 
-__all__ = ["PicDriver", "SimplePicDriver"]
+# ---------------------------------------------------------------------------
+# Optional WarpX-based implementation
+try:  # pragma: no cover - exercised when WarpX dependency is present
+    from .warpx_picmi import WarpXPicmiDriver as _WarpXPicmiDriver
+    import numpy as _np
+
+    @dataclass
+    class WarpXPICDriver(_WarpXPicmiDriver):  # type: ignore[misc]
+        """PIC driver that delegates to the WarpX PICMI interface.
+
+        This thin wrapper re-exposes :class:`WarpXPicmiDriver` under a more
+        convenient name and adds a simple particle exchange method used by the
+        hybrid pinch model.  The heavy lifting is provided by the
+        :mod:`dpf2.physics.warpx_picmi` module which in turn relies on the
+        `pywarpx` package.
+        """
+
+        def exchange_particles(self) -> Tuple[_np.ndarray, _np.ndarray]:
+            """Return particle positions and velocities from WarpX."""
+            try:
+                container = self.warp.get_particle_container("ions")
+            except Exception:  # pragma: no cover - exercised in tests via mocks
+                try:
+                    names = getattr(self.warp, "particle_names", [])
+                    container = (
+                        self.warp.get_particle_container(names[0]) if names else None
+                    )
+                except Exception:
+                    container = None
+            if container is None:
+                return _np.empty((0, 3)), _np.empty((0, 3))
+            pos = _np.array(container.get_positions())
+            vel = _np.array(container.get_velocities())
+            return pos, vel
+
+        # ``step`` from ``WarpXPicmiDriver`` already exchanges fields; we only
+        # need to ensure particles are exchanged each time it is invoked.
+        def step(self, current: float, dt: float) -> Tuple[float, float]:
+            radius, energy = super().step(current, dt)
+            self.exchange_particles()
+            return radius, energy
+
+except Exception:  # pragma: no cover - fallback when WarpX is unavailable
+    class WarpXPICDriver(PicDriver):  # type: ignore[misc]
+        """Fallback stub used when WarpX is not installed."""
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            raise RuntimeError("WarpX PICMI interface is not available")
+
+
+__all__ = ["PicDriver", "SimplePicDriver", "WarpXPICDriver"]

--- a/src/dpf2/pinch_models.py
+++ b/src/dpf2/pinch_models.py
@@ -266,6 +266,8 @@ class HybridPinchModel(PinchModelBase):
 
         rad_fluid, temp, pres, Etot = diagnostics(state)
         rad_pic, e_pic = self.pic_driver.step(I[0], 0.0)
+        getattr(self.pic_driver, "exchange_fields", lambda: None)()
+        getattr(self.pic_driver, "exchange_particles", lambda: None)()
         use_pic = rad_fluid <= self.switch_radius
         rad = rad_pic if use_pic else rad_fluid
         radius.append(rad)
@@ -279,6 +281,8 @@ class HybridPinchModel(PinchModelBase):
             state = solver.step(state, dt, current=I[k])
             rad_fluid, temp, pres, Etot = diagnostics(state)
             rad_pic, e_pic = self.pic_driver.step(I[k], dt)
+            getattr(self.pic_driver, "exchange_fields", lambda: None)()
+            getattr(self.pic_driver, "exchange_particles", lambda: None)()
             if use_pic:
                 if rad_fluid > self.switch_radius:
                     use_pic = False

--- a/tests/numpy_stub.py
+++ b/tests/numpy_stub.py
@@ -61,11 +61,35 @@ class Array:
     def __setitem__(self, idx, value):
         if isinstance(value, Array):
             value = value.data
+        if idx is Ellipsis:
+            def _fill(arr):
+                if isinstance(arr, list):
+                    return [_fill(a) for a in arr]
+                return value
+            self.data = _fill(self.data)
+            return
         if isinstance(idx, tuple):
             idx = tuple(slice(None) if i is Ellipsis else i for i in idx)
             if len(idx) == 2 and isinstance(idx[0], slice) and idx[0] == slice(None) and isinstance(idx[1], int):
-                for row, val in zip(self.data, value):
-                    row[idx[1]] = val
+                if isinstance(value, (int, float)):
+                    for row in self.data:
+                        row[idx[1]] = value
+                else:
+                    for row, val in zip(self.data, value):
+                        row[idx[1]] = val
+                return
+            if (
+                len(idx) == 3
+                and isinstance(idx[0], int)
+                and isinstance(idx[1], int)
+                and isinstance(idx[2], slice)
+                and idx[2] == slice(None)
+            ):
+                row = self.data[idx[0]][idx[1]]
+                if isinstance(value, (int, float)):
+                    self.data[idx[0]][idx[1]] = [value] * len(row)
+                else:
+                    self.data[idx[0]][idx[1]] = list(value)
                 return
             arr = self.data
             for i in idx[:-1]:
@@ -122,12 +146,23 @@ class Array:
         return self.__mul__(other)
 
     def __truediv__(self, other):
-        return self._binary(other, lambda a, b: a / b)
+        return self._binary(other, lambda a, b: a / b if b != 0 else 0.0)
+
+    def __rtruediv__(self, other):
+        return Array(other).__truediv__(self)
+
+    def __pow__(self, other):
+        return self._binary(other, lambda a, b: a ** b)
 
     def __neg__(self):
         if isinstance(self.data, list):
             return Array([(-Array(x)).data if isinstance(x, list) else -x for x in self.data])
         return Array(-self.data)
+
+    def __float__(self):
+        if isinstance(self.data, list):
+            return float(sum_(self.data))
+        return float(self.data)
 
     # helper used by ``__neg__``
     def __repr__(self):  # pragma: no cover - debug helper
@@ -255,6 +290,29 @@ def arange(n: int) -> Array:
     return Array(list(range(n)))
 
 
+def meshgrid(*arrays, indexing="xy"):
+    arrays = [array(a).data for a in arrays]
+    dims = len(arrays)
+    shape = [len(a) for a in arrays]
+    grids = [zeros(tuple(shape)).data for _ in arrays]
+
+    def fill(prefix):
+        if len(prefix) == dims:
+            for i, grid in enumerate(grids):
+                val = arrays[i][prefix[i]]
+                tgt = grid
+                for p in prefix[:-1]:
+                    tgt = tgt[p]
+                tgt[prefix[-1]] = val
+            return
+        dim = len(prefix)
+        for i in range(shape[dim]):
+            fill(prefix + [i])
+
+    fill([])
+    return tuple(array(g) for g in grids)
+
+
 def isscalar(x) -> bool:
     return not isinstance(x, (Array, list, tuple))
 
@@ -287,14 +345,40 @@ def max_(vals):
     return arr.data
 
 
+def sum_(vals, axis=None):
+    arr = array(vals).data
+    if axis is None:
+        if isinstance(arr, list):
+            total = 0.0
+            for v in arr:
+                total += sum_(v)
+            return total
+        return arr
+    if not isinstance(arr, list):
+        return arr
+    if axis < 0:
+        axis = len(Array(arr).shape) + axis
+    if axis == 0:
+        result = arr[0]
+        for sub in arr[1:]:
+            result = Array(result)._binary(sub, lambda a, b: a + b).data
+        return array(result)
+    return array([sum_(sub, axis=axis - 1) for sub in arr])
+
+
 def dot(a: Array, b: Array) -> float:
     return sum(x * y for x, y in zip(array(a), array(b)))
 def mean(vals):
-    arr = array(vals)
-    data = arr.data if isinstance(arr, Array) else arr
-    if isinstance(data, list):
-        return sum(data) / len(data) if data else 0.0
-    return data
+    arr = array(vals).data
+    def _count(a):
+        if isinstance(a, list):
+            return sum(_count(x) for x in a)
+        return 1
+    if isinstance(arr, list):
+        total = sum_(arr)
+        cnt = _count(arr)
+        return total / cnt if cnt else 0.0
+    return arr
 
 
 
@@ -381,15 +465,18 @@ np = types.SimpleNamespace(
     isclose=isclose,
     allclose=allclose,
     array_equal=array_equal,
+    asarray=array,
+    sum=sum_,
     argmax=argmax,
     random=types.SimpleNamespace(default_rng=default_rng),
     Array=Array,
     inf=float("inf"),
     pi=math.pi,
     bool_=bool,
+    meshgrid=meshgrid,
 )
 
 sys.modules.setdefault("numpy", np)
 
-__all__ = ["Array", "array", "zeros", "zeros_like", "vstack", "linspace", "arange", "sin", "exp", "abs_", "max_", "dot", "clip", "sqrt", "gradient", "isclose", "allclose", "np"]
+__all__ = ["Array", "array", "zeros", "zeros_like", "vstack", "linspace", "arange", "meshgrid", "sin", "exp", "abs_", "max_", "dot", "clip", "sqrt", "gradient", "isclose", "allclose", "np"]
 

--- a/tests/physics/test_hybrid_pic.py
+++ b/tests/physics/test_hybrid_pic.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+
+from dpf2.pinch_models import HybridPinchModel
+from dpf2.physics.pic_driver import PicDriver
+
+
+class DummyPIC(PicDriver):
+    """Simple mock PIC driver returning prescribed radii and energies."""
+
+    def __init__(self):
+        self.calls = 0
+        self.radii = [0.1, 0.2, 0.3]
+        self.energy = 0.0
+        self.exchange_fields_calls = 0
+        self.exchange_particles_calls = 0
+
+    def step(self, current: float, dt: float):
+        self.energy += dt
+        r = self.radii[self.calls]
+        self.calls += 1
+        return r, self.energy
+
+    def exchange_fields(self):
+        self.exchange_fields_calls += 1
+        return (), ()
+
+    def exchange_particles(self):
+        self.exchange_particles_calls += 1
+        return (), ()
+
+
+class DummySolver:
+    def step(self, state, dt, current=0.0):
+        return state
+
+
+def test_hybrid_pic_feedback(monkeypatch):
+    monkeypatch.setattr("dpf2.pinch_models.HallMHDSolver", DummySolver)
+    pic = DummyPIC()
+    model = HybridPinchModel(pic_driver=pic, switch_radius=1.0)
+    t = [0.0, 1.0, 2.0]
+    I = [0.0, 0.0, 0.0]
+    res = model.run(t, I)
+    assert np.allclose(res.radius, [0.1, 0.2, 0.3])
+    assert res.energy[1] - res.energy[0] == pytest.approx(1.0)
+    assert res.energy[2] - res.energy[1] == pytest.approx(1.0)
+    assert pic.exchange_fields_calls == 3
+    assert pic.exchange_particles_calls == 3


### PR DESCRIPTION
## Summary
- implement `WarpXPICDriver` wrapper around WarpX PICMI driver that also exchanges particle data
- have `HybridPinchModel` exchange fields and particles with the PIC driver each time step
- add unit test exercising PIC radius/energy feedback

## Testing
- `pytest tests/physics/test_hybrid_transition.py tests/physics/test_hybrid_pic.py -q`
- `pytest tests/physics -q` *(fails: ModuleNotFoundError: No module named 'scipy')*


------
https://chatgpt.com/codex/tasks/task_e_68b8b8ce4858832a940d11ea61cde225