### PR TITLE
Support 3‑D instability grids and Hall-MHD coupling

### DIFF
--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -283,7 +283,7 @@ class HallMHDSolver(PlasmaSolverBase):
     inductance: float = 0.0
     back_emf: float = 0.0
     circuit_feedback: CouplingState | None = field(init=False, default=None)
-    anomalous_resistivity: Callable[[np.ndarray], np.ndarray] | None = None
+    anomalous_resistivity: Callable[[np.ndarray], np.ndarray | tuple[np.ndarray, np.ndarray]] | None = None
     voltage_spikes: list[float] = field(default_factory=list)
     last_pressure: np.ndarray | None = field(init=False, default=None)
     last_ionization: np.ndarray | None = field(init=False, default=None)
@@ -291,6 +291,7 @@ class HallMHDSolver(PlasmaSolverBase):
     last_divB: np.ndarray | None = field(init=False, default=None)
     last_J: np.ndarray | None = field(init=False, default=None)
     last_E: np.ndarray | None = field(init=False, default=None)
+    last_E_anom: np.ndarray | None = field(init=False, default=None)
     last_opacity: np.ndarray | None = field(init=False, default=None)
     last_emissivity: np.ndarray | None = field(init=False, default=None)
     cart_comm: Any | None = field(init=False, default=None)
@@ -311,12 +312,24 @@ class HallMHDSolver(PlasmaSolverBase):
             self.bc(state)
 
     def compute_anomalous_resistivity(self, J: np.ndarray) -> np.ndarray:
-        """Evaluate anomalous resistivity model and record voltage spikes."""
+        """Evaluate anomalous resistivity model and record voltage spikes.
+
+        The ``anomalous_resistivity`` callback may return either just an
+        anomalous resistivity field or a tuple ``(eta, E)`` containing an
+        additional electric field contribution.  The resistivity component is
+        always returned while the electric field is stored on
+        ``last_E_anom`` for use by :meth:`step`.
+        """
 
         if self.anomalous_resistivity is None:
             eta = np.zeros(J.shape[:-1])
+            E = np.zeros_like(J)
         else:
-            eta = self.anomalous_resistivity(J)
+            result = self.anomalous_resistivity(J)
+            if isinstance(result, tuple):
+                eta, E = result
+            else:
+                eta, E = result, np.zeros_like(J)
         if hasattr(np, "abs"):
             mag = np.abs(J[..., 0]) + np.abs(J[..., 1]) + np.abs(J[..., 2])
         else:  # pragma: no cover - very small stub fallback
@@ -324,6 +337,7 @@ class HallMHDSolver(PlasmaSolverBase):
         spike = float(np.max(eta * mag))
         if spike != 0.0:
             self.voltage_spikes.append(spike)
+        self.last_E_anom = E
         return eta
 
     def amr_refinement(self, state: MHDState) -> None:
@@ -537,6 +551,8 @@ class HallMHDSolver(PlasmaSolverBase):
         eta_anom = self.compute_anomalous_resistivity(J)
         eta_total = eta_local + eta_anom
         E = -np.cross(v, B) + eta_total[..., None] * J
+        if self.last_E_anom is not None:
+            E += self.last_E_anom
         if self.hall_coeff != 0.0:
             ne = rho * np.maximum(zbar, 1e-30)
             E += self.hall_coeff * np.cross(J, B) / ne[..., None]

--- a/src/dpf2/physics/lower_hybrid_drift.py
+++ b/src/dpf2/physics/lower_hybrid_drift.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Any
 import math
+import numpy as np
 
 try:  # pragma: no cover - allow running without SciPy
     from scipy.constants import e, m_e, m_p
@@ -12,10 +13,17 @@ except Exception:  # pragma: no cover
     m_p = 1.67262192369e-27
 
 
-def _to_seq(val) -> list[float]:
-    if isinstance(val, Iterable) and not isinstance(val, (str, bytes)):
-        return [float(v) for v in val]
-    return [float(val)]
+def _to_array(val: Any) -> np.ndarray:
+    """Return ``val`` as a floating point array.
+
+    Mirrors :func:`_to_array` from ``m0_instability`` and tolerates the light
+    weight ``numpy`` substitute used in the tests.
+    """
+
+    try:  # pragma: no cover - real NumPy path
+        return np.asarray(val, dtype=float)
+    except TypeError:  # pragma: no cover - ``numpy_stub`` path
+        return np.asarray(val)
 
 
 @dataclass
@@ -31,17 +39,17 @@ class LowerHybridDrift:
         omega_ce = e * self.B / m_e
         return abs(omega_ci * omega_ce) ** 0.5
 
