### PR TITLE
feat(cli): add lab mode manifest utilities

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,8 +16,10 @@ specified output directory.
 
 Most commands accept the ``--lab-mode`` flag to capture a manifest for
 reproducibility. The manifest records the current code hash, RNG seeds,
-particle-per-cell setting and any configuration file paths. The file is
-written as ``manifest.json`` inside the command's output directory.
+particle-per-cell setting and any configuration file paths. Both
+``manifest.json`` and an accompanying ``manifest.h5`` (with the same
+metadata stored as HDF5 attributes) are written inside the command's
+output directory.
 
 ```
 dpf2 simulate -c config.json -o output_dir --lab-mode

--- a/examples/hpc/README.md
+++ b/examples/hpc/README.md
@@ -11,8 +11,8 @@ paths and particle-per-cell settings for reproducibility.
   directory and launches ``dpf2 simulate`` with ``--lab-mode`` using
   ``srun``. The ``CUDA_VISIBLE_DEVICES`` environment variable may be set by
   the :class:`~dpf2.hpc.JobManager` to pin the job to specific GPUs. A
-  ``manifest.json`` file is written inside the run directory capturing
-  reproducibility metadata.
+  ``manifest.json`` and ``manifest.h5`` files are written inside the run
+  directory capturing reproducibility metadata.
 
 * ``slurm_restart.sh`` – similar to ``slurm_run.sh`` but demonstrates how
   to restart from a checkpoint while still capturing a manifest with

--- a/examples/hpc/slurm_restart.sh
+++ b/examples/hpc/slurm_restart.sh
@@ -18,6 +18,7 @@ cp "$checkpoint" "$tmp/"
 cd "$tmp"
 
 # Restart the simulation from the checkpoint using the CLI and record a manifest
+# in ``restart_run/manifest.json`` and ``restart_run/manifest.h5``
 chk_file=$(basename "$checkpoint")
 echo "Restarting from $chk_file"
 srun dpf2 simulate --config config.json --output restart_run --lab-mode

--- a/examples/hpc/slurm_run.sh
+++ b/examples/hpc/slurm_run.sh
@@ -11,9 +11,10 @@ tmp=${SLURM_TMPDIR:-$(mktemp -d)}
 cp $SLURM_SUBMIT_DIR/examples/config.json "$tmp/"
 cd "$tmp"
 
-# Execute the simulation using the CLI with lab-mode manifest.
-# GPU affinity can be controlled by setting ``CUDA_VISIBLE_DEVICES`` prior to
-# submission (e.g. via the JobManager).
+# Execute the simulation using the CLI with lab-mode manifest. This creates
+# ``run/manifest.json`` and ``run/manifest.h5`` capturing reproducibility
+# metadata. GPU affinity can be controlled by setting ``CUDA_VISIBLE_DEVICES``
+# prior to submission (e.g. via the JobManager).
 srun dpf2 simulate --config config.json --output run --lab-mode
 
 # Collect output data back to the submission directory

--- a/src/dpf2/cli/lab.py
+++ b/src/dpf2/cli/lab.py
@@ -1,6 +1,5 @@
 """Utilities for lab-mode reproducibility manifests."""
 from __future__ import annotations
-
 import json
 import subprocess
 import random
@@ -9,8 +8,14 @@ from typing import Sequence, Mapping
 
 import numpy as np
 
+try:  # pragma: no cover - optional dependency
+    import h5py
+except Exception:  # pragma: no cover - h5py may be absent
+    h5py = None  # type: ignore[assignment]
+
 
 MANIFEST_FILENAME = "manifest.json"
+MANIFEST_H5_FILENAME = "manifest.h5"
 
 
 def _code_hash() -> str:
@@ -64,6 +69,18 @@ def write_manifest(
 
     path = out / MANIFEST_FILENAME
     path.write_text(json.dumps(manifest, indent=2))
+
+    if h5py is not None:  # pragma: no cover - only when h5py available
+        h5_path = out / MANIFEST_H5_FILENAME
+        with h5py.File(h5_path, "w") as h5:
+            for key, value in manifest.items():
+                if isinstance(value, (dict, list)):
+                    h5.attrs[key] = json.dumps(value)
+                elif value is None:
+                    h5.attrs[key] = "null"
+                else:
+                    h5.attrs[key] = value
+
     return path
 
-__all__ = ["write_manifest", "MANIFEST_FILENAME"]
+__all__ = ["write_manifest", "MANIFEST_FILENAME", "MANIFEST_H5_FILENAME"]

--- a/src/dpf2/cli/legacy_cli.py
+++ b/src/dpf2/cli/legacy_cli.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import random
 from pathlib import Path
+
+import numpy as np
 
 from ..dpf_config import DPFConfig
 
 from ..simulation_engine import SimulationEngine
+from .lab import write_manifest
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -24,6 +28,11 @@ def build_parser() -> argparse.ArgumentParser:
         default="analytic",
         help="Pinch dynamics model",
     )
+    sim.add_argument(
+        "--lab-mode",
+        action="store_true",
+        help="Record a reproducibility manifest alongside outputs",
+    )
     return parser
 
 
@@ -34,8 +43,22 @@ def main(argv: list[str] | None = None) -> None:
     if args.command == "simulate":
         cfg = DPFConfig.from_file(args.config)
         engine = SimulationEngine(cfg)
+        if args.lab_mode:
+            seeds = {
+                "python": random.getstate()[1][0],
+                "numpy": int(np.random.get_state()[1][0]),
+            }
         results = engine.run(method=args.method, pinch_model=args.pinch_model)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(json.dumps(results.to_dict(), indent=2))
+        if args.lab_mode:
+            ppc = getattr(getattr(cfg, "warpx_settings", None), "max_particles_per_cell", None)
+            write_manifest(
+                args.output.parent,
+                config_paths=[str(args.config)],
+                ppc=ppc,
+                seeds=seeds,
+            )
     else:
         parser.print_help()
 

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -585,13 +585,19 @@ def simulate(
 @click.option("--config", type=click.Path(exists=True, dir_okay=False), required=True)
 @click.option("--dataset", type=str, required=True)
 @click.option("--outdir", type=click.Path(file_okay=False), default="validation")
-def validate(config: str, dataset: str, outdir: str) -> None:
+@click.pass_context
+def validate(ctx: click.Context, config: str, dataset: str, outdir: str) -> None:
     """Run a validation simulation and compare with experimental data."""
     from .validate import run_validation
     try:
         from .validate import run_validation
 
-        ok = run_validation(Path(config), dataset, outdir=Path(outdir))
+        ok = run_validation(
+            Path(config),
+            dataset,
+            outdir=Path(outdir),
+            lab_mode=ctx.obj.get("lab_mode", False),
+        )
         if not ok:
             raise click.ClickException(format_error("VALIDATION", "Validation failed"))
     except Exception as e:  # pragma: no cover - defensive

--- a/src/dpf2/cli/validate.py
+++ b/src/dpf2/cli/validate.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import random
 from pathlib import Path
 from typing import Dict, Iterable, Tuple
 
@@ -26,6 +27,7 @@ from ..dpf_config import DPFConfig
 from ..simulation_engine import SimulationEngine, SimulationResults
 from ..validation_suite import ValidationSuite, score_simulation
 from ..scaling_laws import compare_to_scaling
+from .lab import write_manifest
 
 
 # ---------------------------------------------------------------------------
@@ -106,7 +108,13 @@ def _plot_overlays(
 # ---------------------------------------------------------------------------
 # Public API
 
-def run_validation(config: Path, dataset: str, *, outdir: Path = Path("validation")) -> bool:
+def run_validation(
+    config: Path,
+    dataset: str,
+    *,
+    outdir: Path = Path("validation"),
+    lab_mode: bool = False,
+) -> bool:
     """Execute a simulation and validate against experimental data.
 
     Parameters
@@ -117,6 +125,8 @@ def run_validation(config: Path, dataset: str, *, outdir: Path = Path("validatio
         Identifier of the experimental dataset to use.
     outdir:
         Directory where overlay plots will be written.
+    lab_mode:
+        When ``True``, record a reproducibility manifest alongside outputs.
 
     Returns
     -------
@@ -126,6 +136,11 @@ def run_validation(config: Path, dataset: str, *, outdir: Path = Path("validatio
     """
     cfg = DPFConfig.from_file(config)
     engine = SimulationEngine(cfg)
+    if lab_mode:
+        seeds = {
+            "python": random.getstate()[1][0],
+            "numpy": int(np.random.get_state()[1][0]),
+        }
     results = engine.run()
 
     vsuite = _build_validation_suite(dataset)
@@ -162,6 +177,10 @@ def run_validation(config: Path, dataset: str, *, outdir: Path = Path("validatio
         with (outdir / "scaling_report.json").open("w") as fh:
             json.dump(metrics, fh, indent=2)
 
+    if lab_mode:
+        ppc = getattr(getattr(cfg, "warpx_settings", None), "max_particles_per_cell", None)
+        write_manifest(outdir, config_paths=[str(config)], ppc=ppc, seeds=seeds)
+
     for name, score in report["scores"].items():
         print(f"{name}: {score:.3f}")
 
@@ -192,8 +211,13 @@ def main(argv: Iterable[str] | None = None) -> None:
         default=Path("validation"),
         help="Directory to store overlay plots",
     )
+    parser.add_argument(
+        "--lab-mode",
+        action="store_true",
+        help="Record a reproducibility manifest alongside outputs",
+    )
     args = parser.parse_args(list(argv) if argv is not None else None)
-    run_validation(args.config, args.dataset, outdir=args.outdir)
+    run_validation(args.config, args.dataset, outdir=args.outdir, lab_mode=args.lab_mode)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- add lab-mode manifest writer that also stores HDF5 attributes
- enable `--lab-mode` for validation and legacy CLI commands
- document and showcase lab-mode in HPC submission scripts

## Testing
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b914e8874c832a9b72dac89a47c390