### PR TITLE
Add restart and topology options to HPC job manager

### DIFF
--- a/examples/hpc/slurm_restart.sh
+++ b/examples/hpc/slurm_restart.sh
@@ -8,15 +8,19 @@
 #SBATCH -o %x_%j.out
 #SBATCH -e %x_%j.err
 
-# Stage checkpoint and configuration into scratch
+# Stage checkpoint and configuration into scratch. If ``DPF_RESTART`` is set
+# (for example via :class:`~dpf2.hpc.JobManager.restart`), use that path,
+# otherwise fall back to the previous run's output.
 tmp=${SLURM_TMPDIR:-$(mktemp -d)}
 cp $SLURM_SUBMIT_DIR/examples/config.json "$tmp/"
-cp $SLURM_SUBMIT_DIR/results/result.npz "$tmp/"
+checkpoint=${DPF_RESTART:-$SLURM_SUBMIT_DIR/results/result.npz}
+cp "$checkpoint" "$tmp/"
 cd "$tmp"
 
 # Restart the simulation from the checkpoint
-echo "Restarting from result.npz"
-srun python $SLURM_SUBMIT_DIR/examples/run_simulation.py --config config.json --restart result.npz --output restart_result.npz
+chk_file=$(basename "$checkpoint")
+echo "Restarting from $chk_file"
+srun python $SLURM_SUBMIT_DIR/examples/run_simulation.py --config config.json --restart "$chk_file" --output restart_result.npz
 
 # Collect output data back to the submission directory
 mkdir -p $SLURM_SUBMIT_DIR/results

--- a/examples/hpc/slurm_run.sh
+++ b/examples/hpc/slurm_run.sh
@@ -11,7 +11,8 @@ tmp=${SLURM_TMPDIR:-$(mktemp -d)}
 cp $SLURM_SUBMIT_DIR/examples/config.json "$tmp/"
 cd "$tmp"
 
-# Execute the simulation
+# Execute the simulation. GPU affinity can be controlled by setting
+# ``CUDA_VISIBLE_DEVICES`` prior to submission (e.g. via the JobManager).
 srun python $SLURM_SUBMIT_DIR/examples/run_simulation.py --config config.json --output result.npz
 
 # Collect output data back to the submission directory

--- a/src/dpf2/hpc/manager.py
+++ b/src/dpf2/hpc/manager.py
@@ -105,11 +105,18 @@ class JobManager:
         stage_out: Mapping[str, str] | None = kwargs.pop("stage_out", None)
         job_script = self._wrap_staging(job_script, stage_in, stage_out)
 
+        # Script level arguments and restart handling
+        script_args: list[str] = list(kwargs.pop("script_args", []))
+        restart = kwargs.pop("restart", None)
+        if restart is not None:
+            script_args.extend(["--restart", str(restart)])
+
         if self.scheduler == "slurm":
             gpus = kwargs.pop("gpus", None)
             gpu_type = kwargs.pop("gpu_type", None)
             deps = kwargs.pop("dependencies", None)
             dep_type = kwargs.pop("dependency_type", "afterok")
