### PR TITLE
feat(gui): add project manager and tutorial

### DIFF
--- a/examples/yield_vs_pressure_tutorial.py
+++ b/examples/yield_vs_pressure_tutorial.py
@@ -1,0 +1,29 @@
+"""Yield vs. Pressure optimization tutorial.
+
+This script demonstrates how to perform a simple pressure sweep and overlay the
+resulting yields using :class:`dpf2.gui.ProjectManager`.
+
+The example intentionally uses a small parameter grid so that it can run quickly
+on modest hardware.  Each sweep performs two simulations with different anode
+radii at two pressures and then overlays the yield-versus-pressure trend.
+"""
+
+from dpf2.core.config import DPFConfig
+from dpf2.gui import ProjectManager
+
+
+def main() -> None:
+    cfg = DPFConfig()
+    manager = ProjectManager()
+
+    pressures = [0.5, 1.0]  # torr
+    for p in pressures:
+        cfg.initial_pressure = p
+        manager.run_sweep(f"pressure_{p}", cfg, "anode_radius", [0.01, 0.02])
+
+    manager.overlay_yield_pressure("yield_pressure.png")
+    manager.export_metrics("metrics.csv")
+
+
+if __name__ == "__main__":  # pragma: no cover - example script
+    main()

--- a/src/dpf2/gui/__init__.py
+++ b/src/dpf2/gui/__init__.py
@@ -1,0 +1,9 @@
+"""GUI utilities for DPF2."""
+
+from .project_manager import ProjectManager
+
+try:  # pragma: no cover - optional flask dependency
+    from .dashboard import launch
+    __all__ = ["ProjectManager", "launch"]
+except Exception:  # pragma: no cover - simplify when Flask missing
+    __all__ = ["ProjectManager"]

--- a/src/dpf2/gui/dashboard.py
+++ b/src/dpf2/gui/dashboard.py
@@ -1,0 +1,21 @@
+"""Utilities for launching the built-in web dashboard."""
+
+from ..web.app import create_app
+
+
+def launch(host: str = "127.0.0.1", port: int = 5000, **kwargs) -> None:
+    """Start the Flask-based dashboard.
+
+    Parameters
+    ----------
+    host, port:
+        Network location where the application should listen.
+    kwargs:
+        Additional keyword arguments forwarded to :func:`Flask.run`.
+    """
+
+    app = create_app()
+    app.run(host=host, port=port, **kwargs)
+
+
+__all__ = ["launch"]

--- a/src/dpf2/gui/project_manager.py
+++ b/src/dpf2/gui/project_manager.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+"""Simple project management utilities for parametric studies.
+
+This module provides a lightweight :class:`ProjectManager` class that wraps the
+existing optimization helpers in :mod:`dpf2.optimization.param_sweep` to ease
+running sweeps, comparing results and exporting metrics.  The class stores
+metrics from multiple sweeps which can then be overlaid or written to disk.
+"""
+
+from pathlib import Path
+import csv
+from typing import Dict, Iterable
+
+from ..core.config import DPFConfig
+from ..optimization.param_sweep import (
+    run_parametric_sweep,
+    compute_sweep_metrics,
+    plot_yield_pressure_overlay,
+)
+
+
+class ProjectManager:
+    """Manage simulation sweeps and KPI comparisons.
+
+    Examples
+    --------
+    >>> cfg = DPFConfig()
+    >>> pm = ProjectManager()
+    >>> pm.run_sweep("baseline", cfg, "initial_pressure", [0.5, 1.0])  # doctest: +SKIP
+    >>> pm.export_metrics("metrics.csv")  # doctest: +SKIP
+    """
+
+    def __init__(self) -> None:
+        self.metrics: Dict[str, Dict[float, Dict[str, float]]] = {}
+
+    def run_sweep(
+        self,
+        label: str,
+        base_config: DPFConfig,
+        parameter: str,
+        values: Iterable[float],
+        *,
+        output_dir: str | Path = "sweep_output",
+    ) -> Dict[float, Dict[str, float]]:
+        """Run a parametric sweep and store computed metrics.
+
+        Parameters
+        ----------
+        label:
+            Identifier for the sweep results.
+        base_config:
+            Base configuration to mutate for each sweep value.
+        parameter:
+            Name of :class:`~dpf2.core.config.DPFConfig` attribute to vary.
+        values:
+            Iterable of values for ``parameter``.
+        output_dir:
+            Directory where individual run results should be written.
+        """
+
+        results = run_parametric_sweep(base_config, parameter, values, output_dir=output_dir)
+        metrics = compute_sweep_metrics(base_config, results)
+        self.metrics[label] = metrics
+        return metrics
+
+    def overlay_yield_pressure(self, path: str | Path) -> Path:
+        """Generate a yield-versus-pressure overlay plot for stored metrics."""
+
+        return plot_yield_pressure_overlay(self.metrics, path)
+
+    def export_metrics(self, path: str | Path) -> Path:
+        """Export all stored metrics to a CSV file.
+
+        Parameters
+        ----------
+        path:
+            Destination path for the CSV file.
+        """
+
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["label", "parameter", "yield", "efficiency"])
+            for label, metrics in self.metrics.items():
+                for param_val, vals in metrics.items():
+                    writer.writerow([label, param_val, vals.get("yield", 0.0), vals.get("efficiency", 0.0)])
+        return path
+
+
+__all__ = ["ProjectManager"]

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+import pytest
+
+from dpf2.gui import ProjectManager
+
+
+def test_export_and_overlay(tmp_path):
+    pm = ProjectManager()
+    pm.metrics["run1"] = {0.5: {"yield": 1.0, "efficiency": 0.1}, 1.0: {"yield": 2.0, "efficiency": 0.2}}
+    pm.metrics["run2"] = {0.5: {"yield": 1.5, "efficiency": 0.15}, 1.0: {"yield": 2.5, "efficiency": 0.25}}
+
+    out_csv = pm.export_metrics(tmp_path / "metrics.csv")
+    assert out_csv.exists()
+    content = out_csv.read_text()
+    assert "run1" in content and "run2" in content
+
+    pytest.importorskip("matplotlib")
+    out_plot = pm.overlay_yield_pressure(tmp_path / "yield_pressure.png")
+    assert out_plot.exists()


### PR DESCRIPTION
## Summary
- add GUI `ProjectManager` for sweeps, KPI export, and yield-pressure overlays
- expose optional `launch` helper for starting existing web dashboard
- include yield vs pressure optimization tutorial and tests

## Testing
- `pytest tests/test_project_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b91084367c832aaccd65d53436d3ff