### PR TITLE
feat(gui): interactive run manager and pinch metrics

### DIFF
--- a/src/dpf2/gui/__init__.py
+++ b/src/dpf2/gui/__init__.py
@@ -2,8 +2,16 @@
 
 from .project_manager import ProjectManager
 
+__all__ = ["ProjectManager"]
+
 try:  # pragma: no cover - optional flask dependency
     from .dashboard import launch
-    __all__ = ["ProjectManager", "launch"]
+    __all__.append("launch")
 except Exception:  # pragma: no cover - simplify when Flask missing
-    __all__ = ["ProjectManager"]
+    pass
+
+try:  # pragma: no cover - optional dash dependency
+    from .interactive import launch as launch_dash
+    __all__.append("launch_dash")
+except Exception:  # pragma: no cover - simplify when dash missing
+    pass

--- a/src/dpf2/gui/interactive.py
+++ b/src/dpf2/gui/interactive.py
@@ -1,0 +1,143 @@
+"""Dash-based interactive GUI for parametric studies.
+
+This module provides a lightweight web interface using Plotly Dash that
+exposes geometry presets, parameter sliders and run management utilities.  It
+builds upon :class:`dpf2.gui.project_manager.ProjectManager` and the parametric
+sweep helpers in :mod:`dpf2.optimization.param_sweep`.
+
+The interface is intentionally simple and is designed for exploratory studies
+rather than production work.  Dependencies are optional; if :mod:`dash` is not
+installed, an informative :class:`RuntimeError` is raised when attempting to
+launch the application.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from .project_manager import ProjectManager
+from ..core.config import DPFConfig
+from ..device_profiles import DeviceProfiles
+from ..optimization.param_sweep import run_parametric_sweep, compute_sweep_metrics
+
+try:  # pragma: no cover - optional dependency
+    import dash
+    from dash import Dash, dcc, html, Input, Output, State
+    import plotly.graph_objects as go
+except Exception:  # pragma: no cover - allow import without dash
+    Dash = None  # type: ignore[misc]
+
+
+def _ensure_dash() -> None:
+    """Raise if :mod:`dash` is unavailable."""
+
+    if Dash is None:  # pragma: no cover - exercised only when dash missing
+        raise RuntimeError("dash is required for the interactive GUI")
+
+
+def launch(host: str = "127.0.0.1", port: int = 8050) -> None:
+    """Launch the Dash-based GUI.
+
+    Parameters
+    ----------
+    host, port:
+        Network location where the server should listen.
+    """
+
+    _ensure_dash()
+
+    pm = ProjectManager()
+    app = Dash(__name__)
+
+    presets = DeviceProfiles.with_defaults().devices
+    preset_options = [
+        {"label": name, "value": name} for name in presets.keys()
+    ]
+
+    app.layout = html.Div(
+        [
+            html.H1("DPF2 GUI"),
+            dcc.Dropdown(id="preset", options=preset_options, placeholder="Geometry preset"),
+            dcc.Slider(5_000, 30_000, 1_000, value=10_000, id="voltage", tooltip={"placement": "bottom"}),
+            dcc.Slider(0.1, 5.0, 0.1, value=1.0, id="pressure", tooltip={"placement": "bottom"}),
+            html.Button("Sweep Voltage", id="sweep_voltage"),
+            html.Button("Sweep Pressure", id="sweep_pressure"),
+            html.Button("Overlay Runs", id="overlay_runs"),
+            html.Button("Export Metrics", id="export"),
+            dcc.Graph(id="metrics_plot"),
+        ]
+    )
+
+    def _make_config(preset: str | None, pressure: float, voltage: float) -> DPFConfig:
+        cfg = DPFConfig()
+        cfg.initial_pressure = pressure
+        cfg.charging_voltage = voltage
+        if preset and preset in presets:
+            dev = presets[preset]
+            cfg.anode_radius = dev.anode_radius_cm * 0.01
+            cfg.cathode_radius = dev.cathode_radius_cm * 0.01
+            cfg.electrode_length = dev.anode_length_cm * 0.01
+        return cfg
+
+    @app.callback(
+        Output("metrics_plot", "figure"),
+        Input("sweep_voltage", "n_clicks"),
+        Input("sweep_pressure", "n_clicks"),
+        Input("overlay_runs", "n_clicks"),
+        Input("export", "n_clicks"),
+        State("preset", "value"),
+        State("pressure", "value"),
+        State("voltage", "value"),
+        prevent_initial_call=True,
+    )
+    def _run_actions(v_clicks: int, p_clicks: int, o_clicks: int, e_clicks: int,
+                     preset: str | None, pressure: float, voltage: float):
+        ctx = dash.callback_context
+        if not ctx.triggered:
+            return go.Figure()
+        button_id = ctx.triggered[0]["prop_id"].split(".")[0]
+
+        if button_id == "export":
+            pm.export_metrics(Path("metrics.csv"))
+            return go.Figure()
+
+        if button_id == "overlay_runs":
+            fig = go.Figure()
+            for label, metrics in pm.metrics.items():
+                vals = sorted(metrics.keys())
+                fig.add_trace(go.Scatter(x=vals, y=[metrics[v]["yield"] for v in vals],
+                                         mode="lines+markers", name=f"{label} yield"))
+                fig.add_trace(go.Scatter(x=vals, y=[metrics[v]["pinch_time"] for v in vals],
+                                         mode="lines+markers", name=f"{label} pinch"))
+                fig.add_trace(go.Scatter(x=vals, y=[metrics[v]["efficiency"] for v in vals],
+                                         mode="lines+markers", name=f"{label} eff"))
+            return fig
+
+        cfg = _make_config(preset, pressure, voltage)
+
+        if button_id == "sweep_voltage":
+            values: List[float] = [voltage * f for f in [0.8, 1.0, 1.2]]
+            results = run_parametric_sweep(cfg, "charging_voltage", values)
+            metrics = compute_sweep_metrics(cfg, results)
+            pm.metrics[f"voltage_{len(pm.metrics)}"] = metrics
+            vals = sorted(metrics.keys())
+        else:
+            values = [pressure * f for f in [0.5, 1.0, 1.5]]
+            results = run_parametric_sweep(cfg, "initial_pressure", values)
+            metrics = compute_sweep_metrics(cfg, results)
+            pm.metrics[f"pressure_{len(pm.metrics)}"] = metrics
+            vals = sorted(metrics.keys())
+
+        fig = go.Figure()
+        fig.add_trace(go.Scatter(x=vals, y=[metrics[v]["yield"] for v in vals],
+                                 mode="lines+markers", name="yield"))
+        fig.add_trace(go.Scatter(x=vals, y=[metrics[v]["pinch_time"] for v in vals],
+                                 mode="lines+markers", name="pinch time"))
+        fig.add_trace(go.Scatter(x=vals, y=[metrics[v]["efficiency"] for v in vals],
+                                 mode="lines+markers", name="efficiency"))
+        return fig
+
+    app.run_server(host=host, port=port)
+
+
+__all__ = ["launch"]

--- a/src/dpf2/gui/project_manager.py
+++ b/src/dpf2/gui/project_manager.py
@@ -69,8 +69,41 @@ class ProjectManager:
 
         return plot_yield_pressure_overlay(self.metrics, path)
 
+    def overlay_metrics(self, parameter: str, path: str | Path) -> Path:
+        """Overlay yield, pinch time and efficiency curves for stored sweeps."""
+
+        import matplotlib.pyplot as plt
+
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fig, axes = plt.subplots(3, 1, sharex=True, figsize=(6, 9))
+
+        for label, metrics in self.metrics.items():
+            vals = sorted(metrics.keys())
+            y = [metrics[v].get("yield", 0.0) for v in vals]
+            p = [metrics[v].get("pinch_time", 0.0) for v in vals]
+            e = [metrics[v].get("efficiency", 0.0) for v in vals]
+            axes[0].plot(vals, y, label=label)
+            axes[1].plot(vals, p, label=label)
+            axes[2].plot(vals, e, label=label)
+
+        axes[0].set_ylabel("Yield")
+        axes[1].set_ylabel("Pinch Time")
+        axes[2].set_ylabel("Efficiency")
+        axes[2].set_xlabel(parameter)
+        for ax in axes:
+            ax.grid(True)
+            ax.legend()
+        fig.tight_layout()
+        fig.savefig(path)
+        plt.close(fig)
+        return path
+
     def export_metrics(self, path: str | Path) -> Path:
         """Export all stored metrics to a CSV file.
