### PR TITLE
Add synthetic neutron spectrum utilities

### DIFF
--- a/config_templates/detector_layout.json
+++ b/config_templates/detector_layout.json
@@ -1,0 +1,5 @@
+{
+  "angles": [0.0, 90.0, 180.0],
+  "distance_m": 1.0,
+  "names": ["front", "side", "back"]
+}

--- a/examples/notebooks/neutron_spectra_comparison.ipynb
+++ b/examples/notebooks/neutron_spectra_comparison.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["# Neutron spectra comparison\n", "\n", "This notebook compares synthetic spectra with simple reference data."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dpf2.diagnostics.neutron_spectra import synthetic_tof_spectrum, angular_spectrum, anisotropy_metric, DetectorLayout\n",
+    "import numpy as np\n",
+    "\n",
+    "energies = [1.0, 2.0]\n",
+    "flux = [1.0, 1.0]\n",
+    "time_bins = [0.0, 1.0]\n",
+    "tof = synthetic_tof_spectrum(energies, flux, 1.0, time_bins)\n",
+    "reference_tof = [1.0]\n",
+    "print(\"ToF match:\", np.allclose(tof, reference_tof))\n",
+    "\n",
+    "layout = DetectorLayout(angles=[0.0, 90.0, 180.0], distance_m=1.0)\n",
+    "spectrum = angular_spectrum(layout.angles_deg(), base_yield=1.0, anisotropy=1.0)\n",
+    "reference = [2.0, 1.0, 0.0]\n",
+    "print(\"Angular match:\", np.allclose(spectrum, reference))\n",
+    "print(\"Anisotropy metric:\", anisotropy_metric(spectrum))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -43,6 +43,12 @@ from .plasma import (
     compute_eedf,
     save_eedf_hdf5,
 )
