### PR TITLE
Track redeposition and contamination films in material damage model

### DIFF
--- a/src/dpf2/materials/__init__.py
+++ b/src/dpf2/materials/__init__.py
@@ -2,6 +2,14 @@
 """Material-related models and helpers."""
 
 from .models import MaterialRef
+from .library import MaterialLibrary
+from .state import ComponentMaterialState
+from .mdm import MaterialDamageModel
 
-__all__ = ["MaterialRef"]
+__all__ = [
+    "MaterialRef",
+    "MaterialLibrary",
+    "ComponentMaterialState",
+    "MaterialDamageModel",
+]
 

--- a/src/dpf2/materials/mdm.py
+++ b/src/dpf2/materials/mdm.py
@@ -20,19 +20,58 @@ class MaterialDamageModel:
         self.plasma_model = plasma_model
 
     def apply(self, solver: object, dt: float) -> None:
+        """Update material states for one timestep.
+
+        The solver may expose optional hooks:
+
+        ``surface_flux(name)`` -> incident particle flux for sputtering
+        ``surface_temperature(name)`` -> surface temperature
+        ``deposition_flux(name)`` -> redeposition flux from plasma
+        ``evaporation_rate(name, temperature)`` -> mass loss rate from evaporation
+        """
+
         flux_fn: Callable[[str], float] = getattr(solver, "surface_flux", lambda name: 0.0)
         temp_fn: Callable[[str], float] = getattr(solver, "surface_temperature", lambda name: 300.0)
+        dep_fn: Callable[[str], float] = getattr(solver, "deposition_flux", lambda name: 0.0)
+        evap_fn: Callable[[str, float], float] = getattr(
+            solver, "evaporation_rate", lambda name, temp: 0.0
+        )
 
+        # First pass: handle local sputtering/evaporation and record mass to redistribute
+        redistributed: Dict[str, float] = {}
         for name, state in self.components.items():
             flux = flux_fn(name)
             temperature = temp_fn(name)
             state.record_temperature(temperature)
 
-            erosion = flux * state.material.sputter_yield * dt
-            if erosion > 0.0:
-                state.erode(erosion)
-                if self.plasma_model and hasattr(self.plasma_model, "inject_impurities"):
-                    try:
-                        self.plasma_model.inject_impurities(name, erosion)
-                    except Exception:
-                        pass
+            sputtered = flux * state.material.sputter_yield * dt
+            redep = dep_fn(name) * dt
+            evap = evap_fn(name, temperature) * dt
+
+            net_sputter = max(sputtered - redep, 0.0)
+            state.erode(net_sputter + evap)
+            if redep > 0.0:
+                state.redeposit(redep)
+
+            redistributed[name] = net_sputter
+
+            if self.plasma_model and hasattr(self.plasma_model, "inject_impurities"):
+                try:
+                    if redep > 0.0:
+                        self.plasma_model.inject_impurities(name, -redep)
+                    if evap > 0.0:
+                        self.plasma_model.inject_impurities(name, evap)
+                except Exception:
+                    pass
+
+        # Second pass: distribute net sputtered material as contamination films
+        ncomp = len(self.components)
+        if ncomp > 1:
+            for src_name, amount in redistributed.items():
+                if amount <= 0.0:
+                    continue
+                share = amount / (ncomp - 1)
+                for dest_name, state in self.components.items():
+                    if dest_name == src_name:
+                        continue
+                    state.deposit(share)

--- a/src/dpf2/materials/state.py
+++ b/src/dpf2/materials/state.py
@@ -10,7 +10,8 @@ class ComponentMaterialState:
 
     material: Material
     erosion: float = 0.0
-    film_thickness: float = 0.0
+    redeposited_mass: float = 0.0
+    contamination_thickness: float = 0.0
     temperature_history: List[float] = field(default_factory=list)
 
     def record_temperature(self, temp: float) -> None:
@@ -19,14 +20,18 @@ class ComponentMaterialState:
     def erode(self, amount: float) -> None:
         self.erosion += amount
 
+    def redeposit(self, amount: float) -> None:
+        self.redeposited_mass += amount
+
     def deposit(self, amount: float) -> None:
