### PR TITLE
Validate material references in simulation config

### DIFF
--- a/src/dpf2/materials/__init__.py
+++ b/src/dpf2/materials/__init__.py
@@ -2,6 +2,15 @@
 """Material-related models and helpers."""
 
 from .models import MaterialRef
+from .library import Material, MaterialLibrary
+from .state import ComponentMaterialState
+from .mdm import MaterialDamageModel
 
-__all__ = ["MaterialRef"]
+__all__ = [
+    "MaterialRef",
+    "Material",
+    "MaterialLibrary",
+    "ComponentMaterialState",
+    "MaterialDamageModel",
+]
 

--- a/src/dpf2/simulation/config_schema.py
+++ b/src/dpf2/simulation/config_schema.py
@@ -2,6 +2,8 @@
 from pydantic import BaseModel, validator, Field, root_validator
 from typing import List, Dict, Optional, Any, Tuple
 import numpy as np
+from ..materials.models import MaterialRef
+from ..materials.library import MaterialLibrary
 
 class CircuitConfig(BaseModel):
     """Configuration for the circuit model."""
@@ -196,13 +198,41 @@ class AMRConfig(BaseModel):
 class MaterialConfig(BaseModel):
     """Selection of component materials and initial lifecycle parameters."""
 
-    components: Dict[str, str] = Field(
-        default_factory=dict, description="Mapping of component name to material"
+    components: Dict[str, MaterialRef] = Field(
+        default_factory=dict,
+        description="Mapping of component name to material reference",
     )
     initial_state: Dict[str, Dict[str, float]] = Field(
         default_factory=dict,
         description="Initial state parameters keyed by component",
     )
+
+    @validator("components", pre=True)
+    def _parse_component_materials(cls, v):
+        """Allow legacy mapping of component to material id strings."""
+        if isinstance(v, dict):
+            parsed: Dict[str, MaterialRef] = {}
+            for comp, mat in v.items():
+                if isinstance(mat, MaterialRef):
+                    parsed[comp] = mat
+                elif isinstance(mat, (str, bytes)):
+                    parsed[comp] = MaterialRef(material_id=str(mat))
+                else:
+                    parsed[comp] = MaterialRef.model_validate(mat)
+            return parsed
+        return v
+
+    @validator("components")
+    def _validate_material_ids(cls, v):
+        """Ensure all referenced materials exist in the library."""
+        for comp, ref in v.items():
+            try:
+                MaterialLibrary.get(ref.material_id)
+            except KeyError as exc:
+                raise ValueError(
+                    f"Unknown material '{ref.material_id}' for component '{comp}'"
+                ) from exc
+        return v
 
 class SimulationConfig(BaseModel):
     """Main configuration for the DPF simulation."""

--- a/src/dpf2/simulation/dpf_simulation.py
+++ b/src/dpf2/simulation/dpf_simulation.py
@@ -176,11 +176,12 @@ class DPFSimulation:
                     field_manager=self.field_manager,
                 )
 
-            if self.config.materials.components:
+            materials_cfg = getattr(self.config, "materials", None)
+            if materials_cfg and materials_cfg.components:
                 component_states: Dict[str, ComponentMaterialState] = {}
-                for comp, mat_name in self.config.materials.components.items():
-                    mat = MaterialLibrary.get(mat_name)
-                    init = self.config.materials.initial_state.get(comp, {})
+                for comp, mat_ref in materials_cfg.components.items():
+                    mat = MaterialLibrary.get(mat_ref.material_id)
+                    init = materials_cfg.initial_state.get(comp, {})
                     component_states[comp] = ComponentMaterialState(
                         material=mat,
                         erosion=float(init.get("erosion", 0.0)),

--- a/tests/test_dpf_simulation_run.py
+++ b/tests/test_dpf_simulation_run.py
@@ -156,6 +156,27 @@ def test_run_calls_modules(monkeypatch):
     monkeypatch.setitem(sys.modules, "diagnostics", diagnostics_mod)
     monkeypatch.setitem(sys.modules, "dpf2.diagnostics", diagnostics_mod)
 
+    materials_mod = ModuleType("materials")
+    class MaterialLibrary:
+        @classmethod
+        def get(cls, name):
+            return types.SimpleNamespace(name=name, density=1.0, atomic_mass=1.0, sputter_yield=0.0)
+
+    class ComponentMaterialState:
+        def __init__(self, material, erosion=0.0, film_thickness=0.0):
+            self.material = material
+            self.erosion = erosion
+            self.film_thickness = film_thickness
+
+    class MaterialDamageModel:
+        def __init__(self, components, plasma_model=None):
+            self.components = components
+
+    materials_mod.MaterialLibrary = MaterialLibrary
+    materials_mod.ComponentMaterialState = ComponentMaterialState
+    materials_mod.MaterialDamageModel = MaterialDamageModel
+    monkeypatch.setitem(sys.modules, "dpf2.materials", materials_mod)
+
     pic_solver_mod = ModuleType("pic_solver")
     class PICSolver:
         def __init__(self, *a, **k):

--- a/tests/test_material_config.py
+++ b/tests/test_material_config.py
@@ -1,0 +1,16 @@
+import pytest
+
+from dpf2.simulation.config_schema import MaterialConfig
+from dpf2.materials.models import MaterialRef
+
+
+def test_component_materials_use_materialref():
+    cfg = MaterialConfig(components={"anode": MaterialRef(material_id="copper")})
+    assert isinstance(cfg.components["anode"], MaterialRef)
+    assert cfg.components["anode"].material_id == "copper"
+
+
+def test_unknown_material_validation():
+    with pytest.raises(ValueError):
+        MaterialConfig._validate_material_ids(MaterialConfig, {"anode": MaterialRef(material_id="bad")})
+


### PR DESCRIPTION
## Summary
- use `MaterialRef` objects for component materials in the simulation config
- verify material IDs against `MaterialLibrary` during parsing
- expect `MaterialRef` in `DPFSimulation` and expose material utilities for tests

## Testing
- `PYTHONPATH=src pytest tests/test_material_config.py tests/test_dpf_simulation_run.py::test_run_calls_modules -q`
- `pytest` *(fails: ImportError: cannot import name 'HallMHD' from 'dpf2.physics')*

------
https://chatgpt.com/codex/tasks/task_e_68b9171684b8832ab1a79e03c3174646