-    def growth_rate(self, k):
-        ks = _to_seq(k)
+    def growth_rate(self, k: Any) -> np.ndarray:
+        ks = _to_array(k)
         omega_lh = self.frequency()
-        rates = [0.1 * omega_lh * math.exp(-(kk * kk)) for kk in ks]
-        return rates if len(rates) > 1 else rates[0]
+        rates = 0.1 * omega_lh * np.exp(-(ks * ks))
+        return rates
 
-    def evolve(self, amplitude, k, dt: float):
-        amps = _to_seq(amplitude)
-        rates = _to_seq(self.growth_rate(k))
-        evolved = [a * math.exp(max(min(r * dt, 50.0), -50.0)) for a, r in zip(amps, rates)]
-        return evolved if len(evolved) > 1 else evolved[0]
+    def evolve(self, amplitude: Any, k: Any, dt: float):
+        amp = _to_array(amplitude)
+        rate = _to_array(self.growth_rate(k))
+        evolved = amp * np.exp(np.clip(rate * dt, -50.0, 50.0))
+        return evolved
 
 
 __all__ = ["LowerHybridDrift"]

--- a/src/dpf2/physics/m0_instability.py
+++ b/src/dpf2/physics/m0_instability.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Iterable
+from typing import Any
 import math
+import numpy as np
 
 try:  # pragma: no cover - allow running without SciPy
     from scipy.constants import mu_0, pi
@@ -16,10 +17,19 @@ except Exception:  # pragma: no cover
     MPI = None
 
 
-def _to_seq(val: Any) -> list[float]:
-    if isinstance(val, Iterable) and not isinstance(val, (str, bytes)):
-        return [float(v) for v in val]
-    return [float(val)]
+def _to_array(val: Any) -> np.ndarray:
+    """Return ``val`` as a floating point array.
+
+    ``numpy_stub`` used in the tests provides :func:`asarray` without support
+    for the ``dtype`` keyword.  The helper therefore attempts a typed
+    conversion but gracefully falls back when running with the stub
+    implementation.
+    """
+
+    try:  # pragma: no cover - exercised when real NumPy is present
+        return np.asarray(val, dtype=float)
+    except TypeError:  # pragma: no cover - ``numpy_stub`` path
+        return np.asarray(val)
 
 
 @dataclass
@@ -31,21 +41,21 @@ class MZeroInstability:
     density: Any  # Mass density [kg/m^3]
     comm: Any | None = None  # MPI communicator
 
-    def growth_rate(self):
-        curr = _to_seq(self.current)
-        rad = _to_seq(self.radius)
-        dens = _to_seq(self.density)
-        rates = [abs(mu_0 * c / (2 * pi * r)) / math.sqrt(mu_0 * d) for c, r, d in zip(curr, rad, dens)]
+    def growth_rate(self) -> np.ndarray:
+        curr = _to_array(self.current)
+        rad = _to_array(self.radius)
+        dens = _to_array(self.density)
+        rate = np.abs(mu_0 * curr / (2 * pi * rad)) / np.sqrt(mu_0 * dens)
         if self.comm is not None and MPI is not None:
-            gathered = self.comm.allgather(rates)
-            rates = [r for g in gathered for r in g]
-        return rates if len(rates) > 1 else rates[0]
+            gathered = self.comm.allgather(rate)
+            rate = np.concatenate([np.asarray(g, dtype=float) for g in gathered], axis=0)
+        return rate
 
-    def evolve(self, amplitude, dt: float):
-        amps = _to_seq(amplitude)
-        rates = _to_seq(self.growth_rate())
-        evolved = [a * math.exp(max(min(r * dt, 50.0), -50.0)) for a, r in zip(amps, rates)]
-        return evolved if len(evolved) > 1 else evolved[0]
+    def evolve(self, amplitude: Any, dt: float):
+        amp = _to_array(amplitude)
+        rate = _to_array(self.growth_rate())
+        evolved = amp * np.exp(np.clip(rate * dt, -50.0, 50.0))
+        return evolved
 
 
 __all__ = ["MZeroInstability"]

--- a/tests/physics/test_instabilities.py
+++ b/tests/physics/test_instabilities.py
@@ -1,48 +1,75 @@
-import csv
 import numpy as np
-import math
+import pytest
+
+from dpf2.physics import LowerHybridDrift, MZeroInstability
+from dpf2.hall_mhd_solver import HallMHDSolver, MHDState
 
 mu_0 = 4e-7 * np.pi
 pi = np.pi
 