-        self.film_thickness += amount
+        self.contamination_thickness += amount
 
     def to_dict(self) -> Dict[str, object]:
         return {
             "material": self.material.name,
             "erosion": self.erosion,
-            "film_thickness": self.film_thickness,
+            "redeposited_mass": self.redeposited_mass,
+            "contamination_thickness": self.contamination_thickness,
             "temperature_history": list(self.temperature_history),
         }
 
@@ -36,6 +41,7 @@ class ComponentMaterialState:
         return cls(
             material=mat,
             erosion=float(data.get("erosion", 0.0)),
-            film_thickness=float(data.get("film_thickness", 0.0)),
+            redeposited_mass=float(data.get("redeposited_mass", 0.0)),
+            contamination_thickness=float(data.get("contamination_thickness", 0.0)),
             temperature_history=list(data.get("temperature_history", [])),
         )

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -32,6 +32,8 @@ def test_erosion_accumulation():
     expected = 5.0 * mat.sputter_yield * 2.0
     assert state.erosion == pytest.approx(expected)
     assert state.temperature_history[-1] == 350.0
+    assert state.redeposited_mass == pytest.approx(0.0)
+    assert state.contamination_thickness == pytest.approx(0.0)
 
 
 def test_state_serialization_roundtrip():
@@ -39,12 +41,57 @@ def test_state_serialization_roundtrip():
     original = ComponentMaterialState(
         material=mat,
         erosion=1.0,
-        film_thickness=0.2,
+        redeposited_mass=0.1,
+        contamination_thickness=0.2,
         temperature_history=[300.0, 310.0],
     )
     data = original.to_dict()
     restored = ComponentMaterialState.from_dict(data)
     assert restored.material == mat
     assert restored.erosion == pytest.approx(1.0)
-    assert restored.film_thickness == pytest.approx(0.2)
+    assert restored.redeposited_mass == pytest.approx(0.1)
+    assert restored.contamination_thickness == pytest.approx(0.2)
     assert restored.temperature_history == [300.0, 310.0]
+
+
+def test_redeposition_and_film():
+    copper = MaterialLibrary.get("copper")
+    steel = MaterialLibrary.get("stainless_steel")
+    state_a = ComponentMaterialState(material=copper)
+    state_b = ComponentMaterialState(material=steel)
+
+    class DummySolver:
+        def surface_flux(self, component: str) -> float:
+            return 10.0 if component == "A" else 0.0
+
+        def surface_temperature(self, component: str) -> float:
+            return 400.0
+
+        def deposition_flux(self, component: str) -> float:
+            return 0.02 if component == "A" else 0.0
+
+        def evaporation_rate(self, component: str, temp: float) -> float:
+            return 0.01 if component == "A" else 0.0
+
+    class DummyPlasma:
+        def __init__(self):
+            self.calls = []
+
+        def inject_impurities(self, name: str, amount: float) -> None:
+            self.calls.append((name, amount))
+
+    plasma = DummyPlasma()
+    mdm = MaterialDamageModel({"A": state_a, "B": state_b}, plasma_model=plasma)
+    mdm.apply(DummySolver(), dt=1.0)
+
+    sputter = 10.0 * copper.sputter_yield * 1.0
+    redep = 0.02 * 1.0
+    net = max(sputter - redep, 0.0)
+    evap = 0.01 * 1.0
+
+    assert state_a.erosion == pytest.approx(net + evap)
+    assert state_a.redeposited_mass == pytest.approx(redep)
+    assert state_b.contamination_thickness == pytest.approx(net)
+    # Plasma model should receive negative redeposition and positive evaporation
+    assert ("A", -redep) in plasma.calls
+    assert ("A", evap) in plasma.calls


### PR DESCRIPTION
## Summary
- track redeposited mass and contamination film thickness in `ComponentMaterialState`
- extend `MaterialDamageModel.apply` with deposition and evaporation hooks and inter-component film deposition
- expose material helpers from `dpf2.materials` and test redeposition/film logic

## Testing
- `pytest tests/test_materials.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b917184a64832a952f0b03eb941da1