### PR TITLE
Add engineer tutorials and student walkthrough

### DIFF
--- a/docs/student_intro.md
+++ b/docs/student_intro.md
@@ -31,3 +31,13 @@ browser or a Jupyter notebook.
 
 After exploring the sandbox, continue learning by running the
 [tutorials](tutorials/quickstart.md) or reading the [user guide](user_guide.md).
+
+## Classroom Walk-Through
+
+1. Complete the [Quickstart tutorial](tutorials/quickstart.md) to run your
+   first simulated shot.
+2. Try the [`run_simulation.py`](../examples/run_simulation.py) example to see
+   how configuration files drive a full run.
+3. Explore the [optimization](tutorials/optimization.md) and
+   [diagnostics](tutorials/diagnostics.md) tutorials for deeper engineering
+   insight.

--- a/docs/tutorials/diagnostics.md
+++ b/docs/tutorials/diagnostics.md
@@ -1,0 +1,43 @@
+# Diagnostics Tutorial
+
+Engineers can extract meaningful signals from simulations using these steps.
+
+## 1. Collect detailed diagnostics
+
+Run a simulation with extended logging enabled:
+
+```bash
+python -m dpf2.cli.main simulate -c config.json -o run --diagnostics --verbose
+```
+
+The `run` directory will contain JSON histories and waveform files for each shot.
+
+## 2. Examine current and voltage traces
+
+Plot electrical signals to verify circuit behavior:
+
+```bash
+python -m dpf2.cli.main plot-run --history run/history.json --output iv.png
+```
+
+Look for ringing or phase shifts that indicate wiring issues.
+
+## 3. Inspect density and temperature profiles
+
+Export profiles at peak compression:
+
+```bash
+python -m dpf2.cli.main diagnostics -i run -o analysis/ --profiles
+```
+
+Visualizing these profiles helps determine whether the pinch meets design goals.
+
+## 4. Generate a concise report
+
+Summarize metrics for review meetings:
+
+```bash
+python -m dpf2.cli.main report -i run -o report.pdf
+```
+
+The PDF combines plots, peak values, and configuration parameters for quick interpretation by the engineering team.

--- a/docs/tutorials/optimization.md
+++ b/docs/tutorials/optimization.md
@@ -1,0 +1,47 @@
+# Optimization Tutorial
+
+This guide walks engineers through tuning dense plasma focus (DPF) parameters to meet design goals.
+
+## 1. Establish objectives and bounds
+
+Define variables to tune and constraints in a configuration file:
+
+```yaml
+optimization:
+  target: peak_current
+  bounds:
+    anode_radius: [0.5e-2, 1.5e-2]
+    bank_voltage: [20e3, 40e3]
+```
+
+The solver treats bounds as hard limits during optimization.
+
+## 2. Launch a parameter sweep
+
+Evaluate a grid of configurations with the sweep utility:
+
+```bash
+python -m dpf2.cli.main sweep -c base.json -p sweep.yaml -o sweep_runs/
+```
+
+Each run is tagged with the varied parameters for later sorting.
+
+## 3. Analyze the Pareto front
+
+Collect metrics and plot trade-off surfaces:
+
+```bash
+python -m dpf2.cli.main analyze -i sweep_runs/ --pareto neutron_yield energy_input
+```
+
+The plot highlights configurations that maximize neutron yield for a given energy input.
+
+## 4. Export the best design
+
+Write the optimal settings to a new configuration:
+
+```bash
+python -m dpf2.cli.main best -i sweep_runs/ --metric neutron_yield -o optimal.json
+```
+
+Use this file directly in subsequent simulations or share it with collaborators.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,13 +2,19 @@ site_name: DPF2 Documentation
 nav:
   - Home: index.md
   - User Guide: user_guide.md
-  - Student Introduction: student_intro.md
+  - Student Introduction: student_intro.md  # persona: student
   - Tutorials:
-      - Quickstart: tutorials/quickstart.md
-      - Basic Experiment: tutorials/basic_experiment.md
-      - Advanced Workflow: tutorials/advanced_workflow.md
-      - Optimization & Diagnostics: tutorials/optimization_diagnostics.md
-  - Scientist Theory: scientist_theory.md
+      - Quickstart: tutorials/quickstart.md  # persona: student
+      - Basic Experiment: tutorials/basic_experiment.md  # persona: student
+      - Advanced Workflow: tutorials/advanced_workflow.md  # persona: engineer
+      - Optimization: tutorials/optimization.md  # persona: engineer
+      - Diagnostics: tutorials/diagnostics.md  # persona: engineer
+  - Scientist Theory: scientist_theory.md  # persona: scientist
+  - Examples:  # persona: engineer, scientist
+      - Run Simulation: ../examples/run_simulation.py
+      - PIC Collision: ../examples/pic_collision_example.py
+  - GUI Features:  # persona: student
+      - Sandbox Walk-Through: student_intro.md
   - API Reference: api_reference.md
   - Benchmarks: benchmarks.md
   - Reports:


### PR DESCRIPTION
## Summary
- Add standalone optimization and diagnostics tutorials for engineers
- Expand student walkthrough with classroom steps
- Cross-link examples and GUI features in MkDocs with persona tags

## Testing
- `pytest` (fails: FileNotFoundError and other errors during collection)

------
https://chatgpt.com/codex/tasks/task_e_68b8ffad8104832a8f8f0f2d15942294