### PR TITLE
Refactor radiation config material opacities

### DIFF
--- a/src/dpf2/core_schema.py
+++ b/src/dpf2/core_schema.py
@@ -50,6 +50,9 @@ def model_validator(*, mode: str = "after"):
 
     return decorator
 
+if not hasattr(BaseModel, "parse_obj"):
+    BaseModel.parse_obj = classmethod(lambda cls, d: cls(**d))
+
 if not hasattr(BaseModel, "model_validate"):
     BaseModel.model_validate = classmethod(lambda cls, d, **_: cls.parse_obj(d))
 if not hasattr(BaseModel, "model_dump"):
@@ -75,6 +78,9 @@ if True:  # replace ``model_copy`` with lightweight implementation
         return new
 
     BaseModel.model_copy = _copy
+
+if not hasattr(BaseModel, "model_rebuild"):
+    BaseModel.model_rebuild = classmethod(lambda cls, *_, **__: None)
 
 # ---------------------------------------------------------------------------
 # Type aliases
@@ -274,6 +280,17 @@ class ConfigSectionBase(BaseModel):
 # Radiation configuration
 
 
+class MaterialOpacity(BaseModel):
+    """Per-material opacity definition across radiation groups."""
+
+    material_id: str = Field(..., alias="materialId")
+    group_opacities: List[float] = Field(
+        ..., alias="groupOpacities"
+    )
+
+    model_config = ConfigDict(alias_generator=to_camel_case, populate_by_name=True)
+
+
 class RadiationSettings(ConfigSectionBase):
     """Basic radiation configuration including group counts and opacities."""
 
@@ -299,8 +316,8 @@ class RadiationSettings(ConfigSectionBase):
         },
     )
 
-    material_opacities: Dict[str, List[float]] = Field(
-        default_factory=dict,
+    material_opacities: List[MaterialOpacity] = Field(
+        default_factory=list,
         alias="materialOpacities",
         metadata={
             "units": "1/m",
@@ -309,23 +326,34 @@ class RadiationSettings(ConfigSectionBase):
         },
     )
 
+    @model_validator(mode="before")
+    def _dict_to_material_list(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        mos = values.get("material_opacities")
+        if isinstance(mos, dict):
+            values["material_opacities"] = [
+                {"material_id": k, "group_opacities": v} for k, v in mos.items()
+            ]
+        return values
+
     @model_validator(mode="after")
     def _validate_groups(cls, values: Self) -> Self:
         """Ensure opacity lists match the configured group count."""
         if values.group_opacities and len(values.group_opacities) != values.group_count:
             raise ValueError("group_opacities must match group_count")
-        for mat, vals in values.material_opacities.items():
-            if len(vals) != values.group_count:
+        for mo in values.material_opacities:
+            if len(mo.group_opacities) != values.group_count:
                 raise ValueError(
-                    f"material_opacities for {mat} must match group_count"
+                    f"material_opacities for {mo.material_id} must match group_count"
                 )
         return values
 
     def opacity_for(self, material: str | None = None) -> List[float]:
         """Return opacities for ``material`` or default group values."""
 
-        if material and material in self.material_opacities:
-            return self.material_opacities[material]
+        if material:
+            for mo in self.material_opacities:
+                if mo.material_id == material:
+                    return mo.group_opacities
         return self.group_opacities
 # ---------------------------------------------------------------------------
 # Root configuration model
@@ -619,6 +647,7 @@ __all__ = [
     "ConfigSectionBase",
     "DPFConfig",
     "RadiationSettings",
+    "MaterialOpacity",
     "TimeVoltageProfile",
     "DetectorConfig",
     "ConfigOverride",

--- a/src/dpf2/simulation/config_schema.py
+++ b/src/dpf2/simulation/config_schema.py
@@ -33,11 +33,21 @@ class CollisionConfig(BaseModel):
     charge_exchange_enabled: bool = Field(False, description="Enable charge exchange collisions")
     charge_exchange_cross_section: float = Field(1e-19, gt=0, description="Charge exchange cross-section [m^2]")
 
+class MaterialOpacity(BaseModel):
+    """Per-material opacity definition across radiation groups."""
+
+    material_id: str = Field(..., description="Material identifier")
+    group_opacities: List[float] = Field(
+        ..., description="Opacities for each radiation group"
+    )
+
+
 class RadiationConfig(BaseModel):
     """Configuration for the radiation model."""
+
     num_groups: int = Field(1, description="Number of radiation energy groups")
-    material_opacities: Dict[str, List[float]] = Field(
-        default_factory=dict,
+    material_opacities: List[MaterialOpacity] = Field(
+        default_factory=list,
         description="Material-specific opacities for each group",
     )
     use_line_radiation: bool = Field(False, description="Enable line radiation")
@@ -66,6 +76,15 @@ class RadiationConfig(BaseModel):
     photon_emission_enabled: bool = Field(False, description="Enable photon emission")
     photon_transport_enabled: bool = Field(False, description="Enable photon transport")
     # Add other parameters as needed
+
+    @validator("material_opacities", pre=True)
+    def _convert_material_opacities(cls, v):
+        """Allow legacy dict-based format for material opacities."""
+        if isinstance(v, dict):
+            return [
+                {"material_id": k, "group_opacities": val} for k, val in v.items()
+            ]
+        return v
 
 class PICConfig(BaseModel):
     """Configuration for the Particle-in-Cell (PIC) model."""

--- a/tests/test_core_schema_config.py
+++ b/tests/test_core_schema_config.py
@@ -1,7 +1,8 @@
 import json
+import json
 import pytest
 
-from dpf2.core_schema import DPFConfig, GeometryType, ModeType
+from dpf2.core_schema import DPFConfig, GeometryType, ModeType, MaterialOpacity
 from dpf2.simulation_settings import SimulationSettings
 from dpf2.grid_resolution import GridResolution
 
@@ -66,3 +67,22 @@ def test_invalid_geometry():
 def test_required_fields():
     cfg = DPFConfig.with_defaults()
     assert "created_at" in cfg.required_fields()
+
+
+def test_material_opacity_serialization_round_trip():
+    cfg = DPFConfig.with_defaults()
+    rad = cfg.radiation.model_copy(
+        update={
+            "group_count": 2,
+            "group_opacities": [0.1, 0.2],
+            "material_opacities": [
+                MaterialOpacity(material_id="mat1", group_opacities=[1.0, 2.0])
+            ],
+        }
+    )
+    cfg = cfg.model_copy(update={"radiation": rad})
+
+    dumped = cfg.model_dump()
+    loaded = DPFConfig.model_validate(dumped)
+    assert loaded.radiation.material_opacities[0].material_id == "mat1"
+    assert loaded.radiation.material_opacities[0].group_opacities == [1.0, 2.0]


### PR DESCRIPTION
## Summary
- introduce `MaterialOpacity` model holding material ids and group opacities
- use list of `MaterialOpacity` in radiation configuration schemas
- support legacy dict format and add serialization test

## Testing
- `pytest tests/test_core_schema_config.py::test_defaults_create_section_models tests/test_core_schema_config.py::test_material_opacity_serialization_round_trip -q`


------
https://chatgpt.com/codex/tasks/task_e_68b904e516e0832abc570299df1912ec