-from dpf2.physics import HallMHD, LowerHybridDrift, MZeroInstability
-
 
 def _load_pf1000(field: str):
+    values = []
     with open(f"data/benchmarks/PF1000/{field}.csv") as f:
-        next(f)  # skip header
-        return np.array([float(line.split(",")[1]) for line in f])
+        next(f)
+        for line in f:
+            values.append(float(line.split(",")[1]))
+    return np.array(values)
+
+
+def _state_with_gradient(shape):
+    rho = np.ones(shape)
+    mom = np.zeros(shape + (3,))
+    B = np.zeros(shape + (3,))
+    x = np.linspace(0.0, 1.0, shape[0])
+    for i, val in enumerate(x):
+        for j in range(shape[1]):
+            for k in range(shape[2]):
+                B[i, j, k, 2] = val
+    energy = np.ones(shape)
+    return MHDState(rho=rho, mom=mom, energy=energy, B=B)
 
 
 def test_lower_hybrid_grid_evolution():
     model = LowerHybridDrift(B=1.0, n_i=1e19)
-    k = np.linspace(0.0, 1.0, 5)
+    k = np.zeros((2, 2, 2)) + 0.1
     amp0 = np.zeros_like(k) + 1e-3
     evolved = model.evolve(amp0, k, dt=1.0)
     rates = model.growth_rate(k)
-    expected = [a * math.exp(max(min(r, 50.0), -50.0)) for a, r in zip(amp0, rates)]
+    expected = amp0 * np.exp(np.clip(rates, -50.0, 50.0))
     assert np.allclose(evolved, expected)
 
 
 def test_m0_instability_pf1000_evolution():
-    current = _load_pf1000('current')
-    radius = _load_pf1000('radius') / 100.0  # cm -> m
-    density = np.zeros_like(current) + 1e-3
+    current_1d = _load_pf1000('current')
+    radius_1d = _load_pf1000('radius') / 100.0
+    n = len(current_1d)
+    current = np.zeros((n, 1, 1))
+    radius = np.zeros((n, 1, 1))
+    for i in range(n):
+        current[i, 0, 0] = current_1d[i]
+        radius[i, 0, 0] = radius_1d[i]
+    density = np.zeros((n, 1, 1)) + 1e-3
     instab = MZeroInstability(current=current, radius=radius, density=density)
-    amp0 = np.zeros_like(current) + 1e-3
+    amp0 = np.zeros((n, 1, 1)) + 1e-3
     evolved = instab.evolve(amp0, dt=1.0)
-    rates = np.array([
-        abs(mu_0 * c / (2 * pi * r)) / math.sqrt(mu_0 * d)
-        for c, r, d in zip(current, radius, density)
-    ])
-    expected = amp0 * np.exp(rates)
+    rates = np.abs(mu_0 * current / (2 * pi * radius)) / np.sqrt(mu_0 * density)
+    expected = amp0 * np.exp(np.clip(rates, -50.0, 50.0))
     assert np.allclose(evolved, expected)
 
 
+@pytest.mark.skipif(not hasattr(np, "roll"), reason="requires full NumPy")
 def test_hall_mhd_instability_coupling():
+    shape = (4, 4, 4)
+    state = _state_with_gradient(shape)
     instab = MZeroInstability(current=1e5, radius=0.01, density=1e-3)
-    amp = instab.evolve(1e-3, dt=1.0)
-    model = HallMHD()
-    model.step(np.zeros(9), dt=1.0, current=0.0, instability_amp=amp)
-    assert model.back_emf == amp
-    assert model.beam_velocity > 0.0
+    amp_field = instab.evolve(np.full(shape, 1e-3), dt=1.0)
+
+    def model(J):
+        return amp_field, np.zeros_like(J)
+
+    solver = HallMHDSolver(anomalous_resistivity=model)
+    solver.step(state, dt=0.1)
+    J = solver.last_J
+    expected = amp_field[..., None] * J
+    assert np.allclose(solver.last_E, expected)


### PR DESCRIPTION
## Summary
- extend lower-hybrid drift and m=0 instability models to operate on arbitrary 3‑D grids
- allow HallMHD solver to accept anomalous resistivity and electric field contributions from instability models
- add PF‑1000 benchmark regression tests for grid-based instabilities

## Testing
- `pytest tests/physics/test_instabilities.py tests/physics/test_anomalous_resistivity.py`
- `pytest tests/test_hall_mhd_solver.py` *(fails: 'types.SimpleNamespace' object has no attribute 'roll')*


------
https://chatgpt.com/codex/tasks/task_e_68b8ffa07c1c832a912da3084f99ae5d