### PR TITLE
Add hostfile and GPU mapping support for MPI jobs

### DIFF
--- a/examples/hpc/slurm_restart.sh
+++ b/examples/hpc/slurm_restart.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Restart a DPF2 simulation using a checkpoint
+# Restart a DPF2 simulation using a checkpoint with data staging
 # Submit with a dependency on the initial job:
 #   sbatch --dependency=afterok:<jobid> slurm_restart.sh
 #SBATCH -J dpf2_restart
@@ -8,15 +8,16 @@
 #SBATCH -o %x_%j.out
 #SBATCH -e %x_%j.err
 
-# Stage checkpoint and configuration
+# Stage checkpoint and configuration into scratch
 tmp=${SLURM_TMPDIR:-$(mktemp -d)}
 cp $SLURM_SUBMIT_DIR/examples/config.json "$tmp/"
 cp $SLURM_SUBMIT_DIR/results/result.npz "$tmp/"
 cd "$tmp"
 
-# Restart the simulation
+# Restart the simulation from the checkpoint
 echo "Restarting from result.npz"
 srun python $SLURM_SUBMIT_DIR/examples/run_simulation.py --config config.json --restart result.npz --output restart_result.npz
 
-# Collect output data
+# Collect output data back to the submission directory
+mkdir -p $SLURM_SUBMIT_DIR/results
 cp restart_result.npz $SLURM_SUBMIT_DIR/results/

--- a/examples/hpc/slurm_run.sh
+++ b/examples/hpc/slurm_run.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# Initial run of a DPF2 simulation on a SLURM cluster
+# Initial run of a DPF2 simulation on a SLURM cluster with data staging
 #SBATCH -J dpf2_run
 #SBATCH -N 1
 #SBATCH --gpus=1
 #SBATCH -o %x_%j.out
 #SBATCH -e %x_%j.err
 
-# Stage input data
+# Stage input data into a node-local scratch directory for faster I/O
 tmp=${SLURM_TMPDIR:-$(mktemp -d)}
 cp $SLURM_SUBMIT_DIR/examples/config.json "$tmp/"
 cd "$tmp"
@@ -14,6 +14,6 @@ cd "$tmp"
 # Execute the simulation
 srun python $SLURM_SUBMIT_DIR/examples/run_simulation.py --config config.json --output result.npz
 
-# Collect output data
+# Collect output data back to the submission directory
 mkdir -p $SLURM_SUBMIT_DIR/results
 cp result.npz $SLURM_SUBMIT_DIR/results/

--- a/src/dpf2/hpc/manager.py
+++ b/src/dpf2/hpc/manager.py
@@ -42,6 +42,14 @@ class JobManager:
                     flags = [flags]
                 cmd.extend(list(flags) + [value])
 
+    def _write_temp_file(self, content: str, suffix: str = "") -> str:
+        """Write ``content`` to a temporary file and return its path."""
+
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(fd, "w") as fh:
+            fh.write(content)
+        return path
+
     def _wrap_staging(
         self,
         job_script: str,
@@ -157,6 +165,10 @@ class JobManager:
             if deps is not None:
                 raise ValueError("Dependencies are not supported for MPI scheduler")
 
+            hosts = kwargs.pop("hosts", None)
+            host_gpus = kwargs.pop("host_gpus", None)
+            decomp: Dict[str, Any] | None = kwargs.pop("decomp", None)
+
             cmd = ["mpirun"]
             self._extend_cmd(
                 cmd,
@@ -165,18 +177,38 @@ class JobManager:
                     "nprocs": "-n",
                 },
             )
-            decomp: Dict[str, Any] | None = kwargs.get("decomp")
-            if decomp:
-                for axis, cnt in decomp.items():
-                    cmd.extend([f"--decomp-{axis}", str(cnt)])
-            if "restart" in kwargs:
-                cmd.extend(["--restart", str(kwargs["restart"])])
-            cmd.append(job_script)
 
             env = os.environ.copy()
-            if gpus is not None:
+
+            # Generate hostfile and GPU mapping if requested
+            if host_gpus is not None:
+                host_lines = []
+                gpu_map_lines = []
+                rank = 0
+                for host, gpu_list in host_gpus.items():
+                    host_lines.append(f"{host} slots={len(gpu_list)}")
+                    for gpu in gpu_list:
+                        gpu_map_lines.append(f"{rank} {host} {gpu}")
+                        rank += 1
+                hostfile = self._write_temp_file("\n".join(host_lines) + "\n", suffix=".hosts")
+                cmd.extend(["--hostfile", hostfile])
+                gpu_map_file = self._write_temp_file("\n".join(gpu_map_lines) + "\n", suffix=".gpus")
+                env["DPF_GPU_MAP"] = gpu_map_file
+            elif hosts is not None:
+                hostfile = self._write_temp_file("\n".join(hosts) + "\n", suffix=".hosts")
+                cmd.extend(["--hostfile", hostfile])
+
+            script_cmd = [job_script]
+            if decomp:
+                for axis, cnt in decomp.items():
+                    script_cmd.extend([f"--decomp-{axis}", str(cnt)])
+            if "restart" in kwargs:
+                script_cmd.extend(["--restart", str(kwargs["restart"])])
+
+            if gpus is not None and host_gpus is None:
                 env["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(int(gpus)))
 
+            cmd.extend(script_cmd)
             return subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
         raise ValueError(f"Unsupported scheduler: {self.scheduler}")
 


### PR DESCRIPTION
## Summary
- generate temporary hostfiles and GPU mapping files for MPI runs
- pass domain decomposition flags to solver startup scripts
- document data staging and restart with SLURM example scripts

## Testing
- `pytest tests/test_parallel_settings.py` *(fails: AttributeError: type object 'ParallelSettings' has no attribute 'parse_obj')*


------
https://chatgpt.com/codex/tasks/task_e_68b8b8d2e7d8832a8cf58269f625610d