### PR TITLE
Add configurable diagnostic noise and openPMD output

### DIFF
--- a/src/dpf2/diagnostics/neutron_yield.py
+++ b/src/dpf2/diagnostics/neutron_yield.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Sequence
+from typing import Callable, Sequence
 
 import h5py_stub as h5py  # type: ignore
 
@@ -65,23 +65,64 @@ def save_anisotropic_spectrum_hdf5(
     angles: Sequence[float],
     spectrum: Sequence[Sequence[float]],
     detector_names: Sequence[str] | None = None,
+    response_fn: Callable[[float], float] | None = None,
+    noise_fn: Callable[[float], float] | None = None,
+    openpmd: bool = False,
 ) -> None:
-    """Save anisotropic neutron spectrum in an HDF5 file with per-detector datasets."""
+    """Save anisotropic neutron spectrum in an HDF5 file with per-detector datasets.
+
+    Parameters
+    ----------
+    path:
+        Output file location.
+    energies, angles, spectrum:
+        Spectral information for each detector angle.
+    detector_names:
+        Optional list naming each detector.
+    response_fn, noise_fn:
+        Optional callables applied to the spectral data.  ``response_fn`` is
+        applied first to each value while ``noise_fn`` should return a noise
+        contribution for the already response-corrected value which will be
+        added to it.
+    openpmd:
+        If ``True`` the file will include a minimal openPMD structure with
+        datasets stored under ``/data/0`` and standard attributes.
+    """
+
     spec_arr = [[float(v) for v in row] for row in spectrum]
     if len(spec_arr) != len(angles) or any(len(row) != len(energies) for row in spec_arr):
         raise ValueError("spectrum shape must be (n_angles, n_energies)")
     if detector_names is not None and len(detector_names) != len(angles):
         raise ValueError("detector_names must match number of angles")
+
     with h5py.File(path, "w") as fh:
-        e_ds = fh.create_dataset("energy_MeV", data=[float(e) for e in energies])
+        base = fh
+        if openpmd:
+            fh.attrs.update(
+                {
+                    "openPMD": "1.1.0",
+                    "basePath": "/data/%T/",
+                    "iterationEncoding": "groupBased",
+                    "iterationFormat": "%T",
+                    "software": "dpf2",
+                }
+            )
+            base = fh.require_group("data/0")
+        e_ds = base.create_dataset("energy_MeV", data=[float(e) for e in energies])
         e_ds.data = list(e_ds.data)
-        a_ds = fh.create_dataset("angle_deg", data=[float(a) for a in angles])
+        e_ds.attrs["unitSI"] = 1.0
+        a_ds = base.create_dataset("angle_deg", data=[float(a) for a in angles])
         a_ds.data = list(a_ds.data)
-        grp = fh.require_group("detectors")
+        a_ds.attrs["unitSI"] = 1.0
+        grp = base.require_group("detectors")
         for i, row in enumerate(spec_arr):
+            processed = [response_fn(v) if response_fn else v for v in row]
+            if noise_fn:
+                processed = [v + noise_fn(v) for v in processed]
             name = detector_names[i] if detector_names else f"detector_{i}"
