### PR TITLE
Add basic material damage module with configuration support

### DIFF
--- a/src/dpf2/materials/__init__.py
+++ b/src/dpf2/materials/__init__.py
@@ -1,0 +1,12 @@
+"""Material definition and lifecycle tracking utilities."""
+
+from .library import Material, MaterialLibrary
+from .state import ComponentMaterialState
+from .mdm import MaterialDamageModel
+
+__all__ = [
+    "Material",
+    "MaterialLibrary",
+    "ComponentMaterialState",
+    "MaterialDamageModel",
+]

--- a/src/dpf2/materials/library.py
+++ b/src/dpf2/materials/library.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class Material:
+    """Static material properties."""
+
+    name: str
+    density: float  # kg/m^3
+    atomic_mass: float  # atomic mass units
+    sputter_yield: float  # atoms removed per incident particle
+
+
+class MaterialLibrary:
+    """Simple registry of materials with basic properties."""
+
+    _materials: Dict[str, Material] = {
+        "copper": Material("copper", density=8960.0, atomic_mass=63.546, sputter_yield=0.01),
+        "tungsten": Material("tungsten", density=19300.0, atomic_mass=183.84, sputter_yield=0.005),
+        "stainless_steel": Material("stainless_steel", density=8000.0, atomic_mass=55.845, sputter_yield=0.02),
+    }
+
+    @classmethod
+    def get(cls, name: str) -> Material:
+        """Return a material by name."""
+
+        key = name.lower()
+        if key not in cls._materials:
+            raise KeyError(f"Unknown material '{name}'")
+        return cls._materials[key]

--- a/src/dpf2/materials/mdm.py
+++ b/src/dpf2/materials/mdm.py
@@ -1,0 +1,38 @@
+from typing import Dict, Callable, Optional
+
+from .state import ComponentMaterialState
+
+
+class MaterialDamageModel:
+    """Minimal material damage model.
+
+    Updates component material states from surface fluxes and temperatures
+    provided by a solver.  Impurities may be injected back into a plasma
+    model if it exposes an ``inject_impurities`` method.
+    """
+
+    def __init__(
+        self,
+        components: Dict[str, ComponentMaterialState],
+        plasma_model: Optional[object] = None,
+    ) -> None:
+        self.components = components
+        self.plasma_model = plasma_model
+
+    def apply(self, solver: object, dt: float) -> None:
+        flux_fn: Callable[[str], float] = getattr(solver, "surface_flux", lambda name: 0.0)
+        temp_fn: Callable[[str], float] = getattr(solver, "surface_temperature", lambda name: 300.0)
+
+        for name, state in self.components.items():
+            flux = flux_fn(name)
+            temperature = temp_fn(name)
+            state.record_temperature(temperature)
+
+            erosion = flux * state.material.sputter_yield * dt
+            if erosion > 0.0:
+                state.erode(erosion)
+                if self.plasma_model and hasattr(self.plasma_model, "inject_impurities"):
+                    try:
+                        self.plasma_model.inject_impurities(name, erosion)
+                    except Exception:
+                        pass

--- a/src/dpf2/materials/state.py
+++ b/src/dpf2/materials/state.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from .library import Material, MaterialLibrary
+
+
+@dataclass
+class ComponentMaterialState:
+    """Runtime state for a component's material."""
+
+    material: Material
+    erosion: float = 0.0
+    film_thickness: float = 0.0
+    temperature_history: List[float] = field(default_factory=list)
+
+    def record_temperature(self, temp: float) -> None:
+        self.temperature_history.append(temp)
+
+    def erode(self, amount: float) -> None:
+        self.erosion += amount
+
+    def deposit(self, amount: float) -> None:
+        self.film_thickness += amount
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "material": self.material.name,
+            "erosion": self.erosion,
+            "film_thickness": self.film_thickness,
+            "temperature_history": list(self.temperature_history),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "ComponentMaterialState":
+        mat = MaterialLibrary.get(str(data["material"]))
+        return cls(
+            material=mat,
+            erosion=float(data.get("erosion", 0.0)),
+            film_thickness=float(data.get("film_thickness", 0.0)),
+            temperature_history=list(data.get("temperature_history", [])),
+        )

--- a/src/dpf2/simulation/config_schema.py
+++ b/src/dpf2/simulation/config_schema.py
@@ -157,6 +157,18 @@ class AMRConfig(BaseModel):
         10, ge=1, description="Interval for dumping AMR diagnostics"
     )
 
+
+class MaterialConfig(BaseModel):
+    """Selection of component materials and initial lifecycle parameters."""
+
+    components: Dict[str, str] = Field(
+        default_factory=dict, description="Mapping of component name to material"
+    )
+    initial_state: Dict[str, Dict[str, float]] = Field(
+        default_factory=dict,
+        description="Initial state parameters keyed by component",
+    )
+
 class SimulationConfig(BaseModel):
     """Main configuration for the DPF simulation."""
     grid_shape: List[int] = Field(..., min_items=3, max_items=3, description="Number of grid points (nx, ny, nz)")
