### PR TITLE
Use physical constants in ideal gas EOS

### DIFF
--- a/src/dpf2/eos/ideal_gas.py
+++ b/src/dpf2/eos/ideal_gas.py
@@ -1,21 +1,32 @@
 """Ideal gas equation of state backend.
 
 This lightweight implementation provides ion and electron pressure and
-internal energy for a fully ionised or partially ionised ideal gas.  The
-model assumes a constant adiabatic index ``gamma`` and mean molecular
-weight ``mu`` (in arbitrary units).  When ``ionization`` is non-zero the
-same amount of pressure and energy is attributed to the electron fluid.
+specific internal energy for a fully or partially ionised ideal gas.  The
+model assumes a constant adiabatic index ``gamma`` and mean molecular weight
+``mu`` given in g/mol.  When ``ionization`` is non‑zero the same amount of
+pressure and energy is attributed to the electron fluid.
 
-The calculations intentionally avoid physical constants in order to keep
-unit tests self contained.  The specific gas constant is taken as
-``1 / mu`` so that pressure is given by ``p = rho * R * T`` and the
-specific internal energy follows from ``e = R * T / (gamma - 1)``.
+The specific gas constant is derived from the universal gas constant ``R``
+so that
+
+``R_specific = R * 1000 / mu``
+
+yielding pressure ``p = rho * R_specific * T`` and specific internal energy
+``e = R_specific * T / (gamma - 1)``.  Densities are expected in kg/m^3,
+temperatures in Kelvin, pressures in Pascal and energies in J/kg.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 import numpy as np
+
+try:  # pragma: no cover - prefer SciPy when available
+    from scipy.constants import R as R_UNIVERSAL
+except Exception:  # pragma: no cover - lightweight fallback
+    R_UNIVERSAL = 8.31446261815324  # J/(mol*K)
+
+GRAMS_PER_KILOGRAM = 1000.0
 
 
 @dataclass
@@ -31,9 +42,9 @@ class IdealGasEOS:
     # ------------------------------------------------------------------
     @property
     def R(self) -> float:
-        """Return the specific gas constant used by the model."""
+        """Return the specific gas constant [J/(kg*K)]."""
 
-        return 1.0 / self.mu
+        return R_UNIVERSAL * GRAMS_PER_KILOGRAM / self.mu
 
     # ------------------------------------------------------------------
     # EOS interface
@@ -56,7 +67,9 @@ class IdealGasEOS:
         cv = self.R / (self.gamma - 1.0)
         return cv * T
 
-    def electron_energy(self, rho: np.ndarray, T: np.ndarray) -> np.ndarray:  # noqa: ARG002
+    def electron_energy(
+        self, rho: np.ndarray, T: np.ndarray
+    ) -> np.ndarray:  # noqa: ARG002
         """Electron specific internal energy for density ``rho`` and temperature ``T``."""
 
         if self.ionization == 0.0:

--- a/tests/test_ideal_gas_eos.py
+++ b/tests/test_ideal_gas_eos.py
@@ -4,16 +4,19 @@ from dpf2.eos.ideal_gas import IdealGasEOS
 
 
 def test_ideal_gas_basic_relations():
-    eos = IdealGasEOS(gamma=1.4, mu=2.0, ionization=1.0)
-    rho = np.array([1.0])
-    T = np.array([3.0])
-    R = 1.0 / 2.0
+    eos = IdealGasEOS(gamma=1.4, mu=2.016, ionization=1.0)
+    rho = np.array([0.0899])  # kg/m^3 for H2 at STP
+    T = np.array([273.15])  # Kelvin
+    R_specific = 8.31446261815324 * 1000.0 / 2.016
     p_i = eos.ion_pressure(rho, T)
     p_e = eos.electron_pressure(rho, T)
     e_i = eos.ion_energy(rho, T)
     e_e = eos.electron_energy(rho, T)
-    assert np.allclose(p_i, rho * R * T)
-    assert np.allclose(p_e, rho * R * T)
-    expected_e = R * T / (1.4 - 1.0)
+    expected_p = rho * R_specific * T
+    expected_e = R_specific * T / (1.4 - 1.0)
+    assert np.allclose(p_i, expected_p)
+    assert np.allclose(p_e, expected_p)
     assert np.allclose(e_i, expected_e)
     assert np.allclose(e_e, expected_e)
+    assert np.isclose(p_i[0], 101275.53681892625, rtol=1e-5)
+    assert np.isclose(e_i[0], 2816338.62121597, rtol=1e-5)


### PR DESCRIPTION
## Summary
- compute specific gas constant from universal R and molar mass
- clarify EOS docstring and units
- test ideal gas EOS against canonical STP values

## Testing
- `black src/dpf2/eos/ideal_gas.py tests/test_ideal_gas_eos.py`
- `ruff check src/dpf2/eos/ideal_gas.py tests/test_ideal_gas_eos.py`
- `pytest tests/test_ideal_gas_eos.py tests/test_eos_selector.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9044d8fb4832a983876a37301907b