+from .neutron_spectra import (
+    DetectorLayout,
+    synthetic_tof_spectrum,
+    angular_spectrum,
+    anisotropy_metric,
+)
 
 
 def apply_noise(
@@ -98,6 +104,10 @@ __all__ = [
     "save_density_temperature_map_hdf5",
     "compute_eedf",
     "save_eedf_hdf5",
+    "DetectorLayout",
+    "synthetic_tof_spectrum",
+    "angular_spectrum",
+    "anisotropy_metric",
     "Diagnostics",
     "DetectorArrayGenerator",
     "OutputField",

--- a/src/dpf2/diagnostics/neutron_spectra.py
+++ b/src/dpf2/diagnostics/neutron_spectra.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from bisect import bisect_right
+from typing import Sequence, List
+import math
+
+# Neutron mass used for simple time-of-flight calculations (kg)
+M_N = 1.674e-27
+
+
+@dataclass
+class Detector:
+    """Simple representation of a neutron detector."""
+
+    angle_deg: float
+    distance_m: float
+    name: str
+
+
+@dataclass
+class DetectorLayout:
+    """Container describing a collection of detectors on a ring."""
+
+    angles: Sequence[float]
+    distance_m: float
+    names: Sequence[str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.distance_m <= 0:
+            raise ValueError("distance_m must be positive")
+        if self.names and len(self.names) != len(self.angles):
+            raise ValueError("names must match number of angles")
+        self.detectors: List[Detector] = []
+        for i, ang in enumerate(self.angles):
+            name = self.names[i] if self.names else f"detector_{i}"
+            self.detectors.append(Detector(float(ang), float(self.distance_m), name))
+
+    def angles_deg(self) -> List[float]:
+        """Return detector viewing angles in degrees."""
+
+        return [d.angle_deg for d in self.detectors]
+
+    def names_list(self) -> List[str]:
+        """Return detector names in layout order."""
+
+        return [d.name for d in self.detectors]
+
+
+def synthetic_tof_spectrum(
+    energies: Sequence[float],
+    flux: Sequence[float],
+    distance: float,
+    time_bins: Sequence[float],
+    m_n: float = M_N,
+) -> List[float]:
+    """Generate a simple neutron time-of-flight histogram.
+
+    Parameters
+    ----------
+    energies:
+        Monotonically increasing energy grid in joules.
+    flux:
+        Differential flux corresponding to ``energies``.
+    distance:
+        Source-to-detector distance in meters.
+    time_bins:
+        Edges of time-of-flight histogram bins in seconds.
+    m_n:
+        Neutron mass in kg.  Defaults to :data:`M_N`.
+
+    Returns
+    -------
+    list of float
+        Bin-integrated counts for the requested histogram.
+    """
+
+    if len(energies) != len(flux):
+        raise ValueError("energies and flux must be same length")
+    if any(time_bins[i] >= time_bins[i + 1] for i in range(len(time_bins) - 1)):
+        raise ValueError("time_bins must be monotonically increasing")
+    hist = [0.0 for _ in range(len(time_bins) - 1)]
+    for e1, e2, f1, f2 in zip(energies[:-1], energies[1:], flux[:-1], flux[1:]):
+        dE = e2 - e1
+        contrib = 0.5 * (f1 + f2) * dE
+        e_mid = 0.5 * (e1 + e2)
+        t = distance / math.sqrt(2.0 * e_mid / m_n)
+        idx = bisect_right(time_bins, t) - 1
+        if 0 <= idx < len(hist):
+            hist[idx] += contrib
+    return hist
+
+
+def angular_spectrum(
+    angles: Sequence[float],
+    base_yield: float,
+    anisotropy: float = 0.0,
+) -> List[float]:
+    """Create a simple angular yield spectrum using a cosine model."""
+
+    spectrum: List[float] = []
+    for ang in angles:
+        val = base_yield * (1.0 + anisotropy * math.cos(math.radians(ang)))
+        spectrum.append(float(val))
+    return spectrum
+
+
+def anisotropy_metric(values: Sequence[float]) -> float:
+    """Return a rudimentary anisotropy metric ``(max - min) / mean``."""
+
+    if not values:
+        return 0.0
+    mean = sum(float(v) for v in values) / len(values)
+    if mean == 0.0:
+        return 0.0
+    return (max(values) - min(values)) / mean
+
+
+__all__ = [
+    "Detector",
+    "DetectorLayout",
+    "synthetic_tof_spectrum",
+    "angular_spectrum",
+    "anisotropy_metric",
+]

--- a/tests/test_neutron_spectra.py
+++ b/tests/test_neutron_spectra.py
@@ -1,0 +1,26 @@
+from dpf2.diagnostics.neutron_spectra import (
+    synthetic_tof_spectrum,
+    angular_spectrum,
+    anisotropy_metric,
+    DetectorLayout,
+)
+
+
+def test_synthetic_tof_spectrum():
+    energies = [1.0, 2.0]
+    flux = [1.0, 1.0]
+    distance = 1.0
+    time_bins = [0.0, 1.0]
+    hist = synthetic_tof_spectrum(energies, flux, distance, time_bins)
+    assert len(hist) == 1
+    assert hist[0] == 1.0
+
+
+def test_angular_spectrum_and_anisotropy():
+    angles = [0.0, 90.0, 180.0]
+    spectrum = angular_spectrum(angles, base_yield=1.0, anisotropy=1.0)
+    assert spectrum == [2.0, 1.0, 0.0]
+    metric = anisotropy_metric(spectrum)
+    assert metric == 2.0
+    layout = DetectorLayout(angles=angles, distance_m=1.0)
+    assert layout.detectors[1].angle_deg == 90.0


### PR DESCRIPTION
## Summary
- implement synthetic neutron time-of-flight histogram generator and cosine-based angular spectra
- provide detector layout container and anisotropy metric helper
- add example notebook and configuration template for comparing spectra

## Testing
- `pytest tests/test_neutron_spectra.py tests/test_neutron_yield_diagnostics.py`


------
https://chatgpt.com/codex/tasks/task_e_68b91086b858832a8b85685d0c51aad6