### PR TITLE
Add basic UQ sampling, Bayesian calibration, and CLI utilities

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -60,6 +60,28 @@ dpf2 simulate -c examples/config.json -o results.json
 
 For an interactive walk-through, open the Jupyter notebook in the `examples/notebooks/quickstart.ipynb` file.
 
+## Uncertainty Quantification
+
+The simulator includes basic tools for exploring how input parameters
+affect key outputs.  Two sampling schemes are available: Latin hypercube
+(`lhs`) and Sobol sequences (`sobol`).  A sweep generates multiple
+configurations and records the peak current from each run:
+
+```bash
+dpf2 uq-sweep --config config.json \
+    --parameters '{"charging_voltage":[14000,16000]}' \
+    --method sobol --samples 8 --output sweep.json
+```
+
+Summary statistics can then be computed over the sweep results:
+
+```bash
+dpf2 uq-stats --input sweep.json
+```
+
+The `uq-stats` command prints the mean and standard deviation of the
+peak current across all simulated samples.
+
 ## Server Usage
 
 A lightweight Flask server is provided for remote execution. Install server extras and launch:

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -11,6 +11,8 @@ import tempfile
 import textwrap
 
 import click
+import numpy as np
+import statistics
 
 from dpf2.core.config import DPFConfig
 from dpf2.core.simulation import DPFSimulation
@@ -33,6 +35,7 @@ from dpf2.optimization.param_sweep import (
 )
 
 from dpf2.scaling_laws import sweep_yield_scaling
+from dpf2.uq.sampling import latin_hypercube, sobol_sample
 
 from .errors import format_error
 