@@ -175,6 +187,9 @@ class SimulationConfig(BaseModel):
     geometry: Optional[GeometryConfig] = None
     field_manager: FieldManagerConfig = Field(default_factory=FieldManagerConfig, description="Configuration for the FieldManager.")
     amr: AMRConfig = Field(default_factory=AMRConfig, description="Adaptive mesh refinement settings")
+    materials: MaterialConfig = Field(
+        default_factory=MaterialConfig, description="Material selection and initial state"
+    )
     provenance: Optional[Dict[str, Any]] = None
     telemetry: Optional[Dict[str, Any]] = None
     io: Optional[Dict[str, Any]] = None

--- a/src/dpf2/simulation/dpf_simulation.py
+++ b/src/dpf2/simulation/dpf_simulation.py
@@ -13,6 +13,7 @@ import argparse
 import numpy as np
 import random
 from datetime import datetime
+from typing import Dict
 
 try:  # Prefer package-local imports
     from .config_schema import SimulationConfig, FieldManagerConfig, PICConfig, AMRConfig
@@ -38,6 +39,11 @@ from .utils import FieldManager, SimulationState
 from ..diagnostics import Diagnostics
 from .pic_solver import PICSolver
 from ..core.bases import CouplingState
+from ..materials import (
+    MaterialLibrary,
+    ComponentMaterialState,
+    MaterialDamageModel,
+)
 try:
     from ..exceptions import SimulationRuntimeError
 except Exception:  # pragma: no cover - fallback for standalone usage
@@ -62,6 +68,7 @@ class DPFSimulation:
         self.current_time = 0.0
         self.dt = self.config.dt_init
         self.amr_config = getattr(self.config, "amr", _AMR())
+        self.material_model: MaterialDamageModel | None = None
 
         # Initialize modules
         self.registry = ModuleRegistry()
@@ -169,6 +176,20 @@ class DPFSimulation:
                     field_manager=self.field_manager,
                 )
 
+            if self.config.materials.components:
+                component_states: Dict[str, ComponentMaterialState] = {}
+                for comp, mat_name in self.config.materials.components.items():
+                    mat = MaterialLibrary.get(mat_name)
+                    init = self.config.materials.initial_state.get(comp, {})
+                    component_states[comp] = ComponentMaterialState(
+                        material=mat,
+                        erosion=float(init.get("erosion", 0.0)),
+                        film_thickness=float(init.get("film_thickness", 0.0)),
+                    )
+                self.material_model = MaterialDamageModel(
+                    component_states, plasma_model=self.modules.get("collision")
+                )
+
         except Exception as e:
             raise InitializationError(f"Failed to initialize modules: {e}")
 
@@ -197,6 +218,10 @@ class DPFSimulation:
                     self.solver.step(self.dt)
                     if self.pic_solver:
                         self.pic_solver.step()
+
+                # --- material damage model ---
+                if self.material_model:
+                    self.material_model.apply(self.solver, self.dt)
 
                 # --- collision and radiation modules ---
                 for name in ("collision", "radiation"):

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -1,0 +1,50 @@
+import pytest
+
+import pytest
+
+from dpf2.materials import (
+    MaterialLibrary,
+    ComponentMaterialState,
+    MaterialDamageModel,
+)
+
+
+def test_material_lookup():
+    mat = MaterialLibrary.get("copper")
+    assert mat.name == "copper"
+    assert mat.density == pytest.approx(8960.0)
+
+
+def test_erosion_accumulation():
+    mat = MaterialLibrary.get("tungsten")
+    state = ComponentMaterialState(material=mat)
+
+    class DummySolver:
+        def surface_flux(self, component: str) -> float:
+            return 5.0
+
+        def surface_temperature(self, component: str) -> float:
+            return 350.0
+
+    mdm = MaterialDamageModel({"anode": state})
+    mdm.apply(DummySolver(), dt=2.0)
+
+    expected = 5.0 * mat.sputter_yield * 2.0
+    assert state.erosion == pytest.approx(expected)
+    assert state.temperature_history[-1] == 350.0
+
+
+def test_state_serialization_roundtrip():
+    mat = MaterialLibrary.get("copper")
+    original = ComponentMaterialState(
+        material=mat,
+        erosion=1.0,
+        film_thickness=0.2,
+        temperature_history=[300.0, 310.0],
+    )
+    data = original.to_dict()
+    restored = ComponentMaterialState.from_dict(data)
+    assert restored.material == mat
+    assert restored.erosion == pytest.approx(1.0)
+    assert restored.film_thickness == pytest.approx(0.2)
+    assert restored.temperature_history == [300.0, 310.0]


### PR DESCRIPTION
## Summary
- add `materials` package with material definitions, runtime state, and damage model
- allow simulations to specify materials per component and track lifecycle state
- integrate material damage updates and impurity injection into solver loop
- cover material lookup, erosion accumulation, and serialization with unit tests

## Testing
- `pytest tests/test_materials.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b904f119fc832ab4b3bca42357cd04