### PR TITLE
Add STEP/IGES mesh import with dimension validation

### DIFF
--- a/src/dpf2/dpf_config.py
+++ b/src/dpf2/dpf_config.py
@@ -192,6 +192,12 @@ class ElectrodeGeometry(BaseModel):
     taper_angle: Optional[float] = None
     inner_radius: Optional[float] = None
 
+    @validator("mesh_file")
+    def _check_mesh_file(cls, v: Optional[Path]):
+        if v is not None and not Path(v).exists():
+            raise ValueError(f"mesh_file not found: {v}")
+        return v
+
     @classmethod
     def with_defaults(cls, geometry_preset: Optional[str] = None):
         if geometry_preset == "filippov":
@@ -367,6 +373,27 @@ class DPFConfig(BaseModel):
         gr = values.get("grid_resolution")
         if sc and gr and sc.geometry == "2D_RZ" and gr.ny != 1:
             raise ValueError("ny must be 1 for 2D_RZ geometry")
+
+        amrex = values.get("amrex_settings")
+        if sc and amrex and amrex.electrode_geometry and amrex.electrode_geometry.mesh_file:
+            from .geometry.loaders import load_cad_geometry, load_unstructured_mesh
+
+            p = Path(amrex.electrode_geometry.mesh_file)
+            try:
+                data = load_cad_geometry(p)
+            except ValueError:
+                data = load_unstructured_mesh(p)
+
+            nodes = data.get("nodes") or []
+            if not nodes:
+                raise ValueError("Imported mesh contains no nodes")
+            dim = len(nodes[0])
+            expected = 2 if sc.geometry == "2D_RZ" else 3
+            if dim != expected:
+                raise ValueError(
+                    f"Imported mesh is {dim}D but simulation geometry requires {expected}D"
+                )
+
         return values
 
     @classmethod

--- a/src/dpf2/geometry/loaders.py
+++ b/src/dpf2/geometry/loaders.py
@@ -4,6 +4,11 @@ import json
 from pathlib import Path
 from typing import Dict, Any, List
 
+try:  # pragma: no cover - optional dependency
+    import meshio  # type: ignore
+except Exception:  # pragma: no cover - meshio may not be installed
+    meshio = None
+
 
 def _parse_step_like(lines: List[str]) -> Dict[str, Any]:
     """Parse a tiny subset of STEP/IGES style geometry.
@@ -33,8 +38,10 @@ def load_cad_geometry(path: Path) -> Dict[str, Any]:
     The loader understands a few simple formats used in tests:
 
     * ``.json`` files containing ``nodes`` and ``elements`` lists.
-    * ``.step``/``.stp`` and ``.iges``/``.igs`` files with lines of the form
-      ``NODE x y z`` and ``TRI i j k``.
+    * ``.step``/``.stp`` and ``.iges``/``.igs`` files.  If :mod:`meshio` is
+      available it is used to parse these files.  Otherwise a tiny custom text
+      format is supported where each line is either ``NODE x y z`` or
+      ``TRI i j k``.
     """
 
     p = Path(path)
@@ -42,6 +49,19 @@ def load_cad_geometry(path: Path) -> Dict[str, Any]:
     if suffix == ".json":
         return json.loads(p.read_text())
     if suffix in {".step", ".stp", ".iges", ".igs"}:
+        if meshio is not None:
+            try:  # pragma: no cover - exercised when meshio is available
+                m = meshio.read(p)
+                elements: List[List[int]] = []
+                for block in m.cells:
+                    if block.type in {"triangle", "quad"}:
+                        elements.extend(block.data.tolist())
+                if not elements and m.cells:
+                    elements = m.cells[0].data.tolist()
+                return {"nodes": m.points.tolist(), "elements": elements}
+            except Exception:
+                pass
+        # fallback simple text representation
         lines = [ln.strip() for ln in p.read_text().splitlines() if ln.strip()]
         return _parse_step_like(lines)
     raise ValueError(f"Unsupported CAD format: {suffix}")

--- a/tests/geometry/test_import.py
+++ b/tests/geometry/test_import.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import pytest
+
+from dpf2.dpf_config import DPFConfig
+from dpf2.grid_resolution import GridResolution
+
+
+def _make_config(geometry: str, mesh: Path) -> DPFConfig:
+    cfg = DPFConfig.with_defaults()
+    sc = cfg.simulation_control.model_copy(update={"geometry": geometry})
+    gr = GridResolution.with_defaults(geometry)
+    eg = cfg.amrex_settings.electrode_geometry.model_copy(update={"mesh_file": mesh})
+    amr = cfg.amrex_settings.model_copy(update={"electrode_geometry": eg})
+    cfg = cfg.model_copy(update={"simulation_control": sc, "grid_resolution": gr, "amrex_settings": amr})
+    return cfg
+
+
+def test_mesh_import_valid():
+    path = Path(__file__).with_name("sample.step")
+    cfg = _make_config("3D_Cartesian", path)
+    DPFConfig.validate_cross_fields(DPFConfig, cfg.__dict__)
+    assert cfg.amrex_settings.electrode_geometry.mesh_file == path
+
+
+def test_mesh_dimension_mismatch():
+    path = Path(__file__).with_name("sample.step")
+    cfg = _make_config("2D_RZ", path)
+    with pytest.raises(ValueError):
+        DPFConfig.validate_cross_fields(DPFConfig, cfg.__dict__)


### PR DESCRIPTION
## Summary
- extend CAD loader with optional meshio-based STEP/IGES support and text fallback
- allow configuration to reference imported meshes and validate their dimensionality
- add tests covering mesh import and dimensional checks

## Testing
- `python -m pytest tests/geometry/test_geometry_loading.py tests/geometry/test_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8ffa81f00832a824dfeaccb471224