### PR TITLE
Enhance radiation model with polarization and pair production

### DIFF
--- a/src/dpf2/simulation/radiation_model.py
+++ b/src/dpf2/simulation/radiation_model.py
@@ -7,12 +7,12 @@ Features
 * Configurable opacity models
 * Flux-limited diffusion and a basic photon Monte Carlo scheme
 * Simple telemetry and checkpoint helpers
+* Polarization tracking and pair-production processes
+* Non‑LTE line transport with time dependent level populations
 
-Future Work
------------
-* Polarization, pair production and other high-energy processes
-* Detailed non-LTE line transport and time-dependent effects
-* Expanded test coverage and performance tuning
+The original implementation only provided a minimal treatment of these
+advanced effects; they are now represented in a lightweight but functional
+form suitable for testing and algorithmic development.
 """
 
 import numpy as np
@@ -71,8 +71,8 @@ logger.addHandler(ch)
 class Photon:
     """Lightweight Monte Carlo photon particle.
 
-    Only position, direction, energy and group are evolved. Polarization is
-    stored but unused and scattering is limited to isotropic Compton events."""
+    Only position, direction, energy and group are evolved.  A simple
+    polarization vector is carried and rotated during scattering events."""
 
     __slots__ = ('pos', 'dir', 'energy', 'group', 'polarization')
 
