### PR TITLE
Support material-tagged CAD loading and new geometry presets

### DIFF
--- a/config_templates/hollow.json
+++ b/config_templates/hollow.json
@@ -1,0 +1,11 @@
+{
+  "cathode_radius": 0.025,
+  "anode_radius": 0.05,
+  "electrode_length": 0.12,
+  "gas_type": "deuterium",
+  "initial_pressure": 133.3,
+  "capacitance": 3e-5,
+  "inductance": 2e-8,
+  "resistance": 0.01,
+  "charging_voltage": 15000.0
+}

--- a/config_templates/reentrant.json
+++ b/config_templates/reentrant.json
@@ -1,0 +1,11 @@
+{
+  "cathode_radius": 0.02,
+  "anode_radius": 0.045,
+  "electrode_length": 0.1,
+  "gas_type": "deuterium",
+  "initial_pressure": 133.3,
+  "capacitance": 3e-5,
+  "inductance": 2e-8,
+  "resistance": 0.01,
+  "charging_voltage": 15000.0
+}

--- a/config_templates/tapered.json
+++ b/config_templates/tapered.json
@@ -1,0 +1,11 @@
+{
+  "cathode_radius": 0.02,
+  "anode_radius": 0.04,
+  "electrode_length": 0.1,
+  "gas_type": "deuterium",
+  "initial_pressure": 133.3,
+  "capacitance": 3e-5,
+  "inductance": 2e-8,
+  "resistance": 0.01,
+  "charging_voltage": 15000.0
+}

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -107,10 +107,10 @@ def build_config_wizard() -> DPFConfig:
 
     click.echo("DPF2 configuration wizard\n")
     defaults = DPFConfig()
-    click.echo("Geometry presets: mather, filippov or custom.")
+    click.echo("Geometry presets: mather, filippov, tapered, hollow, re-entrant or custom.")
     preset = click.prompt(
         "Select geometry preset",
-        type=click.Choice(["mather", "filippov", "custom"]),
+        type=click.Choice(["mather", "filippov", "tapered", "hollow", "re-entrant", "custom"]),
         default="mather",
         show_choices=True,
     )
@@ -121,6 +121,18 @@ def build_config_wizard() -> DPFConfig:
     elif preset == "mather":
         defaults = dataclasses.replace(
             defaults, cathode_radius=0.02, anode_radius=0.04, electrode_length=0.1
+        )
+    elif preset == "tapered":
+        defaults = dataclasses.replace(
+            defaults, cathode_radius=0.02, anode_radius=0.04, electrode_length=0.1
+        )
+    elif preset == "hollow":
+        defaults = dataclasses.replace(
+            defaults, cathode_radius=0.025, anode_radius=0.05, electrode_length=0.12
+        )
+    elif preset == "re-entrant":
+        defaults = dataclasses.replace(
+            defaults, cathode_radius=0.02, anode_radius=0.045, electrode_length=0.1
         )
 
     # --- Device size -------------------------------------------------

--- a/src/dpf2/dpf_config.py
+++ b/src/dpf2/dpf_config.py
@@ -162,7 +162,9 @@ class CircuitConfig(BaseModel):
         )
 
 class ElectrodeGeometry(BaseModel):
-    geometry_preset: Optional[Literal["mather", "filippov"]] = None
+    geometry_preset: Optional[
+        Literal["mather", "filippov", "tapered", "hollow", "reentrant"]
+    ] = None
     cathode_type: str
     cathode_bar_count: int
     cathode_gap_degrees: float
@@ -191,6 +193,12 @@ class ElectrodeGeometry(BaseModel):
                 cathode_gap_degrees=0.0,
                 anode_shape="cylinder",
             )
