### PR TITLE
Add configuration set management and project endpoints

### DIFF
--- a/src/dpf2/web/app.py
+++ b/src/dpf2/web/app.py
@@ -5,8 +5,9 @@ import base64
 import os
 from pathlib import Path
 from typing import Iterable
+import uuid
 
-from flask import Flask, redirect, render_template_string, request, url_for
+from flask import Flask, redirect, render_template_string, request, url_for, jsonify
 
 from ..core.config import DPFConfig
 from ..core.simulation import DPFSimulation
@@ -88,6 +89,9 @@ def _parse_sweep_values(vals: str) -> Iterable[float]:
 
 def create_app() -> Flask:
     app = Flask(__name__)
+    projects: dict[str, dict] = {}
+    sweep_results: dict[str, dict] = {}
+    upload_dir = Path("uploads")
 
     @app.route("/", methods=["GET", "POST"])
     def index():
@@ -146,6 +150,30 @@ def create_app() -> Flask:
         if metrics_path.exists():
             metrics_plot = "data:image/png;base64," + base64.b64encode(metrics_path.read_bytes()).decode("ascii")
         return render_template_string(DIAG_HTML, files=files, plot=plot, metrics_plot=metrics_plot)
+
+    @app.route("/projects", methods=["GET", "POST"])
+    def projects_ep():
+        if request.method == "POST":
+            proj_id = request.form.get("id") or f"proj-{uuid.uuid4().hex[:8]}"
+            preset = request.form.get("preset")
+            file = request.files.get("cad")
+            cfg = {"id": proj_id, "preset": preset}
+            if file:
+                upload_dir.mkdir(parents=True, exist_ok=True)
+                path = upload_dir / f"{proj_id}_{file.filename}"
+                file.save(path)
+                cfg["cad"] = str(path)
+            projects[proj_id] = cfg
+            return jsonify(cfg)
+        return jsonify(list(projects.values()))
+
+    @app.route("/sweep/<proj_id>", methods=["GET", "POST"])
+    def sweep_ep(proj_id: str):
+        if request.method == "POST":
+            data = request.get_json() or {}
+            sweep_results.setdefault(proj_id, {}).update(data)
+            return {"status": "ok"}
+        return sweep_results.get(proj_id, {})
 
     return app
 