@@ -88,8 +88,9 @@ class Photon:
         """Perform a simplified isotropic Compton scattering event.
 
         The scattering angle is sampled isotropically and the photon's
-        direction vector is rotated accordingly while remaining normalized.
-        """
+        direction vector is rotated accordingly while remaining normalized.  A
+        crude polarization rotation is also applied so that the polarization
+        remains orthogonal to the new direction."""
         # Sample new energy
         x = self.energy / (m_e * c**2)
         mu = 1 - 2 * random.random()  # cos(theta) for isotropic scattering
@@ -115,6 +116,16 @@ class Photon:
         self.dir = mu * n + sin_theta * (np.cos(phi) * u + np.sin(phi) * v)
         self.dir /= np.linalg.norm(self.dir)
 
+        # Rotate polarization into the new frame.  This is a very lightweight
+        # treatment that simply aligns the polarization with the scattering
+        # plane while keeping it perpendicular to ``self.dir``.
+        p = np.cos(phi) * u + np.sin(phi) * v
+        p -= np.dot(p, self.dir) * self.dir
+        norm = np.linalg.norm(p)
+        if norm > 0:
+            p /= norm
+            self.polarization = p
+
 # --------------------------------------
 # Klein-Nishina Compton cross section
 # --------------------------------------
@@ -127,6 +138,22 @@ def klein_nishina_cross_section(E):
     term3 = -(1 + 3 * x) / (1 + 2 * x)
     sigma = (3 / 4) * pi * r0 ** 2 * (term1 + term2 + term3)
     return max(sigma, 0.0)
+
+# -------------------------------------------------
+# Electron–positron pair production cross section
+# -------------------------------------------------
+PAIR_PRODUCTION_THRESHOLD = 2 * m_e * c ** 2
+
+
+def pair_production_cross_section(E):
+    """Very approximate Bethe-Heitler like cross section.
+
+    This provides only a crude energy dependent scaling suitable for testing
+    and does not aim to be quantitatively accurate."""
+    if E <= PAIR_PRODUCTION_THRESHOLD:
+        return 0.0
+    sigma0 = 1e-30  # m^2 baseline
+    return sigma0 * np.log(E / PAIR_PRODUCTION_THRESHOLD)
 
 # --------------------------------------
 # High-Fidelity Radiation Model Class
@@ -208,6 +235,8 @@ class RadiationModel(PhysicsModule):
         self.photons = []
         self.total_radiated_energy = 0.0
         self.checkpoint_data = {}
+        self.pairs_created = 0
+        self.level_pop = None
 
         logger.info("RadiationModel initialized with %d groups", self.ncomp)
 
@@ -222,15 +251,49 @@ class RadiationModel(PhysicsModule):
         except Exception as e:
             logger.error(f"Error in telemetry thread: {e}")
 
-    def _compute_local_emissivities(self, Te, ne, Z, Bmag):
-        """Computes the local emissivities for Bremsstrahlung, line emission, and synchrotron radiation."""
+    # ------------------------------------------------------------------
+    # Emissivity helpers
+    # ------------------------------------------------------------------
+    def _update_level_population(self, Te, ne, dt):
+        """Evolves a simple two-level population model.
+
+        Parameters
+        ----------
+        Te, ne : ndarray
+            Local electron temperature and density.
+        dt : float
+            Time step for the update.
+
+        Returns
+        -------
+        ndarray
+            Updated excited-state population fraction.
+        """
+        if self.level_pop is None:
+            self.level_pop = np.zeros_like(Te)
+        # Extremely crude collisional rates
+        C12 = 1e-14 * ne * np.sqrt(Te)
+        C21 = 1e-14 * ne * np.sqrt(Te)
+        A21 = 1e8
+        n2 = self.level_pop
+        ones = np.zeros_like(n2) + 1.0
+        dn2 = C12 * (ones - n2) - (C21 + A21) * n2
+        n2 = np.clip(n2 + dt * dn2, 0.0, 1.0)
+        self.level_pop = n2
+        return n2
+
+    def _compute_local_emissivities(self, Te, ne, Z, Bmag, dt=0.0):
+        """Computes the local emissivities for Bremsstrahlung, line emission,
+        synchrotron radiation and time-dependent non-LTE line transport."""
         try:
             # Bremsstrahlung power [W/m^3] (more accurate formula)
             br = 1.69e-32 * self.gaunt_factor * ne**2 * Z**2 * np.sqrt(Te)
 
-            # Line cooling via table
+            # Line cooling via table with non-LTE population factor
             pts = np.stack([Te.flatten(), Z.flatten()], axis=1)
-            line = self.line_interp(pts).reshape(Te.shape)
+            line_lte = self.line_interp(pts).reshape(Te.shape)
+            pop = self._update_level_population(Te, ne, dt)
+            line = line_lte * pop
 
             # Synchrotron emission (relativistic correction)
             gamma = np.sqrt(1 + (Te / (m_e * c**2))**2)  # Relativistic gamma factor
@@ -241,10 +304,10 @@ class RadiationModel(PhysicsModule):
             logger.error(f"Error computing local emissivities: {e}")
             return np.zeros_like(Te), np.zeros_like(Te), np.zeros_like(Te)
 
-    def _build_emissivity(self, Te, ne, Z, Bmag):
+    def _build_emissivity(self, Te, ne, Z, Bmag, dt=0.0):
         """Combines the individual emissivities into a multi-group emissivity array."""
         try:
-            br, line, sync = self._compute_local_emissivities(Te, ne, Z, Bmag)
+            br, line, sync = self._compute_local_emissivities(Te, ne, Z, Bmag, dt)
             Em = np.zeros((self.ncomp,) + br.shape)
             Em[0] = br
             if self.ncomp > 1: Em[1] = line
@@ -418,6 +481,18 @@ class RadiationModel(PhysicsModule):
         except Exception as e:
             logger.error(f"Error in Compton scattering: {e}")
 
+    def _pair_production(self, photon, dt):
+        """Stochastically convert a photon into an electron-positron pair."""
+        sigma = pair_production_cross_section(photon.energy)
+        if sigma <= 0:
+            return False
+        # probability scaled by an arbitrary path length factor
+        prob = 1.0 - float(np.exp(-sigma * dt * 1e6))
+        if random.random() < prob:
+            self.pairs_created += 1
+            return True
+        return False
+
     def emit_photons(self, state, dt):
         """Creates new photons based on the calculated emissivities."""
         try:
@@ -425,7 +500,7 @@ class RadiationModel(PhysicsModule):
             ne = state.density;
             Z = state.get('Z', np.ones_like(ne))
             Bmag = state.get('Bmag', np.zeros_like(ne))
-            br, line, sync = self._compute_local_emissivities(Te, ne, Z, Bmag)
+            br, line, sync = self._compute_local_emissivities(Te, ne, Z, Bmag, dt)
             g = self.ncomp - 1
             V = np.prod(self.geom.CellSize())
             nx, ny, nz = ne.shape
@@ -459,6 +534,11 @@ class RadiationModel(PhysicsModule):
                     # More sophisticated boundary conditions (reflection, periodicity) could be implemented here.
                     continue  
 
+                # Pair production (photon removed if event occurs)
+                if self._pair_production(p, dt):
+                    ie[tuple(idx)] += p.energy
+                    continue
+
                 # Absorption
                 κ = self.group_opacities[p.group]  # Assuming uniform opacity for now
                 if random.random() < 1 - np.exp(-κ * c * dt):  # Absorption probability
@@ -479,7 +559,7 @@ class RadiationModel(PhysicsModule):
             Bmag = state.field_manager.get_B()
             self.Emiss = self._build_emissivity(state.electron_temperature,
                                                 state.density,
-                                                state.get('Z', 1.0), Bmag)
+                                                state.get('Z', 1.0), Bmag, dt)
             self.flux_limited_diffusion(dt)
             # 3) M1 two-moment coupling
             E_arr = self.E_mf.array()
@@ -511,14 +591,14 @@ class RadiationModel(PhysicsModule):
         except Exception as e:
             logger.error(f"Error applying radiation: {e}")
 
-    def compute_radiation_loss(self, state: Dict[str, Any]) -> Any:
+    def compute_radiation_loss(self, state: Dict[str, Any], dt: float = 0.0) -> Any:
         """Computes the radiation loss based on the current simulation state."""
         try:
             Te = state['Te']
             ne = state['density']
             Z = state.get('Z', np.ones_like(ne))
             Bmag = state.get('Bmag', np.zeros_like(ne))
-            br, line, sync = self._compute_local_emissivities(Te, ne, Z, Bmag)
+            br, line, sync = self._compute_local_emissivities(Te, ne, Z, Bmag, dt)
             return br + line + sync
         except Exception as e:
             logger.error(f"Error computing radiation loss: {e}")
@@ -566,6 +646,7 @@ class RadiationModel(PhysicsModule):
             return {
                 "total_radiated_energy": self.total_radiated_energy,
                 "num_photons": len(self.photons),
+                "pairs_created": self.pairs_created,
                 # Add other diagnostics as needed
             }
         except Exception as e:
@@ -577,7 +658,17 @@ class RadiationModel(PhysicsModule):
         try:
             self.checkpoint_data = {
                 'total_radiated_energy': self.total_radiated_energy,
-                'photons': [{'pos': p.pos.tolist(), 'dir': p.dir.tolist(), 'energy': p.energy, 'group': p.group} for p in self.photons]
+                'pairs_created': self.pairs_created,
+                'photons': [
+                    {
+                        'pos': p.pos.tolist(),
+                        'dir': p.dir.tolist(),
+                        'energy': p.energy,
+                        'group': p.group,
+                        'polarization': p.polarization.tolist(),
+                    }
+                    for p in self.photons
+                ]
             }
             return self.checkpoint_data
         except Exception as e:
@@ -588,6 +679,10 @@ class RadiationModel(PhysicsModule):
         """Restores data from a checkpoint."""
         try:
             self.total_radiated_energy = data.get('total_radiated_energy', 0.0)
-            self.photons = [Photon(p['pos'], p['dir'], p['energy'], p['group']) for p in data.get('photons', [])]
+            self.pairs_created = data.get('pairs_created', 0)
+            self.photons = [
+                Photon(p['pos'], p['dir'], p['energy'], p['group'], p.get('polarization'))
+                for p in data.get('photons', [])
+            ]
         except Exception as e:
             logger.error(f"Error during restart: {e}")

--- a/tests/performance/test_radiation_model_performance.py
+++ b/tests/performance/test_radiation_model_performance.py
@@ -1,0 +1,56 @@
+import sys
+import types
+import time
+import math
+
+# Minimal stubs for optional dependencies
+sys.modules.setdefault("amrex", types.ModuleType("amrex"))
+sys.modules.setdefault("adios2", types.ModuleType("adios2"))
+sys.modules.setdefault("h5py", types.ModuleType("h5py"))
+scipy_stub = types.ModuleType("scipy")
+interpolate_stub = types.ModuleType("interpolate")
+interpolate_stub.RegularGridInterpolator = lambda *a, **k: None
+scipy_stub.interpolate = interpolate_stub
+sys.modules.setdefault("scipy", scipy_stub)
+sys.modules.setdefault("scipy.interpolate", interpolate_stub)
+numba_stub = types.ModuleType("numba")
+numba_stub.njit = lambda *a, **k: (lambda f: f)
+numba_stub.prange = range
+sys.modules.setdefault("numba", numba_stub)
+
+import numpy_stub
+
+numpy_stub.np.any = lambda arr: any(arr)
+numpy_stub.np.linalg = types.SimpleNamespace(norm=lambda v: numpy_stub.sqrt(sum(x * x for x in v)))
+numpy_stub.np.arccos = math.acos
+numpy_stub.np.cos = math.cos
+numpy_stub.np.sin = math.sin
+numpy_stub.np.log = math.log
+sys.modules["numpy"] = numpy_stub.np
+np = numpy_stub.np
+
+from dpf2.simulation.radiation_model import RadiationModel, Photon, m_e, c
+
+
+def test_level_population_performance():
+    rm = RadiationModel.__new__(RadiationModel)
+    rm.level_pop = None
+    Te = np.ones((5, 5, 5))
+    ne = np.ones((5, 5, 5))
+    start = time.perf_counter()
+    for _ in range(100):
+        rm._update_level_population(Te, ne, dt=1e-9)
+    elapsed = time.perf_counter() - start
+    assert elapsed < 1.0
+
+
+def test_pair_production_performance():
+    rm = RadiationModel.__new__(RadiationModel)
+    rm.pairs_created = 0
+    photons = [Photon([0, 0, 0], [1, 0, 0], 3 * m_e * c ** 2, 0) for _ in range(100)]
+    start = time.perf_counter()
+    for p in photons:
+        rm._pair_production(p, dt=1e-9)
+    elapsed = time.perf_counter() - start
+    assert elapsed < 1.0
+

--- a/tests/test_radiation_new_physics.py
+++ b/tests/test_radiation_new_physics.py
@@ -1,0 +1,63 @@
+import random
+import sys
+import types
+import math
+
+# Stub optional heavy dependencies used by radiation_model
+sys.modules.setdefault("amrex", types.ModuleType("amrex"))
+sys.modules.setdefault("adios2", types.ModuleType("adios2"))
+sys.modules.setdefault("h5py", types.ModuleType("h5py"))
+scipy_stub = types.ModuleType("scipy")
+interpolate_stub = types.ModuleType("interpolate")
+interpolate_stub.RegularGridInterpolator = lambda *a, **k: None
+scipy_stub.interpolate = interpolate_stub
+sys.modules.setdefault("scipy", scipy_stub)
+sys.modules.setdefault("scipy.interpolate", interpolate_stub)
+numba_stub = types.ModuleType("numba")
+numba_stub.njit = lambda *a, **k: (lambda f: f)
+numba_stub.prange = range
+sys.modules.setdefault("numba", numba_stub)
+
+import numpy_stub
+
+# provide small helpers missing from numpy_stub
+numpy_stub.np.any = lambda arr: any(arr)
+numpy_stub.np.linalg = types.SimpleNamespace(norm=lambda v: numpy_stub.sqrt(sum(x * x for x in v)))
+numpy_stub.np.arccos = math.acos
+numpy_stub.np.cos = math.cos
+numpy_stub.np.sin = math.sin
+numpy_stub.np.log = math.log
+sys.modules["numpy"] = numpy_stub.np
+np = numpy_stub.np
+
+from dpf2.simulation.radiation_model import Photon, RadiationModel, m_e, c
+
+
+def test_polarization_rotates_and_is_orthogonal():
+    random.seed(0)
+    p = Photon([0, 0, 0], [1, 0, 0], m_e * c ** 2, 0, polarization=[0, 1, 0])
+    p.scatter()
+    assert abs(np.dot(p.dir, p.polarization)) < 1e-12
+
+
+def test_pair_production_counts_pairs():
+    rm = RadiationModel.__new__(RadiationModel)
+    rm.pairs_created = 0
+    photon = Photon([0, 0, 0], [1, 0, 0], 3 * m_e * c ** 2, 0)
+    orig = random.random
+    random.random = lambda: 0.0
+    occurred = rm._pair_production(photon, dt=1e30)
+    random.random = orig
+    assert occurred
+    assert rm.pairs_created == 1
+
+
+def test_non_lte_population_time_dependence():
+    rm = RadiationModel.__new__(RadiationModel)
+    rm.level_pop = None
+    Te = np.ones((1, 1, 1))
+    ne = np.ones((1, 1, 1))
+    pop1 = rm._update_level_population(Te, ne, dt=1.0)
+    pop2 = rm._update_level_population(Te, ne, dt=1.0)
+    assert pop1[0][0][0] != pop2[0][0][0]
+


### PR DESCRIPTION
## Summary
- extend photon model to track polarization and rotate it during scattering
- add pair-production physics and non-LTE, time-dependent line transport
- add unit tests and performance benchmarks for new radiation features

## Testing
- `pytest tests/test_radiation_new_physics.py tests/performance/test_radiation_model_performance.py`

------
https://chatgpt.com/codex/tasks/task_e_68b9107a5ad4832a83bddeba603a8024