### PR TITLE
Add structured MaterialRef for insulator data

### DIFF
--- a/src/dpf2/device_profiles.py
+++ b/src/dpf2/device_profiles.py
@@ -28,7 +28,7 @@ def model_validator(*, mode: str = "after"):
 
 
 if not hasattr(BaseModel, "model_validate"):
-    BaseModel.model_validate = classmethod(lambda cls, d, **_: cls.parse_obj(d))
+    BaseModel.model_validate = classmethod(lambda cls, d, **_: cls(**d))
 if not hasattr(BaseModel, "model_dump"):
     BaseModel.model_dump = BaseModel.dict
 if not hasattr(BaseModel, "model_dump_json"):
@@ -37,6 +37,7 @@ if not hasattr(BaseModel, "model_copy"):
     BaseModel.model_copy = BaseModel.copy
 
 from .core_schema import ConfigSectionBase, to_camel_case
+from .materials import MaterialRef
 
 
 class InsulatorSleeve(BaseModel):
@@ -45,7 +46,7 @@ class InsulatorSleeve(BaseModel):
     inner_radius_cm: float = Field(..., alias="innerRadiusCm", ge=0.0)
     thickness_cm: float = Field(..., alias="thicknessCm", ge=0.0)
     length_cm: float = Field(..., alias="lengthCm", ge=0.0)
-    material: Optional[str] = Field(None, alias="material")
+    material: Optional[MaterialRef] = Field(None, alias="material")
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
         extra="forbid",
@@ -67,7 +68,7 @@ class DeviceEntry(BaseModel):
     cathode_radius_cm: float = Field(..., alias="cathodeRadiusCm", ge=0.0)
     anode_length_cm: float = Field(..., alias="anodeLengthCm", ge=0.0)
     insulator_length_cm: float = Field(..., alias="insulatorLengthCm", ge=0.0)
-    insulator_material: Optional[str] = Field(None, alias="insulatorMaterial")
+    insulator_material: Optional[MaterialRef] = Field(None, alias="insulatorMaterial")
     insulator_sleeve: Optional[InsulatorSleeve] = Field(
         None, alias="insulatorSleeve"
     )
@@ -154,12 +155,12 @@ class DeviceProfiles(ConfigSectionBase):
                     "cathodeRadiusCm": 6.0,
                     "anodeLengthCm": 16.0,
                     "insulatorLengthCm": 5.0,
-                    "insulatorMaterial": "alumina",
+                    "insulatorMaterial": {"materialId": "alumina"},
                     "insulatorSleeve": {
                         "innerRadiusCm": 2.5,
                         "thicknessCm": 0.5,
                         "lengthCm": 5.0,
-                        "material": "alumina",
+                        "material": {"materialId": "alumina"},
                     },
                     "breakdownVoltageKV": 25.0,
                     "fuelMixture": {"D": 0.9, "Ar": 0.1},

--- a/src/dpf2/materials/__init__.py
+++ b/src/dpf2/materials/__init__.py
@@ -1,0 +1,5 @@
+"""Material-related models and helpers."""
+
+from .models import MaterialRef
+
+__all__ = ["MaterialRef"]

--- a/src/dpf2/materials/models.py
+++ b/src/dpf2/materials/models.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import ClassVar, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..core_schema import to_camel_case
+
+
+# -----------------------------------------------------------------------------
+# Compatibility layer for Pydantic v1/v2 differences
+if not hasattr(BaseModel, "model_validate"):
+    BaseModel.model_validate = classmethod(lambda cls, d, **_: cls(**d))
+if not hasattr(BaseModel, "model_dump"):
+    BaseModel.model_dump = BaseModel.dict
+if not hasattr(BaseModel, "model_dump_json"):
+    BaseModel.model_dump_json = BaseModel.json
+if not hasattr(BaseModel, "model_copy"):
+    BaseModel.model_copy = BaseModel.copy
+
+
+class MaterialRef(BaseModel):
+    """Reference to a material and optional coating information."""
+
+    material_id: str = Field(..., alias="materialId")
+    coating_id: Optional[str] = Field(None, alias="coatingId")
+
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        extra="forbid",
+        alias_generator=to_camel_case,
+        populate_by_name=True,
+        validate_default=True,
+    )
+
+
+__all__ = ["MaterialRef"]

--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -59,3 +59,14 @@ def test_hash_changes_on_geometry_change():
     data["devices"]["PF1000"]["anodeLengthCm"] = cfg.devices["PF1000"].anode_length_cm * 2
     cfg2 = DeviceProfiles.model_validate(data)
     assert base_hash != cfg2.device_profiles_config_hash
+
+
+def test_insulator_material_is_materialref():
+    cfg = DeviceProfiles.with_defaults()
+    sleeve = cfg.devices["PF1000"].insulator_sleeve
+    assert cfg.devices["PF1000"].insulator_material is not None
+    assert (
+        cfg.devices["PF1000"].insulator_material.material_id == "alumina"
+    )
+    assert sleeve is not None and sleeve.material is not None
+    assert sleeve.material.material_id == "alumina"

--- a/tests/test_insulator_ablation.py
+++ b/tests/test_insulator_ablation.py
@@ -7,8 +7,17 @@ def test_device_profile_has_insulator_sleeve():
     cfg = DeviceProfiles.with_defaults()
     sleeve = cfg.devices["PF1000"].insulator_sleeve
     assert sleeve is not None
-    assert sleeve.inner_radius_cm == pytest.approx(cfg.devices["PF1000"].anode_radius_cm)
-    assert sleeve.length_cm == pytest.approx(cfg.devices["PF1000"].insulator_length_cm)
+    assert sleeve.inner_radius_cm == pytest.approx(
+        cfg.devices["PF1000"].anode_radius_cm
+    )
+    assert sleeve.length_cm == pytest.approx(
+        cfg.devices["PF1000"].insulator_length_cm
+    )
+    assert sleeve.material is not None
+    assert (
+        sleeve.material.material_id
+        == cfg.devices["PF1000"].insulator_material.material_id
+    )
 
 
 def test_ablation_mass_energy_source():


### PR DESCRIPTION
## Summary
- Introduce `MaterialRef` model for material/coating identifiers
- Switch device profile insulator fields to use `MaterialRef`
- Update tests to validate structured material references

## Testing
- `pytest tests/test_insulator_ablation.py tests/test_device_profiles.py -q` *(fails: missing pydantic features in test environment)*
- `pytest -q` *(fails: missing optional dependencies like werkzeug, adios2, scipy)*

------
https://chatgpt.com/codex/tasks/task_e_68b904e134f8832aa041eb087fccbb36