### PR TITLE
Add GV front model and rundown trend plotting

### DIFF
--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -31,6 +31,7 @@ from dpf2.optimization.param_sweep import (
     compute_sweep_metrics,
     plot_metric_overlay,
 )
+from dpf2.physics.axial_rundown import shock_parameter, plot_shock_parameter
 from .errors import format_error
 
 
@@ -445,6 +446,16 @@ def simulate(
         if progress_cb is not None:
             run_kwargs["progress_cb"] = progress_cb
         times, currents, voltages = sim.run(**run_kwargs)
+
+        # Compute and plot axial rundown similarity parameter S
+        try:
+            S = shock_parameter(currents, cfg.anode_radius, cfg.initial_pressure)
+            shock_path = plot_shock_parameter(times, S, Path(output) / "shock_trend.png")
+            if verbose:
+                click.echo(f"Shock parameter plot written to {shock_path}")
+        except Exception:
+            if verbose:
+                click.echo("Shock parameter plot failed")
 
         if pbar is not None:
             pbar.close()

--- a/src/dpf2/physics/__init__.py
+++ b/src/dpf2/physics/__init__.py
@@ -1,6 +1,7 @@
 from .mhd import ResistiveMHD
 from .energy import EnergyTracker
 from .pic import SimplePIC, HybridPIC
+from .gv_front import GVFront
 from .eos import TabulatedEOS, load_tabulated_eos, load_standard_eos
 from .radiation import RadiationTransport
 from .pic_driver import PicDriver, SimplePicDriver, WarpXPICDriver
@@ -40,6 +41,7 @@ __all__ = [
     "RadiationTransport",
     "LowerHybridDrift",
     "MZeroInstability",
+    "GVFront",
 ]
 
 

--- a/src/dpf2/physics/axial_rundown.py
+++ b/src/dpf2/physics/axial_rundown.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Utilities for analyzing axial rundown behavior.
+
+This module provides helpers to compute the dimensionless shock
+parameter ``S`` defined by::
+
+    S = I / (a * p0)
+
+where ``I`` is the discharge current, ``a`` is the anode radius and
+``p0`` is the fill gas pressure.  ``S`` is a useful metric for
+characterizing rundown similarity across devices.  A simple plotting
+utility is also provided for quick‑look diagnostics.
+"""
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+try:  # pragma: no cover - plotting is optional
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - used when matplotlib is absent
+    plt = None  # type: ignore
+
+
+def shock_parameter(current: Iterable[float], anode_radius: float, p0: float) -> np.ndarray:
+    """Return the dimensionless shock parameter ``S``.
+
+    Parameters
+    ----------
+    current:
+        Iterable of discharge current values in amperes.
+    anode_radius:
+        Anode radius ``a`` in metres.
+    p0:
+        Fill gas pressure ``p0`` in pascals.
+    """
+
+    I = np.array(list(current))
+    if anode_radius <= 0 or p0 <= 0:
+        raise ValueError("anode_radius and p0 must be positive")
+    return I / (anode_radius * p0)
+
+
+def plot_shock_parameter(time: Iterable[float], S: Iterable[float], path: Path) -> Path:
+    """Plot ``S`` versus ``time`` and write to ``path``.
+
+    Parameters
+    ----------
+    time:
+        Iterable of time samples in seconds.
+    S:
+        Iterable of ``S`` values as returned by :func:`shock_parameter`.
+    path:
+        Output image file.  Directories are created as needed.
+    """
+
+    if plt is None:
+        raise RuntimeError("matplotlib is required for plotting")
+
+    t = np.array(list(time))
+    s = np.array(list(S))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    plt.figure()
+    plt.plot(t, s)
+    plt.xlabel("Time (s)")
+    plt.ylabel("S = I/(a*p0)")
+    plt.tight_layout()
+    plt.savefig(path)
+    plt.close()
+    return path
+
+
+__all__ = ["shock_parameter", "plot_shock_parameter"]

--- a/src/dpf2/physics/gv_front.py
+++ b/src/dpf2/physics/gv_front.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Simplified Gratton--Vargas sheath front model.
+
+The Gratton--Vargas (GV) snowplow model provides an analytic description of
+how a plasma current sheath propagates in the radial--axial plane of a coaxial
+accelerator.  For lightweight benchmarking and educational purposes we model
+the sheath as a semicircular arc of radius equal to the anode radius ``a`` that
+moves axially with constant velocity ``v``.  While greatly simplified compared
+with the full GV solution, this captures the expected parabolic ``r(z)`` shape
+and provides closed‑form arrival times.
+"""
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+
+
+@dataclass
+class GVFront:
+    """Model the r--z current sheath front.
+
+    Parameters
+    ----------
+    anode_radius:
+        Anode radius ``a`` in metres.
+    velocity:
+        Axial propagation speed ``v`` of the sheath in metres per second.
+    """
+
+    anode_radius: float
+    velocity: float
+
+    def radius(self, z: float | Iterable[float]):
+        """Return radial position of the sheath front at axial coordinate ``z``.
+
+        The simplified model assumes the front traces a semicircle of radius
+        ``a``.  Values of ``z`` outside ``[0, a]`` are clipped to the physical
+        domain.
+        """
+
+        if isinstance(z, Iterable) and not isinstance(z, (float, int)):
+            vals = []
+            for val in z:
+                v = max(0.0, min(float(val), self.anode_radius))
+                diff = self.anode_radius**2 - v**2
+                vals.append(diff**0.5 if diff > 0 else 0.0)
+            return np.array(vals)
+        else:
+            z_val = max(0.0, min(float(z), self.anode_radius))
+            diff = self.anode_radius**2 - z_val**2
+            return diff**0.5 if diff > 0 else 0.0
+
+    def arrival_time(self, z: float | Iterable[float]):
+        """Return the time for the sheath to reach axial position ``z``."""
+
+        if self.velocity <= 0:
+            raise ValueError("velocity must be positive")
+        if isinstance(z, Iterable) and not isinstance(z, (float, int)):
+            return np.array([float(val) / self.velocity for val in z])
+        else:
+            return float(z) / self.velocity
+
+
+__all__ = ["GVFront"]

--- a/src/dpf2/web/app.py
+++ b/src/dpf2/web/app.py
@@ -19,6 +19,7 @@ from ..optimization.param_sweep import (
     compute_sweep_metrics,
     plot_metric_overlay,
 )
+from ..physics.axial_rundown import shock_parameter, plot_shock_parameter
 
 # HTML templates rendered with simple ``render_template_string`` calls.  The
 # templates expose a subset of configuration parameters and allow users to run
@@ -55,6 +56,7 @@ DIAG_HTML = """
 <h1>Diagnostics</h1>
 {% if plot %}<img src="{{ plot }}" alt="sweep plot"><br>{% endif %}
 {% if metrics_plot %}<img src="{{ metrics_plot }}" alt="metrics plot"><br>{% endif %}
+{% if shock_plot %}<img src="{{ shock_plot }}" alt="shock parameter"><br>{% endif %}
 <ul>
 {% for f in files %}<li>{{ f }}</li>{% endfor %}
 </ul>
@@ -127,7 +129,12 @@ def create_app() -> Flask:
                         plot_metric_overlay(param, metrics, Path(output) / "sweep_metrics.png")
                 else:
                     sim = DPFSimulation(cfg)
-                    sim.run(output_dir=output)
+                    t, i, _v = sim.run(output_dir=output)
+                    try:
+                        S = shock_parameter(i, cfg.anode_radius, cfg.initial_pressure)
+                        plot_shock_parameter(t, S, Path(output) / "shock_trend.png")
+                    except Exception:
+                        pass
                 return redirect(url_for("diagnostics", output=output))
             except (ConfigurationError, SimulationRuntimeError, Exception) as exc:  # pragma: no cover - UI path
                 return render_template_string(INDEX_HTML + f"<p>Error: {exc}</p>", cfg=cfg, presets=presets.keys(), output=output)
@@ -149,7 +156,17 @@ def create_app() -> Flask:
         metrics_path = Path(output) / "sweep_metrics.png"
         if metrics_path.exists():
             metrics_plot = "data:image/png;base64," + base64.b64encode(metrics_path.read_bytes()).decode("ascii")
-        return render_template_string(DIAG_HTML, files=files, plot=plot, metrics_plot=metrics_plot)
+        shock_plot = None
+        shock_path = Path(output) / "shock_trend.png"
+        if shock_path.exists():
+            shock_plot = "data:image/png;base64," + base64.b64encode(shock_path.read_bytes()).decode("ascii")
+        return render_template_string(
+            DIAG_HTML,
+            files=files,
+            plot=plot,
+            metrics_plot=metrics_plot,
+            shock_plot=shock_plot,
+        )
 
     @app.route("/projects", methods=["GET", "POST"])
     def projects_ep():

--- a/tests/physics/test_gv_front.py
+++ b/tests/physics/test_gv_front.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pytest
+
+from dpf2.physics.gv_front import GVFront
+
+
+def test_gv_front_shape():
+    gv = GVFront(anode_radius=0.05, velocity=2e4)
+    z = np.linspace(0, gv.anode_radius, 5)
+    r = gv.radius(z)
+    expected = np.array([gv.anode_radius ** 2] * len(z))
+    assert np.allclose(r ** 2 + z ** 2, expected)
+
+
+def test_gv_front_arrival_time():
+    gv = GVFront(anode_radius=0.05, velocity=1e5)
+    z = 0.02
+    assert gv.arrival_time(z) == pytest.approx(z / gv.velocity)


### PR DESCRIPTION
## Summary
- implement simplified Gratton–Vargas sheath front model
- add axial rundown utilities computing S = I/(a*p0) with plotting helpers
- show S trend plots from CLI and Flask GUI

## Testing
- `pytest tests/physics/test_gv_front.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b904482310832ab5cb603fd6ec48fe