@@ -682,6 +685,61 @@ def param_sweep_cmd(
         raise click.ClickException(format_error("SWEEP", str(e)))
 
     click.echo(f"Sweep complete. Results written to {output}")
+
+
+@main.command("uq-sweep")
+@click.option("--config", type=click.Path(exists=True, dir_okay=False), required=True)
+@click.option(
+    "--parameters",
+    type=str,
+    required=True,
+    help="JSON mapping of parameter bounds, e.g. '{\"capacitance\":[1e-6,5e-6]}'",
+)
+@click.option(
+    "--method", type=click.Choice(["lhs", "sobol"]), default="lhs", show_default=True
+)
+@click.option("--samples", type=int, default=4, show_default=True)
+@click.option("--output", type=click.Path(dir_okay=False), default="uq_results.json")
+def uq_sweep_cmd(
+    config: str, parameters: str, method: str, samples: int, output: str
+) -> None:
+    """Run a multi-parameter sweep using UQ sampling schemes."""
+
+    try:
+        cfg = DPFConfig.from_file(config)
+        bounds = json.loads(parameters)
+        sampler = latin_hypercube if method == "lhs" else sobol_sample
+        sample = sampler(bounds, samples)
+        results: list[dict[str, Any]] = []
+        names = list(bounds)
+        for row in sample:
+            params = {n: float(v) for n, v in zip(names, row)}
+            cfg_i = dataclasses.replace(cfg, **params)
+            sim = DPFSimulation(cfg_i)
+            _, currents, _ = sim.run()
+            results.append({"params": params, "peak_current": max(currents)})
+        Path(output).write_text(json.dumps(results, indent=2))
+    except Exception as e:
+        raise click.ClickException(format_error("UQ", str(e)))
+
+    click.echo(f"UQ sweep complete. Results written to {output}")
+
+
+@main.command("uq-stats")
+@click.option("--input", type=click.Path(exists=True, dir_okay=False), required=True)
+def uq_stats_cmd(input: str) -> None:
+    """Compute statistics from a UQ sweep results file."""
+
+    try:
+        data = json.loads(Path(input).read_text())
+        currents = [r["peak_current"] for r in data]
+        stats = {
+            "mean_peak_current": statistics.mean(currents),
+            "std_peak_current": statistics.pstdev(currents),
+        }
+        click.echo(json.dumps(stats))
+    except Exception as e:
+        raise click.ClickException(format_error("UQ", str(e)))
 
 
 @main.command("scaling")

--- a/src/dpf2/uq/__init__.py
+++ b/src/dpf2/uq/__init__.py
@@ -1,0 +1,6 @@
+"""Uncertainty quantification utilities."""
+
+from .sampling import latin_hypercube, sobol_sample
+from .calibration import bayesian_calibration
+
+__all__ = ["latin_hypercube", "sobol_sample", "bayesian_calibration"]

--- a/src/dpf2/uq/calibration.py
+++ b/src/dpf2/uq/calibration.py
@@ -1,0 +1,75 @@
+"""Bayesian calibration routines for model parameter inference."""
+from __future__ import annotations
+
+from typing import Callable, Dict, Tuple
+
+import numpy as np
+import random
+import math
+
+Bounds = Dict[str, Tuple[float, float]]
+
+
+def bayesian_calibration(
+    model: Callable[[np.ndarray], np.ndarray],
+    bounds: Bounds,
+    data: np.ndarray,
+    n_samples: int = 1000,
+    proposal_scale: float = 0.1,
+    seed: int | None = None,
+) -> Dict[str, np.ndarray]:
+    """Infer model parameters from experimental ``data`` using MCMC.
+
+    This implements a simple Metropolis-Hastings sampler with uniform
+    priors over ``bounds`` and a Gaussian likelihood assuming unit
+    variance.
+
+    Parameters
+    ----------
+    model:
+        Callable accepting an array of parameters and returning model
+        predictions aligned with ``data``.
+    bounds:
+        Mapping of parameter names to ``(min, max)`` bounds.
+    data:
+        Experimental measurements to calibrate against.
+    n_samples:
+        Number of MCMC samples to draw.
+    proposal_scale:
+        Standard deviation of the Gaussian proposal distribution as a
+        fraction of the parameter range.
+    seed:
+        Optional random seed for reproducibility.
+
+    Returns
+    -------
+    Dict[str, np.ndarray]
+        Dictionary mapping each parameter name to an array of posterior
+        samples.
+    """
+
+    rng = random.Random(seed)
+    names = list(bounds)
+    lower = np.array([bounds[n][0] for n in names])
+    upper = np.array([bounds[n][1] for n in names])
+    current = (lower + upper) / 2.0
+
+    def log_like(params: np.ndarray) -> float:
+        pred = np.asarray(model(params))
+        resid = data - pred
+        return -0.5 * np.dot(resid, resid)
+
+    samples = np.zeros((n_samples, len(names)))
+    current_logp = log_like(current)
+    widths = proposal_scale * (upper - lower)
+
+    for i in range(n_samples):
+        proposal = np.array([c + rng.gauss(0.0, w) for c, w in zip(current, widths)])
+        if all(lower[j] <= proposal[j] <= upper[j] for j in range(len(names))):
+            logp = log_like(proposal)
+            if math.log(rng.random()) < (logp - current_logp):
+                current = proposal
+                current_logp = logp
+        samples[i] = current
+
+    return {name: samples[:, idx] for idx, name in enumerate(names)}

--- a/src/dpf2/uq/sampling.py
+++ b/src/dpf2/uq/sampling.py
@@ -1,0 +1,88 @@
+"""Sampling schemes for uncertainty quantification."""
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import numpy as np
+import random
+
+try:  # pragma: no cover - optional dependency
+    from scipy.stats import qmc
+except Exception:  # pragma: no cover - fallback when SciPy not installed
+    qmc = None
+
+Bounds = Dict[str, Tuple[float, float]]
+
+
+def latin_hypercube(bounds: Bounds, n_samples: int, seed: int | None = None) -> np.ndarray:
+    """Generate samples using Latin hypercube sampling.
+
+    Parameters
+    ----------
+    bounds:
+        Mapping of parameter names to ``(min, max)`` tuples.
+    n_samples:
+        Number of samples to generate.
+    seed:
+        Optional seed for reproducibility.
+
+    Returns
+    -------
+    ``(n_samples, d)`` array of samples where ``d`` is the number of
+    parameters. Columns follow the order of ``bounds``.
+    """
+
+    names = list(bounds)
+    d = len(names)
+    if qmc is not None:
+        sampler = qmc.LatinHypercube(d=d, seed=seed)
+        sample = sampler.random(n_samples)
+    else:  # Basic LHS implementation using Python's random
+        rng = random.Random(seed)
+        sample = [[0.0] * d for _ in range(n_samples)]
+        for j, name in enumerate(names):
+            a, b = bounds[name]
+            intervals = [(i + rng.random()) / n_samples for i in range(n_samples)]
+            rng.shuffle(intervals)
+            for i, val in enumerate(intervals):
+                sample[i][j] = a + val * (b - a)
+        return np.array(sample)
+    lower = np.array([bounds[k][0] for k in names])
+    upper = np.array([bounds[k][1] for k in names])
+    return lower + sample * (upper - lower)
+
+
+def sobol_sample(bounds: Bounds, n_samples: int, seed: int | None = None) -> np.ndarray:
+    """Generate Sobol sequence samples.
+
+    Parameters
+    ----------
+    bounds:
+        Mapping of parameter names to ``(min, max)`` tuples.
+    n_samples:
+        Number of samples to generate.
+    seed:
+        Optional seed for reproducibility.
+
+    Returns
+    -------
+    ``(n_samples, d)`` array of samples in the order of ``bounds``.
+    """
+
+    names = list(bounds)
+    d = len(names)
+    if qmc is not None:
+        sampler = qmc.Sobol(d=d, scramble=True, seed=seed)
+        m = int(np.ceil(np.log2(n_samples)))
+        sample = sampler.random_base2(m)[:n_samples]
+        lower = np.array([bounds[k][0] for k in names])
+        upper = np.array([bounds[k][1] for k in names])
+        return lower + sample * (upper - lower)
+    else:  # Fall back to simple random sampling
+        rng = random.Random(seed)
+        sample = [[rng.random() for _ in range(d)] for _ in range(n_samples)]
+        for i in range(n_samples):
+            for j, name in enumerate(names):
+                a, b = bounds[name]
+                sample[i][j] = a + sample[i][j] * (b - a)
+        return np.array(sample)

--- a/tests/test_bayesian_calibration.py
+++ b/tests/test_bayesian_calibration.py
@@ -1,0 +1,22 @@
+import random
+import numpy as np
+
+from dpf2.uq.calibration import bayesian_calibration
+
+
+def test_bayesian_calibration_linear_model():
+    rng = random.Random(0)
+
+    def model(params):
+        a = params[0]
+        x = np.linspace(0, 1, 10)
+        return a * x
+
+    true_a = 2.0
+    x = np.linspace(0, 1, 10)
+    noise = np.array([rng.gauss(0, 0.01) for _ in x])
+    data = true_a * x + noise
+
+    samples = bayesian_calibration(model, {"a": (0.0, 4.0)}, data, n_samples=500, seed=0)
+    mean_a = sum(samples["a"]) / len(samples["a"])
+    assert abs(mean_a - true_a) < 0.5

--- a/tests/test_cli_uq.py
+++ b/tests/test_cli_uq.py
@@ -1,0 +1,52 @@
+import dataclasses
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from dpf2.core.config import DPFConfig
+from dpf2.cli import main as cli_main
+
+
+def test_uq_sweep_and_stats(tmp_path, monkeypatch):
+    class DummySim:
+        def __init__(self, cfg):
+            self.cfg = cfg
+
+        def run(self):
+            # Peak current proportional to charging voltage for predictability
+            return [0.0, 1.0], [self.cfg.charging_voltage * 1e-3], [0.0, 0.0]
+
+    monkeypatch.setattr(cli_main, "DPFSimulation", DummySim)
+
+    cfg = DPFConfig()
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(dataclasses.asdict(cfg)))
+
+    runner = CliRunner()
+    out_file = tmp_path / "results.json"
+    params = '{"charging_voltage":[10000,20000]}'
+    res = runner.invoke(
+        cli_main.main,
+        [
+            "uq-sweep",
+            "--config",
+            str(cfg_path),
+            "--parameters",
+            params,
+            "--samples",
+            "2",
+            "--method",
+            "lhs",
+            "--output",
+            str(out_file),
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert out_file.exists()
+
+    res2 = runner.invoke(cli_main.main, ["uq-stats", "--input", str(out_file)])
+    assert res2.exit_code == 0, res2.output
+    stats = json.loads(res2.output.strip())
+    assert "mean_peak_current" in stats
+    assert "std_peak_current" in stats

--- a/tests/test_uq_sampling.py
+++ b/tests/test_uq_sampling.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from dpf2.uq.sampling import latin_hypercube, sobol_sample
+
+
+def test_latin_hypercube_bounds():
+    bounds = {"a": (0.0, 1.0), "b": (-1.0, 1.0)}
+    samples = latin_hypercube(bounds, 4, seed=1)
+    assert samples.shape == (4, 2)
+    assert all(0 <= s <= 1 for s in samples[:, 0])
+    assert all(-1 <= s <= 1 for s in samples[:, 1])
+
+
+def test_sobol_sample_bounds():
+    bounds = {"x": (0.0, 2.0)}
+    samples = sobol_sample(bounds, 4, seed=2)
+    assert samples.shape == (4, 1)
+    assert all(0 <= s <= 2 for s in samples[:, 0])


### PR DESCRIPTION
## Summary
- add Latin hypercube and Sobol sampling utilities
- implement simple Bayesian calibration routine
- expose `uq-sweep` and `uq-stats` CLI commands and document in user guide

## Testing
- `pytest tests/test_uq_sampling.py tests/test_bayesian_calibration.py tests/test_cli_uq.py`


------
https://chatgpt.com/codex/tasks/task_e_68b91087bca4832abfc61ffaef79c2ba