+            gpu_affinity = kwargs.pop("gpu_affinity", None)
 
             cmd = ["sbatch"]
             self._extend_cmd(
@@ -117,6 +124,8 @@ class JobManager:
                 kwargs,
                 {
                     "nodes": "-N",
+                    "nodelist": "--nodelist",
+                    "ntasks_per_node": "--ntasks-per-node",
                     "output": "-o",
                     "error": "-e",
                 },
@@ -133,7 +142,11 @@ class JobManager:
                     dep_str = str(deps)
                 cmd.extend(["--dependency", dep_str])
             cmd.append(job_script)
-            return subprocess.run(cmd, capture_output=True, text=True, check=False)
+            cmd.extend(script_args)
+            env = os.environ.copy()
+            if gpu_affinity is not None:
+                env["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_affinity)
+            return subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
         if self.scheduler == "awsbatch":
             try:
                 import boto3  # type: ignore
@@ -143,6 +156,7 @@ class JobManager:
             gpus = kwargs.pop("gpus", None)
             gpu_type = kwargs.pop("gpu_type", None)
             deps = kwargs.pop("dependencies", None)
+            gpu_affinity = kwargs.pop("gpu_affinity", None)
 
             params: Dict[str, Any] = {
                 "jobName": kwargs.get("job_name", "dpf2-job"),
@@ -157,6 +171,14 @@ class JobManager:
             if gpus is not None or gpu_type is not None:
                 rr = {"value": str(gpus if gpus is not None else 1), "type": "GPU"}
                 params.setdefault("containerOverrides", {})["resourceRequirements"] = [rr]
+            if restart is not None or gpu_affinity is not None:
+                env_list = params.setdefault("containerOverrides", {}).setdefault("environment", [])
+                if restart is not None:
+                    env_list.append({"name": "DPF_RESTART", "value": str(restart)})
+                if gpu_affinity is not None:
+                    env_list.append({"name": "CUDA_VISIBLE_DEVICES", "value": ",".join(str(g) for g in gpu_affinity)})
+            if script_args:
+                params.setdefault("containerOverrides", {})["command"] = [job_script] + script_args
             return batch.submit_job(**params)
         if self.scheduler == "mpi":
             gpus = kwargs.pop("gpus", None)
@@ -167,7 +189,14 @@ class JobManager:
 
             hosts = kwargs.pop("hosts", None)
             host_gpus = kwargs.pop("host_gpus", None)
+            node_topology = kwargs.pop("node_topology", None)
             decomp: Dict[str, Any] | None = kwargs.pop("decomp", None)
+            gpu_affinity = kwargs.pop("gpu_affinity", None)
+
+            if node_topology is not None:
+                if host_gpus is not None:
+                    raise ValueError("Specify either node_topology or host_gpus")
+                host_gpus = node_topology
 
             cmd = ["mpirun"]
             self._extend_cmd(
@@ -198,14 +227,14 @@ class JobManager:
                 hostfile = self._write_temp_file("\n".join(hosts) + "\n", suffix=".hosts")
                 cmd.extend(["--hostfile", hostfile])
 
-            script_cmd = [job_script]
+            script_cmd = [job_script] + script_args
             if decomp:
                 for axis, cnt in decomp.items():
                     script_cmd.extend([f"--decomp-{axis}", str(cnt)])
-            if "restart" in kwargs:
-                script_cmd.extend(["--restart", str(kwargs["restart"])])
 
-            if gpus is not None and host_gpus is None:
+            if gpu_affinity is not None:
+                env["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_affinity)
+            elif gpus is not None and host_gpus is None:
                 env["CUDA_VISIBLE_DEVICES"] = ",".join(str(i) for i in range(int(gpus)))
 
             cmd.extend(script_cmd)

--- a/tests/test_hpc_job_manager.py
+++ b/tests/test_hpc_job_manager.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from dpf2.hpc import JobManager
+
+
+def test_slurm_submit_options(tmp_path, monkeypatch):
+    script = tmp_path / "job.sh"
+    script.write_text("#!/bin/bash\n")
+    jm = JobManager("slurm")
+
+    called = {}
+
+    def fake_run(cmd, capture_output, text, check, env):
+        called["cmd"] = cmd
+        called["env"] = env
+        class R: pass
+        return R()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    jm.submit(
+        str(script),
+        nodes=2,
+        nodelist="node1,node2",
+        gpus=2,
+        gpu_affinity=[0, 1],
+        dependencies=[11, 22],
+        restart="chkpt.dat",
+        script_args=["--foo", "bar"],
+    )
+
+    cmd = called["cmd"]
+    env = called["env"]
+    assert cmd[0] == "sbatch"
+    assert "-N" in cmd and cmd[cmd.index("-N") + 1] == "2"
+    assert "--nodelist" in cmd and cmd[cmd.index("--nodelist") + 1] == "node1,node2"
+    assert "--gpus" in cmd and cmd[cmd.index("--gpus") + 1] == "2"
+    assert "--dependency" in cmd and cmd[cmd.index("--dependency") + 1] == "afterok:11:22"
+    idx = cmd.index(str(script))
+    assert cmd[idx + 1 : idx + 5] == ["--foo", "bar", "--restart", "chkpt.dat"]
+    assert env["CUDA_VISIBLE_DEVICES"] == "0,1"
+
+
+def test_mpi_node_topology_and_restart(tmp_path, monkeypatch):
+    script = tmp_path / "run.py"
+    script.write_text("#!/bin/bash\n")
+    jm = JobManager("mpi")
+
+    called = {}
+
+    def fake_run(cmd, capture_output, text, check, env):
+        called["cmd"] = cmd
+        called["env"] = env
+        class R: pass
+        return R()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    topo = {"hostA": [0, 1], "hostB": [0]}
+    jm.submit(str(script), node_topology=topo, restart="chk.dat", gpu_affinity=[0, 1])
+
+    cmd = called["cmd"]
+    env = called["env"]
+    assert cmd[0] == "mpirun"
+    assert "--hostfile" in cmd
+    hostfile = Path(cmd[cmd.index("--hostfile") + 1])
+    hosts = set(hostfile.read_text().strip().splitlines())
+    assert "hostA slots=2" in hosts and "hostB slots=1" in hosts
+
+    gpu_map = Path(env["DPF_GPU_MAP"]).read_text().strip().splitlines()
+    assert "0 hostA 0" in gpu_map
+    assert "1 hostA 1" in gpu_map
+    assert "2 hostB 0" in gpu_map
+
+    idx = cmd.index(str(script))
+    assert cmd[idx + 1 : idx + 3] == ["--restart", "chk.dat"]
+    assert env["CUDA_VISIBLE_DEVICES"] == "0,1"


### PR DESCRIPTION
## Summary
- support restart files, node topology, and GPU affinity in JobManager
- show data staging and restart handling in SLURM examples
- test JobManager option handling for Slurm and MPI

## Testing
- `pytest tests/test_hpc_job_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8ffab4078832abb24a4f715f667ad