### PR TITLE
refactor: use shared pydantic compat utilities

### DIFF
--- a/src/dpf2/materials/models.py
+++ b/src/dpf2/materials/models.py
@@ -2,21 +2,9 @@ from __future__ import annotations
 
 from typing import ClassVar, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from ..utils import BaseModel, ConfigDict, Field
 
 from ..core_schema import to_camel_case
-
-
-# -----------------------------------------------------------------------------
-# Compatibility layer for Pydantic v1/v2 differences
-if not hasattr(BaseModel, "model_validate"):
-    BaseModel.model_validate = classmethod(lambda cls, d, **_: cls(**d))
-if not hasattr(BaseModel, "model_dump"):
-    BaseModel.model_dump = BaseModel.dict
-if not hasattr(BaseModel, "model_dump_json"):
-    BaseModel.model_dump_json = BaseModel.json
-if not hasattr(BaseModel, "model_copy"):
-    BaseModel.model_copy = BaseModel.copy
 
 
 class MaterialRef(BaseModel):

--- a/src/dpf2/utils/__init__.py
+++ b/src/dpf2/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility helpers for dpf2."""
 
-from .pydantic_compat import model_validator
+from .pydantic_compat import BaseModel, ConfigDict, Field, model_validator
 
-__all__ = ["model_validator"]
+__all__ = ["BaseModel", "ConfigDict", "Field", "model_validator"]

--- a/src/dpf2/utils/pydantic_compat.py
+++ b/src/dpf2/utils/pydantic_compat.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 try:  # pragma: no cover - use real pydantic when available
-    from pydantic import BaseModel, root_validator  # type: ignore
+    from pydantic import BaseModel, ConfigDict, Field, root_validator  # type: ignore
 except Exception:  # pragma: no cover - fallback to lightweight stubs
-    from pydantic_stub import BaseModel, root_validator  # type: ignore
+    from pydantic_stub import BaseModel, ConfigDict, Field, root_validator  # type: ignore
 
 
 def model_validator(*, mode: str = "after"):
@@ -73,4 +73,4 @@ if not hasattr(BaseModel, "model_copy"):
 
         BaseModel.model_copy = _copy  # type: ignore[attr-defined]
 
-__all__ = ["model_validator"]
+__all__ = ["BaseModel", "ConfigDict", "Field", "model_validator"]

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -1,12 +1,9 @@
 import pytest
 
-import pytest
-
-from dpf2.materials import (
-    MaterialLibrary,
-    ComponentMaterialState,
-    MaterialDamageModel,
-)
+from dpf2.materials.library import MaterialLibrary
+from dpf2.materials.state import ComponentMaterialState
+from dpf2.materials.mdm import MaterialDamageModel
+from dpf2.materials import MaterialRef
 
 
 def test_material_lookup():
@@ -48,3 +45,16 @@ def test_state_serialization_roundtrip():
     assert restored.erosion == pytest.approx(1.0)
     assert restored.film_thickness == pytest.approx(0.2)
     assert restored.temperature_history == [300.0, 310.0]
+
+
+def test_materialref_alias_roundtrip():
+    ref = MaterialRef(material_id="copper", coating_id="nickel")
+    dumped = ref.model_dump(by_alias=True)
+    assert dumped.get("materialId", dumped.get("material_id")) == "copper"
+    assert dumped.get("coatingId", dumped.get("coating_id")) == "nickel"
+
+    restored = MaterialRef.model_validate({"material_id": "copper"})
+    assert restored.material_id == "copper"
+    assert restored.coating_id is None
+    clone = restored.model_copy()
+    assert clone is not restored and clone.material_id == restored.material_id


### PR DESCRIPTION
## Summary
- switch MaterialRef to shared BaseModel from utils.pydantic_compat
- expose BaseModel, ConfigDict and Field in utils.pydantic_compat and re-export from utils
- extend materials tests to cover MaterialRef serialization

## Testing
- `pytest tests/test_materials.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9171533ac832aa7c9dbcb8555fb60