### PR TITLE
Enhance neutron diagnostics with yield components and detector models

### DIFF
--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -14,11 +14,18 @@ from .neutron_yield import (
     compute_neutron_yield,
     compute_beam_target_yield,
     compute_thermonuclear_yield,
+    yield_components_with_anisotropy,
     save_anisotropic_spectrum_hdf5,
     simulate_tof_detectors,
     save_tof_hdf5,
+    tof_iv_cross_correlation,
     angular_yield_map,
     save_angular_yield_map_hdf5,
+)
+from .detector_models import (
+    cr39_response,
+    rcf_response,
+    time_gated_scintillator_response,
 )
 from .xray_spectra import compute_xray_spectrum
 from .scope_trace import compute_scope_trace
@@ -76,9 +83,11 @@ __all__ = [
     "compute_neutron_yield",
     "compute_beam_target_yield",
     "compute_thermonuclear_yield",
+    "yield_components_with_anisotropy",
     "save_anisotropic_spectrum_hdf5",
     "simulate_tof_detectors",
     "save_tof_hdf5",
+    "tof_iv_cross_correlation",
     "angular_yield_map",
     "save_angular_yield_map_hdf5",
     "compute_xray_spectrum",
@@ -104,6 +113,9 @@ __all__ = [
     "save_density_temperature_map_hdf5",
     "compute_eedf",
     "save_eedf_hdf5",
+    "cr39_response",
+    "rcf_response",
+    "time_gated_scintillator_response",
     "DetectorLayout",
     "synthetic_tof_spectrum",
     "angular_spectrum",

--- a/src/dpf2/diagnostics/detector_models.py
+++ b/src/dpf2/diagnostics/detector_models.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Sequence, List
+
+import math
+
+
+def _solid_angle(area: float, distance: float) -> float:
+    """Return the small-angle approximation for detector solid angle."""
+    if area <= 0 or distance <= 0:
+        raise ValueError("area and distance must be positive")
+    return area / (distance ** 2)
+
+
+def cr39_response(yields: Sequence[float], area: float, distance: float) -> List[float]:
+    """Estimate track density for a CR-39/RCF detector."""
+    sa = _solid_angle(area, distance)
+    return [float(y) * sa for y in yields]
+
+
+# RCF shares the same simple model as CR-39; provide a convenience alias
+rcf_response = cr39_response
+
+
+def time_gated_scintillator_response(
+    hist: Sequence[float],
+    time_bins: Sequence[float],
+    gate_start: float,
+    gate_end: float,
+    area: float,
+    distance: float,
+) -> float:
+    """Integrate a TOF histogram within a gating window and apply geometry."""
+    if len(time_bins) != len(hist) + 1:
+        raise ValueError("time_bins must bracket histogram bins")
+    if gate_start > gate_end:
+        raise ValueError("gate_start must be <= gate_end")
+    sa = _solid_angle(area, distance)
+    total = 0.0
+    for i, val in enumerate(hist):
+        t_mid = (time_bins[i] + time_bins[i + 1]) / 2.0
+        if gate_start <= t_mid <= gate_end:
+            total += float(val)
+    return total * sa
+
+
+__all__ = [
+    "cr39_response",
+    "rcf_response",
+    "time_gated_scintillator_response",
+]

--- a/src/dpf2/diagnostics/neutron_yield.py
+++ b/src/dpf2/diagnostics/neutron_yield.py
@@ -140,6 +140,62 @@ def compute_thermonuclear_yield(
     return compute_neutron_yield(rate, dt)
 
 
+def yield_components_with_anisotropy(
+    ion_edf: IonBeamEDF,
+    cross_section: Callable[[float], float],
+    angles: Sequence[float],
+    distance: float,
+    time_bins: Sequence[float],
+    reactivity: Sequence[float],
+    ion_density: Sequence[float],
+    dt: float,
+) -> Dict[str, List[float] | float]:
+    """Return beam-target and thermal yields with angular distribution.
+
+    The beam-target component is computed for each detector angle using
+    :func:`compute_beam_target_yield` while the thermonuclear component is
+    treated as isotropic.  An anisotropy factor ``(max-min)/mean`` is also
+    returned for the combined per-angle yields.
+
+    Parameters
+    ----------
+    ion_edf, cross_section, angles, distance, time_bins:
+        Inputs forwarded to :func:`compute_beam_target_yield`.
+    reactivity, ion_density, dt:
+        Inputs forwarded to :func:`compute_thermonuclear_yield`.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys ``"beam_target"`` (list per angle),
+        ``"thermonuclear"`` (total yield), ``"angular_thermal"`` (list per
+        angle assuming isotropy) and ``"anisotropy"`` (float).
+    """
+
+    bt_yields, tofs = compute_beam_target_yield(
+        ion_edf, cross_section, angles, distance, time_bins
+    )
+    th_total = compute_thermonuclear_yield(reactivity, ion_density, dt)
+    # distribute thermal yield isotropically across angles
+    th_per_angle = [th_total / float(len(angles)) for _ in angles] if angles else []
+    total_per_angle = [b + t for b, t in zip(bt_yields, th_per_angle)]
+    if total_per_angle:
+        mean = sum(total_per_angle) / len(total_per_angle)
+        if mean == 0.0:
+            anisotropy = 0.0
+        else:
+            anisotropy = (max(total_per_angle) - min(total_per_angle)) / mean
+    else:
+        anisotropy = 0.0
+    return {
+        "beam_target": bt_yields,
+        "thermonuclear": th_total,
+        "angular_thermal": th_per_angle,
+        "anisotropy": anisotropy,
+        "tof": tofs,
+    }
+
+
 def simulate_tof_detectors(
     ion_edf: IonBeamEDF,
     cross_section: Callable[[float], float],
@@ -262,6 +318,31 @@ def save_tof_hdf5(
             ds.attrs["unitSI"] = 1.0
 
 
+def tof_iv_cross_correlation(
+    tof: Sequence[float],
+    current: Sequence[float],
+    voltage: Sequence[float],
+) -> Dict[str, float]:
+    """Return zero-lag correlation between TOF signal and I/V traces."""
+
+    if not (len(tof) == len(current) == len(voltage)):
+        raise ValueError("signals must have the same length")
+
+    def _corr(a: Sequence[float], b: Sequence[float]) -> float:
+        mean_a = sum(a) / len(a)
+        mean_b = sum(b) / len(b)
+        num = sum((x - mean_a) * (y - mean_b) for x, y in zip(a, b))
+        den = math.sqrt(
+            sum((x - mean_a) ** 2 for x in a) * sum((y - mean_b) ** 2 for y in b)
+        )
+        return num / den if den != 0 else 0.0
+
+    return {
+        "current": _corr(tof, current),
+        "voltage": _corr(tof, voltage),
+    }
+
+
 def angular_yield_map(
     ion_edf: IonBeamEDF,
     cross_section: Callable[[float], float],
@@ -305,9 +386,11 @@ __all__ = [
     "compute_neutron_yield",
     "compute_beam_target_yield",
     "compute_thermonuclear_yield",
+    "yield_components_with_anisotropy",
     "save_anisotropic_spectrum_hdf5",
     "simulate_tof_detectors",
     "save_tof_hdf5",
+    "tof_iv_cross_correlation",
     "angular_yield_map",
     "save_angular_yield_map_hdf5",
 ]

--- a/tests/test_neutron_yield_diagnostics.py
+++ b/tests/test_neutron_yield_diagnostics.py
@@ -6,6 +6,13 @@ from dpf2.diagnostics.neutron_yield import (
     compute_beam_target_yield,
     compute_thermonuclear_yield,
     save_anisotropic_spectrum_hdf5,
+    yield_components_with_anisotropy,
+    tof_iv_cross_correlation,
+)
+from dpf2.diagnostics.detector_models import (
+    cr39_response,
+    rcf_response,
+    time_gated_scintillator_response,
 )
 
 
@@ -43,3 +50,57 @@ def test_save_anisotropic_spectrum_hdf5(tmp_path):
         np.testing.assert_allclose(fh["angle_deg"][:], angles)
         for i, row in enumerate(spectrum):
             np.testing.assert_allclose(fh[f"detectors/detector_{i}"][:], row)
+
+
+def test_yield_components_and_anisotropy():
+    beam = _TestBeam()
+    cross_section = lambda e: e
+    angles = [0.0, 90.0]
+    distance = 1.0
+    time_bins = [0.0, 1.0]
+    reactivity = [1e-20, 1e-20]
+    ion_density = [1e19, 1e19]
+    dt = 1e-6
+    result = yield_components_with_anisotropy(
+        beam,
+        cross_section,
+        angles,
+        distance,
+        time_bins,
+        reactivity,
+        ion_density,
+        dt,
+    )
+    bt, _ = compute_beam_target_yield(beam, cross_section, angles, distance, time_bins)
+    th = compute_thermonuclear_yield(reactivity, ion_density, dt)
+    th_per = [th / 2.0, th / 2.0]
+    total = [b + t for b, t in zip(bt, th_per)]
+    mean = sum(total) / 2.0
+    expected_aniso = (max(total) - min(total)) / mean if mean else 0.0
+    assert result["beam_target"] == bt
+    assert result["thermonuclear"] == th
+    assert result["angular_thermal"] == th_per
+    assert result["anisotropy"] == expected_aniso
+
+
+def test_detector_models():
+    yields = [10.0, 20.0]
+    area = 1e-4
+    distance = 1.0
+    expected = [y * area / distance ** 2 for y in yields]
+    assert cr39_response(yields, area, distance) == expected
+    assert rcf_response(yields, area, distance) == expected
+
+    hist = [1.0, 2.0, 3.0]
+    bins = [0.0, 1.0, 2.0, 3.0]
+    count = time_gated_scintillator_response(hist, bins, 0.0, 3.0, area, distance)
+    assert count == sum(hist) * area / distance ** 2
+
+
+def test_tof_iv_cross_correlation():
+    tof = [1.0, 2.0, 3.0]
+    current = [1.0, 2.0, 3.0]
+    voltage = [3.0, 2.0, 1.0]
+    corr = tof_iv_cross_correlation(tof, current, voltage)
+    assert np.isclose(corr["current"], 1.0)
+    assert np.isclose(corr["voltage"], -1.0)


### PR DESCRIPTION
## Summary
- Separate beam-target and thermonuclear yield calculations with automatic anisotropy estimation
- Add CR-39/RCF and time-gated scintillator detector response models
- Provide zero-lag cross-correlation of TOF signals with current and voltage traces

## Testing
- `venv/bin/pytest tests/test_neutron_yield_diagnostics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b914e10db4832a99a3283cbfa17aa2