+
+        The resulting table contains the sweep label, parameter value and the
+        computed ``yield``, ``pinch_time`` and ``efficiency`` metrics.
 
         Parameters
         ----------
@@ -82,10 +115,16 @@ class ProjectManager:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w", newline="") as f:
             writer = csv.writer(f)
-            writer.writerow(["label", "parameter", "yield", "efficiency"])
+            writer.writerow(["label", "parameter", "yield", "pinch_time", "efficiency"])
             for label, metrics in self.metrics.items():
                 for param_val, vals in metrics.items():
-                    writer.writerow([label, param_val, vals.get("yield", 0.0), vals.get("efficiency", 0.0)])
+                    writer.writerow([
+                        label,
+                        param_val,
+                        vals.get("yield", 0.0),
+                        vals.get("pinch_time", 0.0),
+                        vals.get("efficiency", 0.0),
+                    ])
         return path
 
 

--- a/src/dpf2/optimization/param_sweep.py
+++ b/src/dpf2/optimization/param_sweep.py
@@ -91,7 +91,7 @@ def plot_sweep_results(
 def compute_sweep_metrics(
     base_config: DPFConfig, results: Dict[float, SweepResult]
 ) -> Dict[float, Dict[str, float]]:
-    """Compute simple yield and efficiency estimates for sweep results.
+    """Compute simple yield, pinch time and efficiency estimates for sweep results.
 
     Parameters
     ----------
@@ -104,9 +104,10 @@ def compute_sweep_metrics(
     Returns
     -------
     Dict[float, Dict[str, float]]
-        Mapping of parameter value to metrics ``{"yield", "efficiency"}``.
-        Yield is estimated as the peak current, while efficiency is the ratio
-        of the time-integrated ``I*V`` product to the initial stored energy.
+        Mapping of parameter value to metrics ``{"yield", "pinch_time",
+        "efficiency"}``.  Yield is estimated as the peak current, pinch time is
+        the time at which the peak current occurs and efficiency is the ratio of
+        the time-integrated ``I*V`` product to the initial stored energy.
     """
 
     import numpy as np
@@ -121,8 +122,14 @@ def compute_sweep_metrics(
         power = i_arr * v_arr
         energy_out = float(np.trapz(power, t_arr))
         efficiency = energy_out / energy_in if energy_in else 0.0
-        yield_est = float(i_arr.max())
-        metrics[val] = {"yield": yield_est, "efficiency": efficiency}
+        peak_idx = int(i_arr.argmax()) if len(i_arr) else 0
+        yield_est = float(i_arr[peak_idx])
+        pinch_time = float(t_arr[peak_idx]) if len(t_arr) else 0.0
+        metrics[val] = {
+            "yield": yield_est,
+            "efficiency": efficiency,
+            "pinch_time": pinch_time,
+        }
 
     return metrics
 
@@ -132,26 +139,29 @@ def plot_metric_overlay(
     metrics: Dict[float, Dict[str, float]],
     path: str | Path,
 ) -> Path:
-    """Plot yield and efficiency against the swept parameter on shared axes."""
+    """Plot yield, pinch time and efficiency against a swept parameter."""
 
     import matplotlib.pyplot as plt
 
     vals = sorted(metrics.keys())
     yields = [metrics[v]["yield"] for v in vals]
+    pinch = [metrics[v].get("pinch_time", 0.0) for v in vals]
     effs = [metrics[v]["efficiency"] for v in vals]
 
-    fig, ax1 = plt.subplots()
-    color1 = "tab:blue"
-    ax1.set_xlabel(parameter)
-    ax1.set_ylabel("Yield", color=color1)
-    ax1.plot(vals, yields, color=color1, marker="o", label="yield")
-    ax1.tick_params(axis="y", labelcolor=color1)
+    fig, axes = plt.subplots(3, 1, sharex=True, figsize=(6, 9))
 
-    ax2 = ax1.twinx()
-    color2 = "tab:orange"
-    ax2.set_ylabel("Efficiency", color=color2)
-    ax2.plot(vals, effs, color=color2, marker="s", label="efficiency")
-    ax2.tick_params(axis="y", labelcolor=color2)
+    axes[0].plot(vals, yields, marker="o")
+    axes[0].set_ylabel("Yield")
+
+    axes[1].plot(vals, pinch, marker="^")
+    axes[1].set_ylabel("Pinch Time")
+
+    axes[2].plot(vals, effs, marker="s")
+    axes[2].set_ylabel("Efficiency")
+    axes[2].set_xlabel(parameter)
+
+    for ax in axes:
+        ax.grid(True)
 
     fig.tight_layout()
     path = Path(path)

--- a/tests/test_param_sweep.py
+++ b/tests/test_param_sweep.py
@@ -6,7 +6,11 @@ from pathlib import Path
 import h5py_stub  # noqa: F401  ensures stub is registered before importing modules
 
 from dpf2.core.config import DPFConfig
-from dpf2.optimization.param_sweep import plot_sweep_results, run_parametric_sweep
+from dpf2.optimization.param_sweep import (
+    plot_sweep_results,
+    run_parametric_sweep,
+    compute_sweep_metrics,
+)
 import pytest
 pytest.importorskip("matplotlib")
 
@@ -19,3 +23,12 @@ def test_parametric_sweep(tmp_path: Path) -> None:
     plot_path = tmp_path / "plot.png"
     plot_sweep_results("charging_voltage", results, plot_path)
     assert plot_path.exists()
+
+
+def test_compute_sweep_metrics_includes_pinch(tmp_path: Path) -> None:
+    cfg = DPFConfig()
+    values = [10_000.0, 15_000.0]
+    results = run_parametric_sweep(cfg, "charging_voltage", values, output_dir=tmp_path)
+    metrics = compute_sweep_metrics(cfg, results)
+    for val in values:
+        assert "pinch_time" in metrics[val]


### PR DESCRIPTION
## Summary
- extend sweep metrics with pinch time and updated overlay plotting
- add project manager helpers for overlaying metrics and exporting pinch data
- introduce optional Dash-based GUI with geometry presets and sliders

## Testing
- `pytest tests/test_param_sweep.py -q` *(fails: matplotlib missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b914dd92dc832a9915db7975869977