### PR TITLE
Add DPF tutorial and snapshot sharing with instability visualization

### DIFF
--- a/examples/dpf_phase_tutorial.md
+++ b/examples/dpf_phase_tutorial.md
@@ -1,0 +1,22 @@
+# DPF Phase Tutorial
+
+This guide walks through the major phases of a Dense Plasma Focus (DPF) discharge.
+
+1. **Breakdown**
+   - Apply a high voltage across the electrodes.
+   - The fill gas ionizes and a conductive plasma forms.
+2. **Axial Acceleration**
+   - The plasma sheath accelerates down the anode, sweeping up mass.
+   - Keep track of sheath position and current evolution.
+3. **Radial Compression**
+   - The sheath reaches the end of the anode and collapses inward.
+   - Density and temperature rise rapidly during compression.
+4. **Pinch**
+   - Plasma attains peak compression; fusion reactions may occur.
+   - Diagnostics capture neutron yield and other signals.
+5. **Afterglow**
+   - Plasma expands and cools; instabilities may grow.
+   - Review results and adjust parameters for the next shot.
+
+For more hands-on exploration, load this tutorial into the web interface and experiment
+with exporting and importing configuration snapshots.

--- a/web/frontend/src/App.jsx
+++ b/web/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 import ProjectManager from './ProjectManager.jsx';
+import InstabilityVisualizer from './InstabilityVisualizer.jsx';
 
 export default function App() {
   const [token, setToken] = useState('');
@@ -32,6 +33,24 @@ export default function App() {
     await axios.post(`/update/${runId}`, { voltage: v, pressure: p }, { headers: { Authorization: `Bearer ${token}` } });
   };
 
+  const exportSnapshot = () => {
+    const blob = new Blob([config], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'snapshot.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const importSnapshot = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (evt) => setConfig(evt.target.result);
+    reader.readAsText(file);
+  };
+
   return (
     <div>
       {!token && (
@@ -59,6 +78,25 @@ export default function App() {
               scenario. It will be sent to the server and can be
               exported later for sharing.
             </details>
+            <div>
+              <input
+                type="file"
+                accept="application/json"
+                onChange={importSnapshot}
+                title="Import a configuration snapshot"
+              />
+              <button
+                type="button"
+                onClick={exportSnapshot}
+                title="Export the current configuration snapshot"
+              >
+                Export Snapshot
+              </button>
+              <details>
+                <summary>What is this?</summary>
+                Use snapshots to save or load simulation setups for sharing.
+              </details>
+            </div>
             <br />
             <button type="submit" title="Start the simulation run">Run</button>
           </form>
@@ -114,6 +152,7 @@ export default function App() {
               Represents ambient gas pressure; higher values damp the sheath faster.
             </details>
           </div>
+          <InstabilityVisualizer />
         </div>
       )}
     </div>

--- a/web/frontend/src/InstabilityVisualizer.jsx
+++ b/web/frontend/src/InstabilityVisualizer.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+export default function InstabilityVisualizer() {
+  const [points, setPoints] = useState([]);
+  const svgRef = useRef(null);
+
+  useEffect(() => {
+    const data = [];
+    for (let t = 0; t <= 1; t += 0.05) {
+      const amp = Math.sin(t * 6) * Math.exp(t * 2);
+      data.push({ t, amp });
+    }
+    setPoints(data);
+  }, []);
+
+  const pts = points
+    .map(({ t, amp }) => {
+      const x = t * 200;
+      const y = 100 - ((amp + 1) / 2) * 100;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  const download = () => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const blob = new Blob([svg.outerHTML], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'instability.svg';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="overlay" title="Illustrates a growing instability amplitude">
+      <h4>Instability Growth</h4>
+      <svg ref={svgRef} width="200" height="100">
+        <polyline points={pts} stroke="red" fill="none" />
+      </svg>
+      <button type="button" onClick={download} title="Download this visualization">Download</button>
+      <details>
+        <summary>What is this?</summary>
+        This synthetic plot depicts how an instability might grow during the
+        afterglow phase. Real simulations can export similar data.
+      </details>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Provide a step-by-step Dense Plasma Focus phase walkthrough in `examples/dpf_phase_tutorial.md`
- Enable JSON snapshot import/export in the web UI so setups can be shared
- Add an InstabilityVisualizer component with explanatory tooltips for viewing mock instability growth

## Testing
- `pytest tests/test_visualization.py` *(skipped: matplotlib not installed)*
- `npm install` *(fails: 403 Forbidden fetching @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b9108aa0f8832ab5b45c5c8e6b8fe3