### PR TITLE
Add Bennett radius and plasma metrics diagnostics

### DIFF
--- a/src/dpf2/axial_sheath.py
+++ b/src/dpf2/axial_sheath.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 from typing import Iterable
 
 import numpy as np
+import warnings
+
+from .diagnostics import magnetic_reynolds_number
 
 mu0 = 4e-7 * np.pi
 
@@ -15,6 +18,7 @@ class SheathResult:
     velocity: np.ndarray
     jxb_force: np.ndarray
     end_index: int
+    magnetic_reynolds: np.ndarray | None = None
 
 
 class AxialSheathModel:
@@ -41,6 +45,7 @@ class AxialSheathModel:
         v = self.initial_velocity
         end_idx = len(t) - 1
 
+        rms: list[float] = []
         for k in range(start_index, len(t) - 1):
             dt = t[k + 1] - t[k]
             F = jxb[k] * self.area
@@ -49,6 +54,13 @@ class AxialSheathModel:
             p += v * dt
             pos.append(p)
             vel.append(v)
+            rm = magnetic_reynolds_number(abs(v), self.length, 1e5)
+            rms.append(rm)
+            if rm < 0.1:
+                warnings.warn(
+                    "Magnetic Reynolds number much less than one during rundown",
+                    RuntimeWarning,
+                )
             if p >= self.length:
                 end_idx = k + 1
                 break
@@ -56,4 +68,11 @@ class AxialSheathModel:
             end_idx = len(t) - 1
 
         times = t[start_index:end_idx + 1]
-        return SheathResult(time=times, position=np.array(pos), velocity=np.array(vel), jxb_force=jxb[start_index:end_idx + 1], end_index=end_idx)
+        return SheathResult(
+            time=times,
+            position=np.array(pos),
+            velocity=np.array(vel),
+            jxb_force=jxb[start_index:end_idx + 1],
+            end_index=end_idx,
+            magnetic_reynolds=np.array(rms),
+        )