-            ds = grp.create_dataset(name, data=row)
-            ds.data = list(row)
+            ds = grp.create_dataset(name, data=processed)
+            ds.data = list(processed)
+            ds.attrs["unitSI"] = 1.0
 
 
 __all__ = [

--- a/src/dpf2/diagnostics/pinhole_imaging.py
+++ b/src/dpf2/diagnostics/pinhole_imaging.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import List, Sequence, Tuple
+from typing import Callable, List, Sequence, Tuple
 
 
 def pinhole_image(
@@ -10,6 +10,8 @@ def pinhole_image(
     detector_distance: float,
     detector_pixels: Tuple[int, int],
     pixel_size: float,
+    response_fn: Callable[[float], float] | None = None,
+    noise_fn: Callable[[float], float] | None = None,
 ) -> List[List[float]]:
     """Generate a simple pinhole camera image from point sources.
 
@@ -25,6 +27,11 @@ def pinhole_image(
         Number of pixels ``(nx, ny)`` on the detector plane.
     pixel_size:
         Physical size of each pixel in meters.
+    response_fn, noise_fn:
+        Optional callables applied to each pixel value after accumulation.
+        ``response_fn`` is evaluated first and ``noise_fn`` should return a
+        noise contribution which is then added to the response-corrected
+        pixel value.
 
     Returns
     -------
@@ -50,6 +57,15 @@ def pinhole_image(
         if 0 <= i < nx and 0 <= j < ny:
             r2 = x_det * x_det + y_det * y_det + detector_distance * detector_distance
             image[j][i] += I / (4.0 * math.pi * r2)
+    if response_fn or noise_fn:
+        for j in range(ny):
+            for i in range(nx):
+                val = image[j][i]
+                if response_fn:
+                    val = response_fn(val)
+                if noise_fn:
+                    val += noise_fn(val)
+                image[j][i] = val
     return image
 
 

--- a/src/dpf2/diagnostics/synthetic_signals.py
+++ b/src/dpf2/diagnostics/synthetic_signals.py
@@ -8,52 +8,96 @@ specialised diagnostics that would exist in a full application.
 
 from __future__ import annotations
 
-from typing import Iterable, List
+from typing import Callable, Iterable, List
 import math
 
 from ..core.bases import CouplingState
 
 
-def current_waveform(history: Iterable[CouplingState]) -> List[float]:
+def _apply(
+    values: List[float],
+    response_fn: Callable[[float], float] | None,
+    noise_fn: Callable[[float], float] | None,
+) -> List[float]:
+    if response_fn:
+        values = [response_fn(v) for v in values]
+    if noise_fn:
+        values = [v + noise_fn(v) for v in values]
+    return values
+
+
+def current_waveform(
+    history: Iterable[CouplingState],
+    response_fn: Callable[[float], float] | None = None,
+    noise_fn: Callable[[float], float] | None = None,
+) -> List[float]:
     """Return the circuit current for each time step."""
 
-    return [float(state.current) for state in history]
+    data = [float(state.current) for state in history]
+    return _apply(data, response_fn, noise_fn)
 
 
-def voltage_waveform(history: Iterable[CouplingState]) -> List[float]:
+def voltage_waveform(
+    history: Iterable[CouplingState],
+    response_fn: Callable[[float], float] | None = None,
+    noise_fn: Callable[[float], float] | None = None,
+) -> List[float]:
     """Return the capacitor voltage for each time step."""
 
-    return [float(state.voltage) for state in history]
+    data = [float(state.voltage) for state in history]
+    return _apply(data, response_fn, noise_fn)
 
 
-def coupled_current_waveform(history: Iterable[CouplingState]) -> List[float]:
+def coupled_current_waveform(
+    history: Iterable[CouplingState],
+    response_fn: Callable[[float], float] | None = None,
+    noise_fn: Callable[[float], float] | None = None,
+) -> List[float]:
     """Return current including simple back-reaction term.
 
     The ``CouplingState.back_reaction`` value is interpreted as a voltage
     contribution which is scaled by unity for this synthetic diagnostic.
     """
 
-    return [float(state.current + state.back_reaction) for state in history]
+    data = [float(state.current + state.back_reaction) for state in history]
+    return _apply(data, response_fn, noise_fn)
 
 
-def coupled_voltage_waveform(history: Iterable[CouplingState]) -> List[float]:
+def coupled_voltage_waveform(
+    history: Iterable[CouplingState],
+    response_fn: Callable[[float], float] | None = None,
+    noise_fn: Callable[[float], float] | None = None,
+) -> List[float]:
     """Return voltage including mutual inductance contribution."""
 
-    return [float(state.voltage + state.mutual_inductance) for state in history]
+    data = [float(state.voltage + state.mutual_inductance) for state in history]
+    return _apply(data, response_fn, noise_fn)
 
 
-def rogowski_signal(history: Iterable[CouplingState], dt: float) -> List[float]:
+def rogowski_signal(
+    history: Iterable[CouplingState],
+    dt: float,
+    response_fn: Callable[[float], float] | None = None,
+    noise_fn: Callable[[float], float] | None = None,
+) -> List[float]:
     """Compute a synthetic Rogowski coil signal ``dI/dt``."""
 
     currents = current_waveform(history)
     if len(currents) < 2 or dt <= 0:
-        return [0.0 for _ in currents]
-    deriv = [(currents[i + 1] - currents[i]) / dt for i in range(len(currents) - 1)]
-    deriv.append(deriv[-1])
-    return deriv
+        deriv = [0.0 for _ in currents]
+    else:
+        deriv = [(currents[i + 1] - currents[i]) / dt for i in range(len(currents) - 1)]
+        deriv.append(deriv[-1])
+    return _apply(deriv, response_fn, noise_fn)
 
 
-def bdot_signal(history: Iterable[CouplingState], radius: float, dt: float) -> List[float]:
+def bdot_signal(
+    history: Iterable[CouplingState],
+    radius: float,
+    dt: float,
+    response_fn: Callable[[float], float] | None = None,
+    noise_fn: Callable[[float], float] | None = None,
+) -> List[float]:
     """Generate a simple B-dot probe signal assuming axial field geometry."""
 
     mu0 = 4.0 * math.pi * 1e-7
@@ -62,10 +106,11 @@ def bdot_signal(history: Iterable[CouplingState], radius: float, dt: float) -> L
     currents = current_waveform(history)
     B = [mu0 * I / (2.0 * math.pi * radius) for I in currents]
     if len(B) < 2 or dt <= 0:
-        return [0.0 for _ in B]
-    deriv = [(B[i + 1] - B[i]) / dt for i in range(len(B) - 1)]
-    deriv.append(deriv[-1])
-    return deriv
+        deriv = [0.0 for _ in B]
+    else:
+        deriv = [(B[i + 1] - B[i]) / dt for i in range(len(B) - 1)]
+        deriv.append(deriv[-1])
+    return _apply(deriv, response_fn, noise_fn)
 
 
 __all__ = [

--- a/tests/diagnostics/test_noise_and_hdf5.py
+++ b/tests/diagnostics/test_noise_and_hdf5.py
@@ -1,0 +1,54 @@
+import math
+import pytest
+import h5py_stub as h5py
+
+from dpf2.diagnostics.pinhole_imaging import pinhole_image
+from dpf2.diagnostics.synthetic_signals import current_waveform
+from dpf2.diagnostics.neutron_yield import save_anisotropic_spectrum_hdf5
+from dpf2.core.bases import CouplingState
+
+
+def test_noise_response_pinhole():
+    img = pinhole_image(
+        [(0.0, 0.0, 1.0)],
+        [1.0],
+        detector_distance=1.0,
+        detector_pixels=(1, 1),
+        pixel_size=1.0,
+        response_fn=lambda x: x * 2.0,
+        noise_fn=lambda x: 0.1,
+    )
+    expected = (1.0 / (4.0 * math.pi)) * 2.0 + 0.1
+    assert abs(img[0][0] - expected) < 1e-12
+
+
+def test_noise_response_synthetic_signal():
+    history = [CouplingState(current=1.0), CouplingState(current=2.0)]
+    data = current_waveform(
+        history,
+        response_fn=lambda x: x * 2.0,
+        noise_fn=lambda x: 0.1,
+    )
+    assert data == [1.0 * 2.0 + 0.1, 2.0 * 2.0 + 0.1]
+
+
+def test_save_anisotropic_spectrum_openpmd(tmp_path):
+    path = tmp_path / "spec.h5"
+    energies = [1.0, 2.0]
+    angles = [0.0, 45.0]
+    spectrum = [[1.0, 2.0], [3.0, 4.0]]
+    save_anisotropic_spectrum_hdf5(
+        path,
+        energies,
+        angles,
+        spectrum,
+        response_fn=lambda x: x * 2.0,
+        noise_fn=lambda x: 0.1,
+        openpmd=True,
+    )
+    with h5py.File(path, "r") as fh:
+        assert fh.attrs["openPMD"] == "1.1.0"
+        ds = fh["data/0/detectors/detector_0"]
+        data = list(ds.data)
+        assert data[0] == pytest.approx(1.0 * 2.0 + 0.1)
+        assert ds.attrs["unitSI"] == 1.0


### PR DESCRIPTION
## Summary
- allow neutron spectrum, pinhole imaging, and synthetic signals to apply configurable response and noise functions
- enable optional openPMD/HDF5 output with per-detector datasets
- add tests for noise injection and HDF5 structure

## Testing
- `pytest tests/diagnostics -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b8d23a18832a912dee5a47294d43