### PR TITLE
Add RMSE/L2 validation metrics and report generation

### DIFF
--- a/src/dpf2/cli/validate.py
+++ b/src/dpf2/cli/validate.py
@@ -24,7 +24,7 @@ import numpy as np
 
 from ..dpf_config import DPFConfig
 from ..simulation_engine import SimulationEngine, SimulationResults
-from ..validation_suite import ValidationSuite
+from ..validation_suite import ValidationSuite, score_simulation
 from ..scaling_laws import compare_to_scaling
 
 
@@ -76,42 +76,6 @@ def _simulation_observables(res: SimulationResults) -> Dict[str, Tuple[np.ndarra
         "V(t)": (res.time * 1e6, res.voltage / 1e3),
         "Yn": (np.array([0.0]), np.array([res.neutron_yield])),
     }
-
-
-def _score_observable(
-    sim: Tuple[np.ndarray, np.ndarray],
-    exp: Tuple[np.ndarray, np.ndarray],
-    tolerance: float,
-) -> float:
-    """Compute a simple normalized RMSE score for a single observable."""
-    exp_t, exp_v = exp
-    sim_t, sim_v = sim
-    sim_interp = np.interp(exp_t, sim_t, sim_v)
-    rmse = float(np.sqrt(np.mean((sim_interp - exp_v) ** 2)))
-    norm = np.max(np.abs(exp_v)) or 1.0
-    return max(0.0, 1.0 - rmse / (norm * tolerance))
-
-
-def _compute_scores(
-    res: SimulationResults,
-    vsuite: ValidationSuite,
-    exp: Dict[str, Tuple[np.ndarray, np.ndarray]],
-) -> Tuple[Dict[str, float], float, bool]:
-    """Calculate per-observable and aggregate scores."""
-    sim = _simulation_observables(res)
-    scores: Dict[str, float] = {}
-    for obs in vsuite.validation_targets:
-        if obs not in exp or obs not in sim:
-            continue
-        tol = vsuite.observable_tolerances.get(obs, 1.0)
-        scores[obs] = _score_observable(sim[obs], exp[obs], tol)
-    weights = vsuite.observable_weighting or {k: 1.0 for k in scores}
-    total = sum(weights.values()) or 1.0
-    overall = (
-        sum(scores.get(k, 0.0) * weights.get(k, 0.0) for k in scores) / total
-    )
-    passed = overall >= vsuite.score_pass_threshold
-    return scores, overall, passed
 
 
 def _plot_overlays(
@@ -166,21 +130,44 @@ def run_validation(config: Path, dataset: str, *, outdir: Path = Path("validatio
 
     vsuite = _build_validation_suite(dataset)
     exp = _load_experimental(vsuite)
-    scores, overall, passed = _compute_scores(results, vsuite, exp)
+    sim = _simulation_observables(results)
+    tol_map = {
+        "current": vsuite.observable_tolerances.get("I(t)", 1.0),
+        "voltage": vsuite.observable_tolerances.get("V(t)", 1.0),
+        "neutron_yield": vsuite.observable_tolerances.get("Yn", 1.0),
+    }
+    weight_map = None
+    if vsuite.observable_weighting:
+        weight_map = {
+            "current": vsuite.observable_weighting.get("I(t)", 0.0),
+            "voltage": vsuite.observable_weighting.get("V(t)", 0.0),
+            "neutron_yield": vsuite.observable_weighting.get("Yn", 0.0),
+        }
+    report = score_simulation(
+        sim,
+        dataset,
+        tol_map,
+        resample_method=vsuite.resample_method or "interpolate",
+        weights=weight_map,
+        pass_threshold=vsuite.score_pass_threshold,
+    )
     _plot_overlays(results, exp, outdir)
+
+    outdir.mkdir(parents=True, exist_ok=True)
+    with (outdir / "validation_report.json").open("w") as fh:
+        json.dump(report, fh, indent=2)
 
     metrics = compare_to_scaling(results, vsuite.dataset_directory)
     if metrics:
-        outdir.mkdir(parents=True, exist_ok=True)
         with (outdir / "scaling_report.json").open("w") as fh:
             json.dump(metrics, fh, indent=2)
 
-    for name, score in scores.items():
+    for name, score in report["scores"].items():
         print(f"{name}: {score:.3f}")
-        
-    print(f"Overall score: {overall:.3f}")
-    print("Validation passed" if passed else "Validation failed")
-    return passed
+
+    print(f"Overall score: {report['overall']:.3f}")
+    print("Validation passed" if report["passed"] else "Validation failed")
+    return report["passed"]
 
 
 def main(argv: Iterable[str] | None = None) -> None:

--- a/src/dpf2/validation_suite.py
+++ b/src/dpf2/validation_suite.py
@@ -432,13 +432,19 @@ def score_simulation(
 
     ref = load_validation_dataset(device)
     scores: Dict[str, float] = {}
+    rmse_metrics: Dict[str, float] = {}
+    l2_metrics: Dict[str, float] = {}
     for name, ref_profile in ref.items():
         if name not in sim_outputs:
             continue
         ref_t, ref_v = ref_profile
         sim_t, sim_v = sim_outputs[name]
         sim_rs = resample_profile((sim_t, sim_v), ref_t, method=resample_method)
-        rmse = float(np.sqrt(np.mean((sim_rs - ref_v) ** 2)))
+        diff = sim_rs - ref_v
+        rmse = float(np.sqrt(np.mean(diff**2)))
+        l2 = float(np.sqrt(np.sum(diff**2)))
+        rmse_metrics[name] = rmse
+        l2_metrics[name] = l2
         norm = np.max(np.abs(ref_v)) or 1.0
         tol = tolerances.get(name, 1.0)
         scores[name] = max(0.0, 1.0 - rmse / (norm * tol))
@@ -454,7 +460,13 @@ def score_simulation(
             )
         else:
             overall = sum(scores.values()) / len(scores)
-    return {"scores": scores, "overall": overall, "passed": overall >= pass_threshold}
+    return {
+        "scores": scores,
+        "rmse": rmse_metrics,
+        "l2": l2_metrics,
+        "overall": overall,
+        "passed": overall >= pass_threshold,
+    }
 
 
 __all__ = [

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -25,4 +25,6 @@ def test_run_validation_creates_report(tmp_path):
     outdir = tmp_path / "out"
     ok = run_validation(cfg_path, "PF1000", outdir=outdir)
     assert (outdir / "scaling_report.json").exists()
+    report = (outdir / "validation_report.json").read_text()
+    assert "rmse" in report and "l2" in report
     assert isinstance(ok, bool)

--- a/tests/validation/test_suite.py
+++ b/tests/validation/test_suite.py
@@ -28,6 +28,8 @@ def test_score_simulation_pass(tmp_path):
     )
     assert res["passed"]
     assert res["overall"] == pytest.approx(1.0)
+    assert res["rmse"]["current"] == pytest.approx(0.0)
+    assert res["l2"]["current"] == pytest.approx(0.0)
 
 
 def test_weighted_rmse_changes_overall(tmp_path):
@@ -49,6 +51,8 @@ def test_weighted_rmse_changes_overall(tmp_path):
         {"current": 0.1, "voltage": 0.1, "neutron_yield": 0.2},
         weights=bias_weights,
     )
+    assert res_eq["rmse"]["voltage"] > 0.0
+    assert res_eq["l2"]["voltage"] > 0.0
     assert res_bias["overall"] > res_eq["overall"]
 
 


### PR DESCRIPTION
## Summary
- extend validation scoring to compute and expose RMSE and L2 metrics for current, voltage, and neutron yield
- enhance `dpf2 validate` command to produce a JSON validation report
- test scoring and CLI report creation

## Testing
- `pytest tests/test_validation_suite.py tests/validation/test_suite.py tests/test_cli_validate.py`

------
https://chatgpt.com/codex/tasks/task_e_68b90ae5ca50832a87ca82d0b3a32c1b