### PR TITLE
feat: add benchmark CLI dashboard

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,9 +1,33 @@
 # Benchmarks
 
-The `benchmarks/` directory contains small regression problems with known
-analytic solutions.  They are intended both as examples of the simulation
-infrastructure and as safeguards against code regression.  Each benchmark
-compares model output to a reference solution from the literature.
+DPF2 ships with both frozen regression benchmarks and small analytic
+examples that exercise individual physics models.  These benchmarks act as
+guard rails against code regression and provide usage examples for the
+simulation infrastructure.
+
+## Frozen regression suite
+
+Predefined projects live under `Reference/Benchmarks/`.  Each project
+contains two files:
+
+- `inputs.json` – configuration passed to the simulator
+- `expected.json` – reference time histories with tolerance bands
+
+Run a single case and produce a pass/fail dashboard plus a PNG overlay using:
+
+```bash
+dpf2 run-benchmark unu_pff --benchmark-dir Reference/Benchmarks --output results
+```
+
+To execute the entire suite at once:
+
+```bash
+dpf2 run-compare --benchmark-dir Reference/Benchmarks --output results
+```
+
+Both commands write plots showing the simulation output overlaid on grey
+tolerance bands and print a summary of whether current, voltage and neutron
+yield fall within their respective thresholds.
 
 ## Analytic plasma expansion
 

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -1104,9 +1104,12 @@ def run_benchmark(case: str, benchmark_dir: str, output: str) -> None:
     fig.savefig(out_root / f"{case}.png")
     plt.close(fig)
 
-    header = "{:<7} {:<7} {:<7}".format("Current", "Voltage", "Neutron")
+    header = "{:<20} {:<7} {:<7} {:<7}".format(
+        "Benchmark", "Current", "Voltage", "Neutron"
+    )
     click.echo(header)
-    row = "{:<7} {:<7} {:<7}".format(
+    row = "{:<20} {:<7} {:<7} {:<7}".format(
+        case,
         "PASS" if pass_current else "FAIL",
         "PASS" if pass_voltage else "FAIL",
         "PASS" if pass_neut else "FAIL",


### PR DESCRIPTION
## Summary
- improve `run-benchmark` CLI to print benchmark name alongside pass/fail results
- document frozen benchmark workflow and CLI usage

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'HallMHD' from 'dpf2.physics')*
- `pytest tests/test_cli_run_benchmark.py::test_run_benchmark_cmd -q`


------
https://chatgpt.com/codex/tasks/task_e_68b917f383f8832a913dd665c24f2e8d