+        if geometry_preset == "tapered":
+            return cls.tapered(geometry_preset="tapered", cathode_type="bar", cathode_bar_count=10, cathode_gap_degrees=36.0)
+        if geometry_preset == "hollow":
+            return cls.hollow(geometry_preset="hollow", cathode_type="bar", cathode_bar_count=10, cathode_gap_degrees=36.0)
+        if geometry_preset == "reentrant":
+            return cls.reentrant(geometry_preset="reentrant", cathode_type="bar", cathode_bar_count=10, cathode_gap_degrees=36.0)
         # default to mather-style geometry
         return cls(
             geometry_preset="mather",

--- a/src/dpf2/geometry/loaders.py
+++ b/src/dpf2/geometry/loaders.py
@@ -14,12 +14,14 @@ def _parse_step_like(lines: List[str]) -> Dict[str, Any]:
     """Parse a tiny subset of STEP/IGES style geometry.
 
     The parser understands lines beginning with ``NODE`` to define points and
-    ``TRI`` to define triangular faces.  Indices in ``TRI`` statements are
-    one-based to mimic common CAD conventions.
+    ``TRI`` to define triangular faces.  ``TRI`` statements may include an
+    optional fourth field specifying a material tag for the element.  Indices in
+    ``TRI`` statements are one-based to mimic common CAD conventions.
     """
 
     nodes: List[List[float]] = []
     elements: List[List[int]] = []
+    materials: List[Any] = []
     for ln in lines:
         parts = ln.split()
         if not parts:
@@ -27,9 +29,18 @@ def _parse_step_like(lines: List[str]) -> Dict[str, Any]:
         tag, *rest = parts
         if tag.upper() == "NODE" and len(rest) == 3:
             nodes.append([float(v) for v in rest])
-        elif tag.upper() == "TRI" and len(rest) == 3:
-            elements.append([int(v) for v in rest])
-    return {"nodes": nodes, "elements": elements}
+        elif tag.upper() == "TRI" and len(rest) in {3, 4}:
+            elements.append([int(v) for v in rest[:3]])
+            if len(rest) == 4:
+                mat = rest[3]
+                try:
+                    materials.append(int(mat))
+                except ValueError:
+                    materials.append(mat)
+    out: Dict[str, Any] = {"nodes": nodes, "elements": elements}
+    if materials:
+        out["materials"] = materials
+    return out
 
 
 def load_cad_geometry(path: Path) -> Dict[str, Any]:
@@ -37,11 +48,12 @@ def load_cad_geometry(path: Path) -> Dict[str, Any]:
 
     The loader understands a few simple formats used in tests:
 
-    * ``.json`` files containing ``nodes`` and ``elements`` lists.
+    * ``.json`` files containing ``nodes`` and ``elements`` lists (and optional
+      ``materials``).
     * ``.step``/``.stp`` and ``.iges``/``.igs`` files.  If :mod:`meshio` is
-      available it is used to parse these files.  Otherwise a tiny custom text
-      format is supported where each line is either ``NODE x y z`` or
-      ``TRI i j k``.
+      available it is used to parse these files.  Cell based material tags are
+      extracted when present.  Otherwise a tiny custom text format is supported
+      where each line is either ``NODE x y z`` or ``TRI i j k [mat]``.
     """
 
     p = Path(path)
@@ -53,12 +65,27 @@ def load_cad_geometry(path: Path) -> Dict[str, Any]:
             try:  # pragma: no cover - exercised when meshio is available
                 m = meshio.read(p)
                 elements: List[List[int]] = []
-                for block in m.cells:
+                materials: List[Any] = []
+                for idx, block in enumerate(m.cells):
                     if block.type in {"triangle", "quad"}:
-                        elements.extend(block.data.tolist())
+                        data = block.data.tolist()
+                        elements.extend(data)
+                        # try to pull material tags from cell data
+                        tag = None
+                        if m.cell_data:
+                            for key in ("material", "gmsh:physical", "cell_tags"):
+                                vals = m.cell_data.get(key)
+                                if vals and len(vals) > idx:
+                                    tag = vals[idx]
+                                    break
+                        if tag is not None:
+                            materials.extend(tag.tolist() if hasattr(tag, "tolist") else list(tag))
                 if not elements and m.cells:
                     elements = m.cells[0].data.tolist()
-                return {"nodes": m.points.tolist(), "elements": elements}
+                result: Dict[str, Any] = {"nodes": m.points.tolist(), "elements": elements}
+                if materials:
+                    result["materials"] = materials
+                return result
             except Exception:
                 pass
         # fallback simple text representation

--- a/tests/geometry/sample.igs
+++ b/tests/geometry/sample.igs
@@ -1,4 +1,4 @@
 NODE 0 0 0
 NODE 0 0 1
 NODE 0 1 1
-TRI 1 2 3
+TRI 1 2 3 7

--- a/tests/geometry/sample.step
+++ b/tests/geometry/sample.step
@@ -1,4 +1,4 @@
 NODE 0 0 0
 NODE 1 0 0
 NODE 0 1 0
-TRI 1 2 3
+TRI 1 2 3 steel

--- a/tests/geometry/test_geometry_loading.py
+++ b/tests/geometry/test_geometry_loading.py
@@ -8,12 +8,14 @@ def test_load_step_geometry():
     data = load_cad_geometry(path)
     assert len(data["nodes"]) == 3
     assert data["elements"][0] == [1, 2, 3]
+    assert data["materials"][0] == "steel"
 
 
 def test_load_iges_geometry():
     path = Path(__file__).with_name("sample.igs")
     data = load_cad_geometry(path)
     assert len(data["elements"]) == 1
+    assert data["materials"][0] == 7
 
 
 def test_load_axisymmetric_mesh():

--- a/web/frontend/src/ProjectManager.jsx
+++ b/web/frontend/src/ProjectManager.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import axios from 'axios';
 import YieldPressureOverlay from './YieldPressureOverlay.jsx';
 import EfficiencyCurveOverlay from './EfficiencyCurveOverlay.jsx';
@@ -10,6 +10,7 @@ export default function ProjectManager({ projects = [] }) {
 
   const [preset, setPreset] = useState('');
   const [cad, setCad] = useState(null);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     setConfigSets(projects);
@@ -55,6 +56,7 @@ export default function ProjectManager({ projects = [] }) {
 
   const addConfigSet = async (e) => {
     e.preventDefault();
+    if (error) return;
     const form = new FormData();
     form.append('preset', preset);
     if (cad) form.append('cad', cad);
@@ -74,6 +76,35 @@ export default function ProjectManager({ projects = [] }) {
     data: results[id] || {},
     color: colors[idx % colors.length],
   }));
+
+  const metrics = useMemo(() => {
+    const out = {};
+    selectedIds.forEach((id) => {
+      const res = results[id] || {};
+      const vals = Object.values(res);
+      if (vals.length) {
+        out[id] = {
+          maxYield: Math.max(...vals.map((v) => v.yield)),
+          maxEfficiency: Math.max(...vals.map((v) => v.efficiency)),
+        };
+      }
+    });
+    return out;
+  }, [results, selectedIds]);
+
+  const handleFile = (e) => {
+    const file = e.target.files[0];
+    setError('');
+    if (file) {
+      const ok = /\.(step|stp|iges|igs|json)$/i.test(file.name);
+      if (!ok) {
+        setError('Unsupported geometry format');
+        setCad(null);
+        return;
+      }
+    }
+    setCad(file);
+  };
 
   return (
     <div>
@@ -104,9 +135,39 @@ export default function ProjectManager({ projects = [] }) {
           <option value="hollow">Hollow</option>
           <option value="re-entrant">Re-entrant</option>
         </select>
-        <input type="file" onChange={(e) => setCad(e.target.files[0])} />
+        <input type="file" onChange={handleFile} />
+        {error && <p className="error">{error}</p>}
         <button type="submit">Add</button>
       </form>
+
+      {selectedIds.length > 1 && (
+        <table className="comparison">
+          <thead>
+            <tr>
+              <th>Project</th>
+              <th>Max Yield</th>
+              <th>Max Efficiency</th>
+            </tr>
+          </thead>
+          <tbody>
+            {selectedIds.map((id) => (
+              <tr key={id}>
+                <td>{id}</td>
+                <td>
+                  {metrics[id]?.maxYield !== undefined
+                    ? metrics[id].maxYield.toFixed(3)
+                    : '-'}
+                </td>
+                <td>
+                  {metrics[id]?.maxEfficiency !== undefined
+                    ? metrics[id].maxEfficiency.toFixed(3)
+                    : '-'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
 
       {selectedIds.length > 0 && (
         <div className="overlays">


### PR DESCRIPTION
## Summary
- parse STEP/IGES files via meshio with material tagging
- add tapered, hollow, and re-entrant geometry presets for CLI/GUI
- enhance ProjectManager with comparison metrics and geometry validation

## Testing
- `pytest tests/geometry/test_geometry_loading.py`

------
https://chatgpt.com/codex/tasks/task_e_68b90ae4ab98832ab7587e8943ecec7b