--- a/web/frontend/src/App.jsx
+++ b/web/frontend/src/App.jsx
@@ -9,6 +9,7 @@ export default function App() {
 
   const [voltage, setVoltage] = useState(1.0);
   const [pressure, setPressure] = useState(0.1);
+  const [projects, setProjects] = useState([]);
 
 
   const login = async (e) => {

--- a/web/frontend/src/EfficiencyCurveOverlay.jsx
+++ b/web/frontend/src/EfficiencyCurveOverlay.jsx
@@ -1,8 +1,9 @@
 import React, { useMemo, useRef } from 'react';
 
-export default function EfficiencyCurveOverlay({ data = {} }) {
+export default function EfficiencyCurveOverlay({ datasets = [] }) {
   const svgRef = useRef(null);
-  const points = useMemo(() => {
+
+  const computePoints = (data) => {
     const entries = Object.entries(data);
     if (entries.length === 0) return '';
     const width = 200;
@@ -20,7 +21,7 @@ export default function EfficiencyCurveOverlay({ data = {} }) {
         return `${x},${y}`;
       })
       .join(' ');
-  }, [data]);
+  };
 
   const download = () => {
     const svg = svgRef.current;
@@ -38,7 +39,10 @@ export default function EfficiencyCurveOverlay({ data = {} }) {
     <div className="overlay">
       <h4>Efficiency Curve</h4>
       <svg ref={svgRef} width="200" height="100">
-        {points && <polyline points={points} stroke="green" fill="none" />}
+        {datasets.map(({ label, data, color = 'green' }) => {
+          const pts = computePoints(data);
+          return <polyline key={label} points={pts} stroke={color} fill="none" />;
+        })}
       </svg>
       <button type="button" onClick={download}>
         Download

--- a/web/frontend/src/ProjectManager.jsx
+++ b/web/frontend/src/ProjectManager.jsx
@@ -3,60 +3,113 @@ import axios from 'axios';
 import YieldPressureOverlay from './YieldPressureOverlay.jsx';
 import EfficiencyCurveOverlay from './EfficiencyCurveOverlay.jsx';
 
-export default function ProjectManager({ projects }) {
-  const [activeId, setActiveId] = useState(null);
+export default function ProjectManager({ projects = [] }) {
+  const [configSets, setConfigSets] = useState(projects);
+  const [selectedIds, setSelectedIds] = useState([]);
   const [results, setResults] = useState({});
-  const active = projects.find((p) => p.id === activeId);
+
+  const [preset, setPreset] = useState('');
+  const [cad, setCad] = useState(null);
 
   useEffect(() => {
-    if (!activeId) return undefined;
-    const fetchResults = async () => {
-      try {
-        const { data } = await axios.get(`/sweep/${activeId}`);
-        setResults((r) => ({ ...r, [activeId]: data }));
-      } catch (err) {
-        // ignore fetch errors
-      }
-    };
-    fetchResults();
+    setConfigSets(projects);
+  }, [projects]);
 
-    const ws = new WebSocket(
-      `${window.location.origin.replace('http', 'ws')}/ws/sweep/${activeId}`
+  useEffect(() => {
+    const sockets = [];
+    selectedIds.forEach((id) => {
+      if (!results[id]) {
+        axios
+          .get(`/sweep/${id}`)
+          .then(({ data }) => setResults((r) => ({ ...r, [id]: data })))
+          .catch(() => {});
+      }
+      const ws = new WebSocket(
+        `${window.location.origin.replace('http', 'ws')}/ws/sweep/${id}`
+      );
+      ws.onmessage = (evt) => {
+        const msg = JSON.parse(evt.data);
+        if (msg.parameter !== undefined) {
+          setResults((r) => ({
+            ...r,
+            [id]: {
+              ...(r[id] || {}),
+              [msg.parameter]: {
+                yield: msg.yield,
+                efficiency: msg.efficiency,
+              },
+            },
+          }));
+        }
+      };
+      sockets.push(ws);
+    });
+    return () => sockets.forEach((s) => s.close());
+  }, [selectedIds]);
+
+  const toggleSelect = (id) => {
+    setSelectedIds((ids) =>
+      ids.includes(id) ? ids.filter((i) => i !== id) : [...ids, id]
     );
-    ws.onmessage = (evt) => {
-      const msg = JSON.parse(evt.data);
-      if (msg.parameter !== undefined) {
-        setResults((r) => ({
-          ...r,
-          [activeId]: {
-            ...(r[activeId] || {}),
-            [msg.parameter]: { yield: msg.yield, efficiency: msg.efficiency },
-          },
-        }));
-      }
-    };
-    return () => ws.close();
-  }, [activeId]);
+  };
 
-  const activeResults = activeId ? results[activeId] || {} : {};
+  const addConfigSet = async (e) => {
+    e.preventDefault();
+    const form = new FormData();
+    form.append('preset', preset);
+    if (cad) form.append('cad', cad);
+    try {
+      const { data } = await axios.post('/projects', form);
+      setConfigSets((c) => [...c, data]);
+      setPreset('');
+      setCad(null);
+    } catch (err) {
+      // ignore upload errors
+    }
+  };
+
+  const colors = ['blue', 'green', 'red', 'orange', 'purple'];
+  const datasets = selectedIds.map((id, idx) => ({
+    label: id,
+    data: results[id] || {},
+    color: colors[idx % colors.length],
+  }));
 
   return (
     <div>
-      <h3>Projects</h3>
-      {projects.length === 0 && <p>No projects submitted yet.</p>}
+      <h3>Configuration Sets</h3>
+      {configSets.length === 0 && <p>No projects submitted yet.</p>}
       <ul>
-        {projects.map((p) => (
+        {configSets.map((p) => (
           <li key={p.id}>
-            <button type="button" onClick={() => setActiveId(p.id)}>
+            <label>
+              <input
+                type="checkbox"
+                checked={selectedIds.includes(p.id)}
+                onChange={() => toggleSelect(p.id)}
+              />
               {p.id}
-            </button>
+            </label>
           </li>
         ))}
       </ul>
-      {active && (
+
+      <form onSubmit={addConfigSet}>
+        <h4>Add Configuration Set</h4>
+        <select value={preset} onChange={(e) => setPreset(e.target.value)}>
+          <option value="">Geometry Preset</option>
+          <option value="tapered">Tapered</option>
+          <option value="hollow">Hollow</option>
+          <option value="re-entrant">Re-entrant</option>
+        </select>
+        <input type="file" onChange={(e) => setCad(e.target.files[0])} />
+        <button type="submit">Add</button>
+      </form>
+
+      {selectedIds.length > 0 && (
         <div className="overlays">
-          <YieldPressureOverlay data={activeResults} />
-          <EfficiencyCurveOverlay data={activeResults} />
+          <YieldPressureOverlay datasets={datasets} />
+          <EfficiencyCurveOverlay datasets={datasets} />
         </div>
       )}
     </div>

--- a/web/frontend/src/YieldPressureOverlay.jsx
+++ b/web/frontend/src/YieldPressureOverlay.jsx
@@ -1,8 +1,9 @@
 import React, { useMemo, useRef } from 'react';
 
-export default function YieldPressureOverlay({ data = {} }) {
+export default function YieldPressureOverlay({ datasets = [] }) {
   const svgRef = useRef(null);
-  const points = useMemo(() => {
+
+  const computePoints = (data) => {
     const entries = Object.entries(data);
     if (entries.length === 0) return '';
     const width = 200;
@@ -20,7 +21,7 @@ export default function YieldPressureOverlay({ data = {} }) {
         return `${x},${y}`;
       })
       .join(' ');
-  }, [data]);
+  };
 
   const download = () => {
     const svg = svgRef.current;
@@ -38,7 +39,10 @@ export default function YieldPressureOverlay({ data = {} }) {
     <div className="overlay">
       <h4>Yield/Pressure Curve</h4>
       <svg ref={svgRef} width="200" height="100">
-        {points && <polyline points={points} stroke="blue" fill="none" />}
+        {datasets.map(({ label, data, color = 'blue' }) => {
+          const pts = computePoints(data);
+          return <polyline key={label} points={pts} stroke={color} fill="none" />;
+        })}
       </svg>
       <button type="button" onClick={download}>
         Download


### PR DESCRIPTION
## Summary
- Support multiple configuration sets with geometry presets and CAD uploads.
- Overlay sweep metrics across selected configuration sets.
- Provide REST endpoints to store projects and retrieve sweep results.

## Testing
- `pytest` *(fails: FileNotFoundError: No such file or directory: '/workspace/dpf2/dpf2/ionization_energy.csv'; NameError: name 'types' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ffa41e68832a981a964694058833