--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -28,6 +28,11 @@ from .streaming import NeutronYieldStreamer, XRayEmissionStreamer, RealTimeCompa
 from .interferometry import interferometer_phase_shift
 from .pinhole_imaging import pinhole_image
 from .plasma import (
+    bennett_radius,
+    plasma_beta,
+    alfven_mach_number,
+    magnetic_reynolds_number,
+    lundquist_number,
     save_density_temperature_map_hdf5,
     compute_eedf,
     save_eedf_hdf5,
@@ -74,6 +79,11 @@ __all__ = [
     "apply_detector_response",
     "interferometer_phase_shift",
     "pinhole_image",
+    "bennett_radius",
+    "plasma_beta",
+    "alfven_mach_number",
+    "magnetic_reynolds_number",
+    "lundquist_number",
     "save_density_temperature_map_hdf5",
     "compute_eedf",
     "save_eedf_hdf5",

--- a/src/dpf2/diagnostics/plasma.py
+++ b/src/dpf2/diagnostics/plasma.py
@@ -1,9 +1,70 @@
 from __future__ import annotations
 
+from math import pi, sqrt
 from pathlib import Path
 from typing import Callable, Sequence
 
 import h5py_stub as h5py  # type: ignore
+
+try:  # pragma: no cover - SciPy optional
+    from scipy.constants import mu_0, k as k_B, m_p
+except Exception:  # pragma: no cover - fallback values
+    mu_0 = 4e-7 * pi
+    k_B = 1.380649e-23
+    m_p = 1.67262192369e-27
+
+
+def bennett_radius(I: float, n: float, T: float) -> float:
+    """Return the Bennett pinch radius.
+
+    Parameters
+    ----------
+    I:
+        Pinch current in amperes.
+    n:
+        Number density in m^-3.
+    T:
+        Plasma temperature in kelvin.
+    """
+
+    if n <= 0 or T <= 0:
+        raise ValueError("n and T must be positive")
+    return sqrt(2 * k_B * T / (mu_0 * n)) / abs(I)
+
+
+def plasma_beta(n: float, T: float, B: float) -> float:
+    """Compute plasma beta for a cell."""
+
+    if B == 0:
+        raise ValueError("B must be non-zero")
+    pressure = n * k_B * T
+    return 2 * mu_0 * pressure / (B * B)
+
+
+def alfven_mach_number(v: float, B: float, n: float) -> float:
+    """Return the Alfven Mach number for a cell."""
+
+    rho = n * m_p
+    v_a = B / sqrt(mu_0 * rho)
+    if v_a == 0:
+        raise ValueError("v_A is zero")
+    return v / v_a
+
+
+def magnetic_reynolds_number(v: float, L: float, sigma: float) -> float:
+    """Compute the magnetic Reynolds number."""
+
+    if sigma <= 0:
+        raise ValueError("sigma must be positive")
+    return mu_0 * sigma * v * L
+
+
+def lundquist_number(B: float, n: float, L: float, sigma: float) -> float:
+    """Compute the Lundquist number."""
+
+    rho = n * m_p
+    v_a = B / sqrt(mu_0 * rho)
+    return mu_0 * sigma * v_a * L
 
 
 def save_density_temperature_map_hdf5(
@@ -134,6 +195,11 @@ def save_eedf_hdf5(
 
 
 __all__ = [
+    "bennett_radius",
+    "plasma_beta",
+    "alfven_mach_number",
+    "magnetic_reynolds_number",
+    "lundquist_number",
     "save_density_temperature_map_hdf5",
     "compute_eedf",
     "save_eedf_hdf5",

--- a/src/dpf2/pinch_models.py
+++ b/src/dpf2/pinch_models.py
@@ -22,6 +22,12 @@ from .eos import RealGasEOS
 from .fusion import bosch_hale_dd
 from .hall_mhd_solver import HallMHDSolver, MHDState
 from .physics import PicDriver
+from .diagnostics import (
+    plasma_beta,
+    alfven_mach_number,
+    magnetic_reynolds_number,
+    lundquist_number,
+)
 
 __all__ = [
     "PinchModelBase",
@@ -42,6 +48,10 @@ class PinchResult:
     neutron_yield: float
     axial_position: np.ndarray | None = None
     energy: np.ndarray | None = None
+    beta: np.ndarray | None = None
+    alfven_mach: np.ndarray | None = None
+    magnetic_reynolds: np.ndarray | None = None
+    lundquist: np.ndarray | None = None
 
 
 class PinchModelBase:
@@ -66,7 +76,25 @@ class AnalyticPinchModel(PinchModelBase):
         temperature = 1e3 * (I / 1e4) ** 2
         yield_integrand = (temperature / 1e3) ** 3 * I ** 2
         neutron_yield = float(np.trapz(yield_integrand, t) * 1e-20)
-        return PinchResult(t, radius, temperature, pressure, neutron_yield)
+        B = 4e-7 * np.pi * I / (2 * np.pi * radius)
+        n = pressure / np.maximum(temperature, 1e-12) / 1.380649e-23
+        beta = np.array([plasma_beta(ni, Ti, Bi) for ni, Ti, Bi in zip(n, temperature, B)])
+        vr = np.gradient(radius, t, edge_order=2)
+        alfven = np.array([alfven_mach_number(v, Bi, ni) for v, Bi, ni in zip(vr, B, n)])
+        sigma = 1e5
+        rm = np.array([magnetic_reynolds_number(abs(v), r, sigma) for v, r in zip(vr, radius)])
+        s = np.array([lundquist_number(Bi, ni, r, sigma) for Bi, ni, r in zip(B, n, radius)])
+        return PinchResult(
+            t,
+            radius,
+            temperature,
+            pressure,
+            neutron_yield,
+            beta=beta,
+            alfven_mach=alfven,
+            magnetic_reynolds=rm,
+            lundquist=s,
+        )
 
 
 class SemiAnalyticPinchModel(PinchModelBase):
@@ -114,7 +142,25 @@ class SemiAnalyticPinchModel(PinchModelBase):
         reactivity = bosch_hale_dd(temperature / 1e3)
         rate = 0.25 * n_i ** 2 * reactivity * volume
         neutron_yield = float(np.trapz(rate, t))
-        return PinchResult(t, r, temperature, pressure, neutron_yield, axial_position=z)
+        B = 4e-7 * np.pi * I / (2 * np.pi * r)
+        beta = np.array([plasma_beta(ni, Ti, Bi) for ni, Ti, Bi in zip(n_i, temperature, B)])
+        vr = sol.y[1]
+        alfven = np.array([alfven_mach_number(v, Bi, ni) for v, Bi, ni in zip(vr, B, n_i)])
+        sigma = 1e5
+        rm = np.array([magnetic_reynolds_number(abs(v), rad, sigma) for v, rad in zip(vr, r)])
+        s = np.array([lundquist_number(Bi, ni, rad, sigma) for Bi, ni, rad in zip(B, n_i, r)])
+        return PinchResult(
+            t,
+            r,
+            temperature,
+            pressure,
+            neutron_yield,
+            axial_position=z,
+            beta=beta,
+            alfven_mach=alfven,
+            magnetic_reynolds=rm,
+            lundquist=s,
+        )
 
 
 class MHDPinchModel(PinchModelBase):
@@ -155,36 +201,59 @@ class MHDPinchModel(PinchModelBase):
         energy = internal + 0.5 * np.sum(B**2, axis=-1)
         state = MHDState(rho=rho, mom=mom, energy=energy, B=B)
 
-        def diagnostics(s: MHDState) -> tuple[float, float, float, float]:
+        def diagnostics(s: MHDState) -> tuple[float, float, float, float, float, float, float, float]:
             v = s.mom / s.rho[..., None]
-            kinetic = 0.5 * s.rho * np.sum(v**2, axis=-1)
-            magnetic = 0.5 * np.sum(s.B**2, axis=-1)
+            vmag = np.sqrt(np.sum(v**2, axis=-1))
+            kinetic = 0.5 * s.rho * vmag**2
+            Bmag = np.sqrt(np.sum(s.B**2, axis=-1))
+            magnetic = 0.5 * Bmag**2
             internal = s.energy - kinetic - magnetic
             p = (gamma - 1.0) * internal
             T = p / s.rho
             rad = np.sqrt(np.sum(s.rho * self.r2) / np.sum(s.rho))
-            return rad, float(np.mean(T)), float(np.mean(p)), float(np.sum(s.energy))
+            n = s.rho / (3.344e-27)
+            n_mean = float(np.mean(n))
+            B_mean = float(np.mean(Bmag))
+            beta = plasma_beta(n_mean, float(np.mean(T)), B_mean)
+            v_mean = float(np.mean(vmag))
+            alfven = alfven_mach_number(v_mean, B_mean, n_mean)
+            sigma = 1e5
+            rm = magnetic_reynolds_number(v_mean, rad, sigma)
+            s_num = lundquist_number(B_mean, n_mean, rad, sigma)
+            return rad, float(np.mean(T)), float(np.mean(p)), float(np.sum(s.energy)), beta, alfven, rm, s_num
 
         radius = []
         temperature = []
         pressure = []
         energy_hist = []
+        beta_hist = []
+        alfven_hist = []
+        rm_hist = []
+        s_hist = []
 
-        rad, temp, pres, Etot = diagnostics(state)
+        rad, temp, pres, Etot, b, a, rm, s_num = diagnostics(state)
         radius.append(rad)
         temperature.append(temp)
         pressure.append(pres)
         energy_hist.append(Etot)
+        beta_hist.append(b)
+        alfven_hist.append(a)
+        rm_hist.append(rm)
+        s_hist.append(s_num)
 
         neutron_yield = 0.0
         for k in range(len(t) - 1):
             dt = t[k + 1] - t[k]
             state = solver.step(state, dt)
-            rad, temp, pres, Etot = diagnostics(state)
+            rad, temp, pres, Etot, b, a, rm, s_num = diagnostics(state)
             radius.append(rad)
             temperature.append(temp)
             pressure.append(pres)
             energy_hist.append(Etot)
+            beta_hist.append(b)
+            alfven_hist.append(a)
+            rm_hist.append(rm)
+            s_hist.append(s_num)
             n_i = np.mean(state.rho) / (3.344e-27)
             reactivity = bosch_hale_dd(max(temp, 0.0) / 1e3)
             mag = np.mean(np.sum(state.B**2, axis=-1))
@@ -198,6 +267,10 @@ class MHDPinchModel(PinchModelBase):
             pressure=np.asarray(pressure),
             neutron_yield=float(neutron_yield),
             energy=np.asarray(energy_hist),
+            beta=np.asarray(beta_hist),
+            alfven_mach=np.asarray(alfven_hist),
+            magnetic_reynolds=np.asarray(rm_hist),
+            lundquist=np.asarray(s_hist),
         )
 
 
@@ -249,22 +322,37 @@ class HybridPinchModel(PinchModelBase):
         energy = internal + 0.5 * np.sum(B**2, axis=-1)
         state = MHDState(rho=rho, mom=mom, energy=energy, B=B)
 
-        def diagnostics(s: MHDState) -> tuple[float, float, float, float]:
+        def diagnostics(s: MHDState) -> tuple[float, float, float, float, float, float, float, float]:
             v = s.mom / s.rho[..., None]
-            kinetic = 0.5 * s.rho * np.sum(v**2, axis=-1)
-            magnetic = 0.5 * np.sum(s.B**2, axis=-1)
+            vmag = np.sqrt(np.sum(v**2, axis=-1))
+            kinetic = 0.5 * s.rho * vmag**2
+            Bmag = np.sqrt(np.sum(s.B**2, axis=-1))
+            magnetic = 0.5 * Bmag**2
             internal = s.energy - kinetic - magnetic
             p = (gamma - 1.0) * internal
             T = p / s.rho
             rad = np.sqrt(np.sum(s.rho * self.r2) / np.sum(s.rho))
-            return rad, float(np.mean(T)), float(np.mean(p)), float(np.sum(s.energy))
+            n = s.rho / (3.344e-27)
+            n_mean = float(np.mean(n))
+            B_mean = float(np.mean(Bmag))
+            beta = plasma_beta(n_mean, float(np.mean(T)), B_mean)
+            v_mean = float(np.mean(vmag))
+            alfven = alfven_mach_number(v_mean, B_mean, n_mean)
+            sigma = 1e5
+            rm = magnetic_reynolds_number(v_mean, rad, sigma)
+            s_num = lundquist_number(B_mean, n_mean, rad, sigma)
+            return rad, float(np.mean(T)), float(np.mean(p)), float(np.sum(s.energy)), beta, alfven, rm, s_num
 
         radius: list[float] = []
         temperature: list[float] = []
         pressure: list[float] = []
         energy_hist: list[float] = []
+        beta_hist: list[float] = []
+        alfven_hist: list[float] = []
+        rm_hist: list[float] = []
+        s_hist: list[float] = []
 
-        rad_fluid, temp, pres, Etot = diagnostics(state)
+        rad_fluid, temp, pres, Etot, b, a, rm, s_num = diagnostics(state)
         rad_pic, e_pic, j_pic = self.pic_driver.step(state, I[0], 0.0)
         getattr(self.pic_driver, "exchange_fields", lambda: (None, None))()
         getattr(self.pic_driver, "exchange_particles", lambda: (None, None))()
@@ -274,6 +362,10 @@ class HybridPinchModel(PinchModelBase):
         temperature.append(temp)
         pressure.append(pres)
         energy_hist.append(Etot + e_pic)
+        beta_hist.append(b)
+        alfven_hist.append(a)
+        rm_hist.append(rm)
+        s_hist.append(s_num)
 
         neutron_yield = 0.0
         for k in range(len(t) - 1):
@@ -282,7 +374,7 @@ class HybridPinchModel(PinchModelBase):
             getattr(self.pic_driver, "exchange_fields", lambda: (None, None))()
             getattr(self.pic_driver, "exchange_particles", lambda: (None, None))()
             state = solver.step(state, dt, current=j_pic)
-            rad_fluid, temp, pres, Etot = diagnostics(state)
+            rad_fluid, temp, pres, Etot, b, a, rm, s_num = diagnostics(state)
             if use_pic:
                 if rad_fluid > self.switch_radius:
                     use_pic = False
@@ -294,6 +386,10 @@ class HybridPinchModel(PinchModelBase):
             temperature.append(temp)
             pressure.append(pres)
             energy_hist.append(Etot + e_pic)
+            beta_hist.append(b)
+            alfven_hist.append(a)
+            rm_hist.append(rm)
+            s_hist.append(s_num)
             n_i = np.mean(state.rho) / (3.344e-27)
             reactivity = bosch_hale_dd(max(temp, 0.0) / 1e3)
             rate = 0.25 * n_i**2 * reactivity * self.volume
@@ -306,5 +402,9 @@ class HybridPinchModel(PinchModelBase):
             pressure=np.asarray(pressure),
             neutron_yield=float(neutron_yield),
             energy=np.asarray(energy_hist),
+            beta=np.asarray(beta_hist),
+            alfven_mach=np.asarray(alfven_hist),
+            magnetic_reynolds=np.asarray(rm_hist),
+            lundquist=np.asarray(s_hist),
         )
 

--- a/tests/diagnostics/test_bennett.py
+++ b/tests/diagnostics/test_bennett.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+from dpf2.diagnostics import bennett_radius
+
+
+def test_bennett_radius_monotonic():
+    n = 1e20
+    T = 1e3
+    currents = np.linspace(1e3, 1e5, 10)
+    radii = [bennett_radius(I, n, T) for I in currents]
+    assert all(r1 >= r2 for r1, r2 in zip(radii[:-1], radii[1:]))


### PR DESCRIPTION
## Summary
- add Bennett pinch radius calculation and per-cell beta, Alfven Mach, magnetic Reynolds, and Lundquist numbers
- log magnetic Reynolds number during rundown and warn when diffusion dominates
- record plasma metric histories in pinch models and test Bennett radius monotonicity

## Testing
- `pytest tests/diagnostics/test_bennett.py -q`
- `pytest tests/test_prepulse_axial_sheath.py::test_axial_sheath_advances -q`


------
https://chatgpt.com/codex/tasks/task_e_68b90449f204832ab362ff968b39fceb