### PR TITLE
Add ion beam EDF interface and neutron ToF diagnostic

### DIFF
--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, root_validator
 
 # Local diagnostic computation utilities
 from .neutron_yield import (
+    IonBeamEDF,
     compute_neutron_yield,
     compute_beam_target_yield,
     compute_thermonuclear_yield,
@@ -55,6 +56,7 @@ def apply_detector_response(
     return [float(response_fn(v)) for v in signal]
 
 __all__ = [
+    "IonBeamEDF",
     "compute_neutron_yield",
     "compute_beam_target_yield",
     "compute_thermonuclear_yield",

--- a/src/dpf2/diagnostics/neutron_yield.py
+++ b/src/dpf2/diagnostics/neutron_yield.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, Sequence
+from bisect import bisect_right
+from typing import Callable, Protocol, Sequence, Tuple
 
 import h5py_stub as h5py  # type: ignore
+import math
 
 
 def compute_neutron_yield(reaction_rate: Sequence[float], dt: float) -> float:
@@ -30,21 +32,77 @@ def compute_neutron_yield(reaction_rate: Sequence[float], dt: float) -> float:
     return total * dt
 
 
+class IonBeamEDF(Protocol):
+    """Interface providing ion energy distributions by angle."""
+
+    def energy_distribution(self, angle_deg: float) -> Tuple[Sequence[float], Sequence[float]]:
+        """Return energies and differential flux for a detector angle."""
+
+
 def compute_beam_target_yield(
-    ion_distribution: Sequence[float],
-    target_density: Sequence[float],
-    cross_section: Sequence[float],
-    dt: float,
-) -> float:
-    """Compute beam-target neutron yield from diagnostic inputs."""
-    if dt <= 0:
-        raise ValueError("dt must be positive")
-    if not (
-        len(ion_distribution) == len(target_density) == len(cross_section)
-    ):
-        raise ValueError("all inputs must have the same length")
-    rate = [i * n * s for i, n, s in zip(ion_distribution, target_density, cross_section)]
-    return compute_neutron_yield(rate, dt)
+    ion_edf: IonBeamEDF,
+    cross_section: Callable[[float], float],
+    angles: Sequence[float],
+    distance: float,
+    time_bins: Sequence[float],
+    m_n: float = 1.674e-27,
+) -> tuple[list[float], list[list[float]]]:
+    """Integrate EDF×σ(E) and compute TOF histograms for each angle.
+
+    Parameters
+    ----------
+    ion_edf:
+        Provider of ion energy distributions.
+    cross_section:
+        Callable returning the reaction cross section for an energy value.
+    angles:
+        Detector angles in degrees for which to compute ``dN/dΩ``.
+    distance:
+        Distance from source to detector in meters for time-of-flight.
+    time_bins:
+        Monotonic sequence of time bin edges in seconds.
+    m_n:
+        Neutron mass used for flight time calculation in kg.
+
+    Returns
+    -------
+    tuple of (yields, tofs)
+        ``yields`` contains ``dN/dΩ`` for each requested angle and ``tofs``
+        contains corresponding time-of-flight histograms.
+    """
+
+    if any(time_bins[i] >= time_bins[i + 1] for i in range(len(time_bins) - 1)):
+        raise ValueError("time_bins must be monotonically increasing")
+
+    yields: list[float] = []
+    tofs: list[list[float]] = []
+    for ang in angles:
+        energies, dist = ion_edf.energy_distribution(float(ang))
+        e = [float(v) for v in energies]
+        f = [float(v) for v in dist]
+        if len(e) != len(f):
+            raise ValueError("energies and distribution must have the same length")
+        if len(e) < 2:
+            yields.append(0.0)
+            tofs.append([0.0 for _ in range(len(time_bins) - 1)])
+            continue
+        integ = 0.0
+        hist = [0.0 for _ in range(len(time_bins) - 1)]
+        for i in range(len(e) - 1):
+            e1, e2 = e[i], e[i + 1]
+            f1, f2 = f[i], f[i + 1]
+            s1, s2 = cross_section(e1), cross_section(e2)
+            dE = e2 - e1
+            contrib = 0.5 * (f1 * s1 + f2 * s2) * dE
+            integ += contrib
+            e_mid = (e1 + e2) / 2.0
+            t = distance / math.sqrt(2.0 * e_mid / m_n)
+            idx = bisect_right(time_bins, t) - 1
+            if 0 <= idx < len(hist):
+                hist[idx] += contrib
+        yields.append(integ)
+        tofs.append(hist)
+    return yields, tofs
 
 
 def compute_thermonuclear_yield(
@@ -126,6 +184,7 @@ def save_anisotropic_spectrum_hdf5(
 
 
 __all__ = [
+    "IonBeamEDF",
     "compute_neutron_yield",
     "compute_beam_target_yield",
     "compute_thermonuclear_yield",

--- a/tests/diagnostics/test_neutron_tof.py
+++ b/tests/diagnostics/test_neutron_tof.py
@@ -1,0 +1,32 @@
+import math
+
+from dpf2.diagnostics.neutron_yield import IonBeamEDF, compute_beam_target_yield
+
+
+class _Beam(IonBeamEDF):
+    def __init__(self, data):
+        self.data = data
+
+    def energy_distribution(self, angle_deg: float):
+        return self.data[angle_deg]
+
+
+def test_forward_anisotropy_and_tof():
+    E1 = 1e-13
+    E2 = 1.5e-13
+    beam = _Beam({
+        0.0: ([E1, E2], [2.0, 0.0]),
+        90.0: ([E1, E2], [1.0, 0.0]),
+    })
+    cross_section = lambda e: 1.0
+    distance = 1.0
+    E_mid = (E1 + E2) / 2.0
+    m_n = 1.674e-27
+    t_exp = distance / math.sqrt(2.0 * E_mid / m_n)
+    time_bins = [0.0, t_exp * 0.9, t_exp * 1.1]
+    angles = [0.0, 90.0]
+    yields, tofs = compute_beam_target_yield(beam, cross_section, angles, distance, time_bins)
+    assert yields[0] > yields[1]
+    assert tofs[0][0] == 0.0
+    assert tofs[0][1] > 0.0
+    assert tofs[1][1] == tofs[0][1] / 2.0

--- a/tests/test_neutron_yield_diagnostics.py
+++ b/tests/test_neutron_yield_diagnostics.py
@@ -2,23 +2,31 @@ import numpy as np
 import h5py_stub as h5py
 
 from dpf2.diagnostics.neutron_yield import (
+    IonBeamEDF,
     compute_beam_target_yield,
     compute_thermonuclear_yield,
     save_anisotropic_spectrum_hdf5,
 )
 
 
+class _TestBeam(IonBeamEDF):
+    def energy_distribution(self, angle_deg: float):
+        return [1.0, 2.0], [1.0, 1.0]
+
+
 def test_compute_beam_and_thermonuclear_yields():
-    ion_dist = [1.0, 2.0]
-    target_density = [1e19, 1e19]
-    cross_section = [1e-24, 2e-24]
-    dt = 1e-6
-    bt = compute_beam_target_yield(ion_dist, target_density, cross_section, dt)
-    expected_bt = sum(i * n * s for i, n, s in zip(ion_dist, target_density, cross_section)) * dt
-    assert bt == expected_bt
+    beam = _TestBeam()
+    cross_section = lambda e: e
+    angles = [0.0]
+    distance = 1.0
+    time_bins = [0.0, 1.0]
+    yield_vals, _ = compute_beam_target_yield(beam, cross_section, angles, distance, time_bins)
+    expected_bt = 0.5 * ((1.0 * 1.0) + (1.0 * 2.0)) * (2.0 - 1.0)
+    assert yield_vals[0] == expected_bt
 
     reactivity = [1e-20, 2e-20]
     ion_density = [1e19, 1e19]
+    dt = 1e-6
     th = compute_thermonuclear_yield(reactivity, ion_density, dt)
     expected_th = sum(r * n ** 2 for r, n in zip(reactivity, ion_density)) * dt
     assert th == expected_th
@@ -33,4 +41,5 @@ def test_save_anisotropic_spectrum_hdf5(tmp_path):
     with h5py.File(path, "r") as fh:
         np.testing.assert_allclose(fh["energy_MeV"][:], energies)
         np.testing.assert_allclose(fh["angle_deg"][:], angles)
-        np.testing.assert_allclose(fh["spectrum"][:], spectrum)
+        for i, row in enumerate(spectrum):
+            np.testing.assert_allclose(fh[f"detectors/detector_{i}"][:], row)


### PR DESCRIPTION
## Summary
- introduce `IonBeamEDF` protocol for angle-resolved ion energy distributions
- integrate EDF×σ(E) in `compute_beam_target_yield` and produce `dN/dΩ` with time-of-flight histograms
- export new interface through diagnostics package and update HDF5 spectrum tests

## Testing
- `pytest tests/test_neutron_yield_diagnostics.py tests/diagnostics/test_neutron_tof.py tests/diagnostics/test_noise_and_hdf5.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9044afa84832a83d69e093f9365ad