### PR TITLE
Add hybrid PIC solver integrating fluid and particle dynamics

### DIFF
--- a/src/dpf2/simulation/hybrid_pic_solver.py
+++ b/src/dpf2/simulation/hybrid_pic_solver.py
@@ -1,0 +1,147 @@
+"""Hybrid 2D/3D Particle-in-Cell module.
+
+This solver couples a fluid description with a particle description to
+capture kinetic effects while retaining a coarse fluid background.  The
+implementation focuses on two physical processes relevant to DPF
+simulations:
+
+* ``m=0`` interchange growth that can rapidly disrupt the plasma column.
+* Mechanism-based anomalous resistivity leading to voltage spikes.
+
+The solver exposes a :class:`~dpf2.core.bases.CouplingState` interface so
+that it may be connected to the existing external circuit model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+import numpy as np
+
+from ..core.bases import CouplingState, PlasmaSolverBase
+
+
+class _FluidSolver(Protocol):
+    """Minimal protocol for fluid solvers used by :class:`HybridPICSolver`."""
+
+    def step(self, state: Any, dt: float, current: float, voltage: float) -> Any:
+        ...
+
+
+class _ParticleSolver(Protocol):
+    """Minimal protocol for particle solvers used by :class:`HybridPICSolver`."""
+
+    def step(self, state: Any, dt: float, current: float, voltage: float) -> Any:
+        ...
+
+    def beam_current(self) -> float:  # pragma: no cover - trivial protocol
+        """Return the instantaneous beam current in Amperes."""
+        ...
+
+
+@dataclass
+class HybridPICSolver(PlasmaSolverBase):
+    """Hybrid fluid/PIC plasma solver.
+
+    Parameters
+    ----------
+    fluid:
+        Instance implementing the minimal fluid solver protocol.
+    particles:
+        Instance implementing the minimal particle solver protocol.
+    dim:
+        Problem dimensionality, either 2 or 3.  The default is three
+        dimensions.  Only basic geometry factors depend on ``dim``.
+    base_resistivity:
+        Background resistivity (Ohm·m) used in the anomalous resistivity
+        model.
+    J_crit:
+        Critical current density (A/m²) above which the anomalous
+        resistivity mechanism activates.
+    radius:
+        Characteristic plasma radius (m) used for ``m=0`` growth estimates.
+    """
+
+    fluid: _FluidSolver
+    particles: _ParticleSolver
+    dim: int = 3
+    base_resistivity: float = 1e-4
+    J_crit: float = 1e6
+    radius: float = 1e-2
+    circuit_feedback: CouplingState = field(init=False, default_factory=CouplingState)
+    last_voltage_spike: float = field(init=False, default=0.0)
+    last_beam_current: float = field(init=False, default=0.0)
+
+    def m0_growth(self, current: float, density: float) -> float:
+        """Estimate the linear ``m=0`` interchange growth rate.
+
+        The model is intentionally simplified but retains the expected
+        proportionality ``gamma ∝ I / (r * sqrt{ρ})``.
+        """
+
+        if density <= 0:
+            return 0.0
+        return abs(current) / (self.radius * np.sqrt(density))
+
+    def compute_anomalous_resistivity(self, J: float) -> tuple[float, float]:
+        """Return (eta, spike) for the given current density ``J``.
+
+        The anomalous resistivity follows a quadratic scaling once a
+        threshold current density is exceeded.  The corresponding voltage
+        spike ``eta * J`` is also returned.
+        """
+
+        if abs(J) <= self.J_crit:
+            return self.base_resistivity, 0.0
+        excess = abs(J) / self.J_crit
+        eta = self.base_resistivity * excess * excess
+        spike = eta * abs(J)
+        return eta, spike
+
+    def step(self, state: Any, dt: float, current: float, voltage: float) -> Any:
+        """Advance both fluid and particle descriptions.
+
+        The method updates the coupled solvers, evaluates ``m=0`` growth
+        and anomalous resistivity, and records the beam current reported by
+        the particle sub-system.  Circuit coupling is provided through
+        :class:`~dpf2.core.bases.CouplingState`.
+        """
+
+        # Advance constituent solvers.  State objects are forwarded
+        # verbatim to keep the interface lightweight.
+        fluid_state = self.fluid.step(state, dt, current, voltage)
+        particle_state = self.particles.step(state, dt, current, voltage)
+
+        # Simple cylindrical current density estimate.
+        area = np.pi * self.radius ** (2 if self.dim == 3 else 1)
+        J = current / max(area, 1e-12)
+
+        eta, spike = self.compute_anomalous_resistivity(J)
+        self.last_voltage_spike = spike
+        self.last_beam_current = self.particles.beam_current()
+
+        # A crude inductance model incorporating m=0 growth.  In practice
+        # this would be replaced by a full EM field solution.
+        density = 1.0  # kg/m^3 placeholder
+        growth = self.m0_growth(current, density)
+        Lp = self.radius * (1.0 + 0.1 * growth)
+        emf = eta * current
+
+        self.circuit_feedback = CouplingState(
+            Lp=Lp,
+            emf=emf,
+            current=current,
+            voltage=voltage,
+            back_reaction=spike,
+        )
+
+        # The solver does not maintain its own state; forward the tuple of
+        # the sub-solvers for potential external use.
+        return fluid_state, particle_state
+
+    def coupling_interface(self) -> CouplingState:  # pragma: no cover - simple
+        return self.circuit_feedback
+
+
+__all__ = ["HybridPICSolver"]

--- a/tests/test_hybrid_pic_solver.py
+++ b/tests/test_hybrid_pic_solver.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from dpf2.core.bases import CouplingState, PlasmaSolverBase
+from dpf2.simulation.hybrid_pic_solver import HybridPICSolver
+
+
+class FluidStub(PlasmaSolverBase):
+    """Minimal fluid solver used for testing."""
+
+    def step(self, state, dt, current, voltage):  # pragma: no cover - trivial
+        return state
+
+
+class ParticleStub:
+    def __init__(self, energies):
+        # ``numpy_stub.Array`` does not implement rich comparison so we store
+        # the energies as a simple list and perform comparisons manually.
+        self.energies = list(energies)
+
+    def step(self, state, dt, current, voltage):  # pragma: no cover - trivial
+        return state
+
+    def beam_current(self):
+        # Count particles exceeding 1 keV and scale by an arbitrary factor
+        return float(sum(1 for e in self.energies if e > 1.0))
+
+
+def test_hybrid_solver_coupling_and_diagnostics():
+    fluid = FluidStub()
+    particles = ParticleStub([0.5, 2.0, 3.0])
+    solver = HybridPICSolver(fluid, particles, dim=2, radius=0.01)
+
+    state = {}
+    solver.step(state, dt=1e-9, current=10.0, voltage=5.0)
+    feedback = solver.coupling_interface()
+
+    assert isinstance(feedback, CouplingState)
+    assert feedback.current == 10.0
+    assert solver.last_voltage_spike >= 0.0
+    assert solver.last_beam_current == 2.0
+
+


### PR DESCRIPTION
## Summary
- add HybridPICSolver combining fluid and particle solvers with m=0 growth and anomalous resistivity models
- expose CouplingState interface for circuit coupling and diagnostics
- cover solver coupling with unit test exercising voltage spike and beam current outputs

## Testing
- `pytest tests/test_hybrid_pic_solver.py`
- `pytest` *(fails: ImportError: cannot import name 'HallMHD' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68b9107fd7a0832a99d56bb66d25e80d