### PR TITLE
feat: add neutron anisotropy diagnostics

### DIFF
--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -15,6 +15,10 @@ from .neutron_yield import (
     compute_beam_target_yield,
     compute_thermonuclear_yield,
     save_anisotropic_spectrum_hdf5,
+    simulate_tof_detectors,
+    save_tof_hdf5,
+    angular_yield_map,
+    save_angular_yield_map_hdf5,
 )
 from .xray_spectra import compute_xray_spectrum
 from .scope_trace import compute_scope_trace
@@ -67,6 +71,10 @@ __all__ = [
     "compute_beam_target_yield",
     "compute_thermonuclear_yield",
     "save_anisotropic_spectrum_hdf5",
+    "simulate_tof_detectors",
+    "save_tof_hdf5",
+    "angular_yield_map",
+    "save_angular_yield_map_hdf5",
     "compute_xray_spectrum",
     "compute_scope_trace",
     "current_waveform",

--- a/src/dpf2/diagnostics/neutron_yield.py
+++ b/src/dpf2/diagnostics/neutron_yield.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 from bisect import bisect_right
-from typing import Callable, Protocol, Sequence, Tuple
+from typing import Callable, Protocol, Sequence, Tuple, Dict, List
 
 import h5py_stub as h5py  # type: ignore
 import math
+from ..neutron_yield_model import compute_directional_spectrum
 
 
 def compute_neutron_yield(reaction_rate: Sequence[float], dt: float) -> float:
@@ -117,6 +118,31 @@ def compute_thermonuclear_yield(
     return compute_neutron_yield(rate, dt)
 
 
+def simulate_tof_detectors(
+    ion_edf: IonBeamEDF,
+    cross_section: Callable[[float], float],
+    angles: Sequence[float],
+    distance: float,
+    time_bins: Sequence[float],
+    detector_names: Sequence[str] | None = None,
+    response_fn: Callable[[float], float] | None = None,
+    noise_fn: Callable[[float], float] | None = None,
+) -> Dict[str, List[float]]:
+    """Generate synthetic neutron time-of-flight detector histograms."""
+
+    _, tofs = compute_beam_target_yield(
+        ion_edf, cross_section, angles, distance, time_bins
+    )
+    dets: Dict[str, List[float]] = {}
+    for i, hist in enumerate(tofs):
+        processed = [response_fn(v) if response_fn else v for v in hist]
+        if noise_fn:
+            processed = [v + noise_fn(v) for v in processed]
+        name = detector_names[i] if detector_names else f"detector_{i}"
+        dets[name] = [float(v) for v in processed]
+    return dets
+
+
 def save_anisotropic_spectrum_hdf5(
     path: str | Path,
     energies: Sequence[float],
@@ -183,10 +209,83 @@ def save_anisotropic_spectrum_hdf5(
             ds.attrs["unitSI"] = 1.0
 
 
+def save_tof_hdf5(
+    path: str | Path,
+    time_bins: Sequence[float],
+    detectors: Dict[str, Sequence[float]],
+    openpmd: bool = False,
+) -> None:
+    """Export synthetic time-of-flight detector data to an HDF5 file."""
+
+    with h5py.File(path, "w") as fh:
+        base = fh
+        if openpmd:
+            fh.attrs.update(
+                {
+                    "openPMD": "1.1.0",
+                    "basePath": "/data/%T/",
+                    "iterationEncoding": "groupBased",
+                    "iterationFormat": "%T",
+                    "software": "dpf2",
+                }
+            )
+            base = fh.require_group("data/0")
+        t_ds = base.create_dataset("time_s", data=[float(t) for t in time_bins])
+        t_ds.data = list(t_ds.data)
+        t_ds.attrs["unitSI"] = 1.0
+        grp = base.require_group("detectors")
+        for name, hist in detectors.items():
+            ds = grp.create_dataset(name, data=[float(v) for v in hist])
+            ds.data = list(ds.data)
+            ds.attrs["unitSI"] = 1.0
+
+
+def angular_yield_map(
+    ion_edf: IonBeamEDF,
+    cross_section: Callable[[float], float],
+    angles: Sequence[float],
+    energy_bins: Sequence[float],
+) -> List[List[float]]:
+    """Wrapper around :func:`compute_directional_spectrum` for diagnostics."""
+
+    return compute_directional_spectrum(ion_edf, cross_section, angles, energy_bins)
+
+
+def save_angular_yield_map_hdf5(
+    path: str | Path,
+    energy_bins: Sequence[float],
+    angles: Sequence[float],
+    spectrum: Sequence[Sequence[float]],
+    detector_names: Sequence[str] | None = None,
+    response_fn: Callable[[float], float] | None = None,
+    noise_fn: Callable[[float], float] | None = None,
+    openpmd: bool = False,
+) -> None:
+    """Export angular yield map to HDF5 using standard spectrum layout."""
+    energies = [
+        (energy_bins[i] + energy_bins[i + 1]) / 2.0
+        for i in range(len(energy_bins) - 1)
+    ]
+    save_anisotropic_spectrum_hdf5(
+        path,
+        energies,
+        angles,
+        spectrum,
+        detector_names=detector_names,
+        response_fn=response_fn,
+        noise_fn=noise_fn,
+        openpmd=openpmd,
+    )
+
+
 __all__ = [
     "IonBeamEDF",
     "compute_neutron_yield",
     "compute_beam_target_yield",
     "compute_thermonuclear_yield",
     "save_anisotropic_spectrum_hdf5",
+    "simulate_tof_detectors",
+    "save_tof_hdf5",
+    "angular_yield_map",
+    "save_angular_yield_map_hdf5",
 ]

--- a/src/dpf2/neutron_yield_model.py
+++ b/src/dpf2/neutron_yield_model.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Optional, Tuple, Literal
+from bisect import bisect_right
+from typing import Any, ClassVar, Dict, List, Optional, Tuple, Literal, Callable, Sequence, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field
 from .utils.pydantic_compat import model_validator as _model_validator
@@ -25,6 +26,13 @@ def from_camel_case(string: str) -> str:
             out.append(ch)
     return "".join(out)
 from .units_settings import UnitsSettings
+
+
+class IonBeamEDF(Protocol):
+    """Protocol providing ion energy distributions by angle."""
+
+    def energy_distribution(self, angle_deg: float) -> Tuple[Sequence[float], Sequence[float]]:
+        ...
 
 
 class NeutronYieldModel(ConfigSectionBase):
@@ -210,4 +218,98 @@ class NeutronYieldModel(ConfigSectionBase):
         return values
 
 
-__all__ = ["NeutronYieldModel"]
+class TabulatedIonEDF(IonBeamEDF):
+    """Simple in-memory implementation of :class:`IonBeamEDF`.
+
+    The distribution is stored as a mapping from detector angle in degrees to a
+    tuple ``(energies, flux)`` where both entries are sequences of equal length
+    containing the ion energy grid and the corresponding differential flux
+    values.
+    """
+
+    def __init__(self, data: Dict[float, Tuple[Sequence[float], Sequence[float]]]):
+        self._data: Dict[float, Tuple[List[float], List[float]]] = {
+            float(a): ([float(e) for e in en], [float(f) for f in fl])
+            for a, (en, fl) in data.items()
+        }
+
+    def energy_distribution(self, angle_deg: float) -> Tuple[Sequence[float], Sequence[float]]:
+        return self._data.get(float(angle_deg), ([], []))
+
+    @classmethod
+    def from_json(cls, path: str | Path) -> "TabulatedIonEDF":
+        """Create an instance from a JSON file.
+
+        The JSON structure is expected to have ``angles``, ``energies`` and
+        ``distributions`` fields where ``distributions[i]`` corresponds to the
+        differential flux at ``angles[i]`` over the shared ``energies`` grid.
+        """
+
+        obj = json.loads(Path(path).read_text())
+        angles = obj.get("angles", [])
+        energies = obj.get("energies", [])
+        dists = obj.get("distributions", [])
+        if len(angles) != len(dists):
+            raise ValueError("angles and distributions length mismatch")
+        data = {
+            float(ang): (energies, dists[i])
+            for i, ang in enumerate(angles)
+        }
+        return cls(data)
+
+
+def compute_directional_spectrum(
+    ion_edf: IonBeamEDF,
+    cross_section: Callable[[float], float],
+    angles: Sequence[float],
+    energy_bins: Sequence[float],
+) -> List[List[float]]:
+    """Compute energy spectra ``dN/dE`` for multiple detector angles.
+
+    Parameters
+    ----------
+    ion_edf:
+        Provider of ion energy distributions.
+    cross_section:
+        Callable returning the reaction cross section for a given energy.
+    angles:
+        Sequence of detector angles in degrees.
+    energy_bins:
+        Monotonic sequence of energy bin edges in joules.
+
+    Returns
+    -------
+    list of list of float
+        Spectral yield for each angle and energy bin.
+    """
+
+    if any(energy_bins[i] >= energy_bins[i + 1] for i in range(len(energy_bins) - 1)):
+        raise ValueError("energy_bins must be monotonically increasing")
+
+    spectra: List[List[float]] = []
+    for ang in angles:
+        energies, dist = ion_edf.energy_distribution(float(ang))
+        e = [float(v) for v in energies]
+        f = [float(v) for v in dist]
+        if len(e) != len(f):
+            raise ValueError("energies and distribution must have the same length")
+        hist = [0.0 for _ in range(len(energy_bins) - 1)]
+        for i in range(len(e) - 1):
+            e1, e2 = e[i], e[i + 1]
+            f1, f2 = f[i], f[i + 1]
+            s1, s2 = cross_section(e1), cross_section(e2)
+            dE = e2 - e1
+            contrib = 0.5 * (f1 * s1 + f2 * s2) * dE
+            e_mid = (e1 + e2) / 2.0
+            idx = bisect_right(energy_bins, e_mid) - 1
+            if 0 <= idx < len(hist):
+                hist[idx] += contrib
+        spectra.append(hist)
+    return spectra
+
+
+__all__ = [
+    "NeutronYieldModel",
+    "TabulatedIonEDF",
+    "compute_directional_spectrum",
+]

--- a/tests/diagnostics/test_neutron_anisotropy.py
+++ b/tests/diagnostics/test_neutron_anisotropy.py
@@ -1,0 +1,43 @@
+import math
+
+from dpf2.neutron_yield_model import TabulatedIonEDF
+from dpf2.diagnostics import (
+    simulate_tof_detectors,
+    save_tof_hdf5,
+    angular_yield_map,
+    save_angular_yield_map_hdf5,
+)
+
+
+def _make_edf():
+    E1 = 1e-13
+    E2 = 1.5e-13
+    data = {
+        0.0: ([E1, E2], [2.0, 0.0]),
+        90.0: ([E1, E2], [1.0, 0.0]),
+    }
+    return TabulatedIonEDF(data), E1, E2
+
+
+def test_forward_vs_radial_counts(tmp_path):
+    edf, E1, E2 = _make_edf()
+    cross_section = lambda e: 1.0
+    distance = 1.0
+    m_n = 1.674e-27
+    E_mid = (E1 + E2) / 2.0
+    t_exp = distance / math.sqrt(2.0 * E_mid / m_n)
+    time_bins = [0.0, t_exp * 0.9, t_exp * 1.1]
+    angles = [0.0, 90.0]
+
+    dets = simulate_tof_detectors(edf, cross_section, angles, distance, time_bins)
+    assert sum(dets["detector_0"]) > sum(dets["detector_1"])
+    tof_path = tmp_path / "tof.h5"
+    save_tof_hdf5(tof_path, time_bins, dets)
+    assert tof_path.exists()
+
+    energy_bins = [E1, E2]
+    spec = angular_yield_map(edf, cross_section, angles, energy_bins)
+    assert sum(spec[0]) > sum(spec[1])
+    spec_path = tmp_path / "spec.h5"
+    save_angular_yield_map_hdf5(spec_path, energy_bins, angles, spec)
+    assert spec_path.exists()


### PR DESCRIPTION
## Summary
- extend neutron yield model with tabulated ion energy distributions and directional spectra utilities
- add synthetic neutron time-of-flight detectors and angular yield map exports
- test forward versus radial neutron anisotropy

## Testing
- `pytest tests/test_neutron_yield_model.py tests/test_neutron_yield_diagnostics.py tests/diagnostics/test_neutron_tof.py tests/diagnostics/test_neutron_anisotropy.py`

------
https://chatgpt.com/codex/tasks/task_e_68b90ae3d604832a97f7decd373edb72