### PR TITLE
Add Paschen breakdown time utility and pre-pulse integration

### DIFF
--- a/src/dpf2/paschen.py
+++ b/src/dpf2/paschen.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+
+def paschen_breakdown_time(gap: float, pressure: float, voltage: float) -> float:
+    """Estimate the breakdown delay using a simple Paschen-like scaling.
+
+    The model assumes the delay scales with the reduced field ``(p * d) / V``.
+    The caller is responsible for using consistent units for all arguments.
+
+    Parameters
+    ----------
+    gap:
+        Electrode separation distance.
+    pressure:
+        Gas pressure.
+    voltage:
+        Applied voltage.
+
+    Returns
+    -------
+    float
+        Estimated time to breakdown.
+    """
+    if voltage <= 0:
+        raise ValueError("voltage must be positive")
+    return gap * pressure / voltage

--- a/src/dpf2/prepulse.py
+++ b/src/dpf2/prepulse.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, Optional
 
 import numpy as np
+
+from .paschen import paschen_breakdown_time
 
 mu0 = 4e-7 * np.pi
 
@@ -19,11 +21,23 @@ class PrePulseResult:
 class PrePulseBreakdownModel:
     """Minimal pre-pulse breakdown model with :math:`J\times B` force."""
 
-    def __init__(self, area: float, mass: float, force_threshold: float) -> None:
+    def __init__(
+        self,
+        area: float,
+        mass: float,
+        force_threshold: float,
+        *,
+        gap: Optional[float] = None,
+        pressure: Optional[float] = None,
+        voltage: Optional[float] = None,
+    ) -> None:
         self.area = area
         self.mass = mass
         self.force_threshold = force_threshold
         self.radius = np.sqrt(area / np.pi)
+        self.gap = gap
+        self.pressure = pressure
+        self.voltage = voltage
 
     def run(self, time: Iterable[float], current: Iterable[float]) -> PrePulseResult:
         t = np.array(list(time))
@@ -32,5 +46,13 @@ class PrePulseBreakdownModel:
         B = mu0 * I / (2 * np.pi * self.radius)
         jxb = J * B
         idx_candidates = [i for i, val in enumerate(jxb) if val >= self.force_threshold]
-        idx = idx_candidates[0] if idx_candidates else len(t) - 1
+        idx_jxb = idx_candidates[0] if idx_candidates else len(t) - 1
+
+        idx_paschen: Optional[int] = None
+        if None not in (self.gap, self.pressure, self.voltage):
+            t_paschen = paschen_breakdown_time(self.gap, self.pressure, self.voltage)
+            idx_paschen = next((i for i, tt in enumerate(t) if tt >= t_paschen), len(t) - 1)
+
+        candidates = [i for i in (idx_jxb, idx_paschen) if i is not None]
+        idx = min(candidates)
         return PrePulseResult(time=t, jxb_force=jxb, breakdown_time=float(t[idx]), breakdown_index=idx)

--- a/tests/physics/test_paschen.py
+++ b/tests/physics/test_paschen.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+from dpf2.paschen import paschen_breakdown_time
+from dpf2.prepulse import PrePulseBreakdownModel
+
+
+def test_breakdown_delay_varies_across_gases():
+    gap = 1.0
+    voltage = 20.0
+    pressures = {"He": 0.5, "Ar": 1.0, "Xe": 2.0}
+    delays = {g: paschen_breakdown_time(gap, p, voltage) for g, p in pressures.items()}
+    assert delays["He"] < delays["Ar"] < delays["Xe"]
+
+
+def test_prepulse_uses_paschen_delay():
+    time = np.linspace(0.0, 5.0, 11)
+    current = np.linspace(0.0, 10.0, 11)
+    model = PrePulseBreakdownModel(
+        area=1.0,
+        mass=1.0,
+        force_threshold=1e6,
+        gap=1.0,
+        pressure=1.0,
+        voltage=10.0,
+    )
+    res = model.run(time, current)
+    t_paschen = paschen_breakdown_time(1.0, 1.0, 10.0)
+    expected_idx = next((i for i, tt in enumerate(time) if tt >= t_paschen), len(time) - 1)
+    assert res.breakdown_index == expected_idx


### PR DESCRIPTION
## Summary
- add `paschen_breakdown_time` utility for simple Paschen scaling
- integrate Paschen delay into `PrePulseBreakdownModel`
- test breakdown predictions across gases

## Testing
- `pytest tests/physics/test_paschen.py tests/test_prepulse_axial_sheath.py::test_prepulse_breakdown_detects_threshold -q`


------
https://chatgpt.com/codex/tasks/task_e_68b90452f434832a8cdb37584d312fa9