### PR TITLE
feat(gui): add sweep dashboard with overlay export

### DIFF
--- a/src/dpf2/gui/interactive.py
+++ b/src/dpf2/gui/interactive.py
@@ -18,12 +18,12 @@ from typing import List
 from .project_manager import ProjectManager
 from ..core.config import DPFConfig
 from ..device_profiles import DeviceProfiles
-from ..optimization.param_sweep import run_parametric_sweep, compute_sweep_metrics
 
 try:  # pragma: no cover - optional dependency
     import dash
     from dash import Dash, dcc, html, Input, Output, State
     import plotly.graph_objects as go
+    from plotly.subplots import make_subplots
 except Exception:  # pragma: no cover - allow import without dash
     Dash = None  # type: ignore[misc]
 
@@ -57,26 +57,77 @@ def launch(host: str = "127.0.0.1", port: int = 8050) -> None:
     app.layout = html.Div(
         [
             html.H1("DPF2 GUI"),
-            dcc.Dropdown(id="preset", options=preset_options, placeholder="Geometry preset"),
-            dcc.Slider(5_000, 30_000, 1_000, value=10_000, id="voltage", tooltip={"placement": "bottom"}),
-            dcc.Slider(0.1, 5.0, 0.1, value=1.0, id="pressure", tooltip={"placement": "bottom"}),
+            dcc.Dropdown(
+                id="preset",
+                options=preset_options,
+                placeholder="Geometry preset",
+            ),
+            html.Div(
+                [
+                    dcc.Input(
+                        id="anode_radius",
+                        type="number",
+                        placeholder="Anode radius (cm)",
+                    ),
+                    dcc.Input(
+                        id="cathode_radius",
+                        type="number",
+                        placeholder="Cathode radius (cm)",
+                    ),
+                    dcc.Input(
+                        id="electrode_length",
+                        type="number",
+                        placeholder="Electrode length (cm)",
+                    ),
+                ]
+            ),
+            dcc.Slider(
+                5_000,
+                30_000,
+                1_000,
+                value=10_000,
+                id="voltage",
+                tooltip={"placement": "bottom"},
+            ),
+            dcc.Slider(
+                0.1,
+                5.0,
+                0.1,
+                value=1.0,
+                id="pressure",
+                tooltip={"placement": "bottom"},
+            ),
             html.Button("Sweep Voltage", id="sweep_voltage"),
             html.Button("Sweep Pressure", id="sweep_pressure"),
             html.Button("Overlay Runs", id="overlay_runs"),
             html.Button("Export Metrics", id="export"),
+            html.Button("Export Overlay", id="export_overlay"),
             dcc.Graph(id="metrics_plot"),
         ]
     )
 
-    def _make_config(preset: str | None, pressure: float, voltage: float) -> DPFConfig:
+    def _make_config(
+        preset: str | None,
+        pressure: float,
+        voltage: float,
+        anode: float | None,
+        cathode: float | None,
+        length: float | None,
+    ) -> DPFConfig:
         cfg = DPFConfig()
         cfg.initial_pressure = pressure
         cfg.charging_voltage = voltage
         if preset and preset in presets:
             dev = presets[preset]
-            cfg.anode_radius = dev.anode_radius_cm * 0.01
-            cfg.cathode_radius = dev.cathode_radius_cm * 0.01
-            cfg.electrode_length = dev.anode_length_cm * 0.01
+            if anode is None:
+                anode = dev.anode_radius_cm
+            if cathode is None:
+                cathode = dev.cathode_radius_cm
+            if length is None:
+                length = dev.anode_length_cm
+        cfg.anode_radius = (anode or 0.0) * 0.01
+        cfg.cathode_radius = (cathode or 0.0) * 0.01
+        cfg.electrode_length = (length or 0.0) * 0.01
         return cfg
 
     @app.callback(
@@ -85,13 +136,28 @@ def launch(host: str = "127.0.0.1", port: int = 8050) -> None:
         Input("sweep_pressure", "n_clicks"),
         Input("overlay_runs", "n_clicks"),
         Input("export", "n_clicks"),
+        Input("export_overlay", "n_clicks"),
         State("preset", "value"),
         State("pressure", "value"),
         State("voltage", "value"),
+        State("anode_radius", "value"),
+        State("cathode_radius", "value"),
+        State("electrode_length", "value"),
         prevent_initial_call=True,
     )
-    def _run_actions(v_clicks: int, p_clicks: int, o_clicks: int, e_clicks: int,
-                     preset: str | None, pressure: float, voltage: float):
+    def _run_actions(
+        v_clicks: int,
+        p_clicks: int,
+        o_clicks: int,
+        e_clicks: int,
+        eo_clicks: int,
+        preset: str | None,
+        pressure: float,
+        voltage: float,
+        anode: float | None,
+        cathode: float | None,
+        length: float | None,
+    ):
         ctx = dash.callback_context
         if not ctx.triggered:
             return go.Figure()
@@ -101,40 +167,99 @@ def launch(host: str = "127.0.0.1", port: int = 8050) -> None:
             pm.export_metrics(Path("metrics.csv"))
             return go.Figure()
 
+        if button_id == "export_overlay":
+            pm.overlay_metrics(Path("overlay.png"))
+            return go.Figure()
+
         if button_id == "overlay_runs":
-            fig = go.Figure()
+            fig = make_subplots(
+                rows=1,
+                cols=3,
+                subplot_titles=("Yield", "Pinch Time", "Efficiency"),
+            )
+            params = {pm.params.get(lbl, "") for lbl in pm.metrics}
+            x_label = params.pop() if len(params) == 1 else "parameter"
             for label, metrics in pm.metrics.items():
                 vals = sorted(metrics.keys())
-                fig.add_trace(go.Scatter(x=vals, y=[metrics[v]["yield"] for v in vals],
-                                         mode="lines+markers", name=f"{label} yield"))
-                fig.add_trace(go.Scatter(x=vals, y=[metrics[v]["pinch_time"] for v in vals],
-                                         mode="lines+markers", name=f"{label} pinch"))
-                fig.add_trace(go.Scatter(x=vals, y=[metrics[v]["efficiency"] for v in vals],
-                                         mode="lines+markers", name=f"{label} eff"))
+                fig.add_trace(
+                    go.Scatter(
+                        x=vals,
+                        y=[metrics[v]["yield"] for v in vals],
+                        mode="lines+markers",
+                        name=f"{label} yield",
+                    ),
+                    row=1,
+                    col=1,
+                )
+                fig.add_trace(
+                    go.Scatter(
+                        x=vals,
+                        y=[metrics[v]["pinch_time"] for v in vals],
+                        mode="lines+markers",
+                        name=f"{label} pinch",
+                    ),
+                    row=1,
+                    col=2,
+                )
+                fig.add_trace(
+                    go.Scatter(
+                        x=vals,
+                        y=[metrics[v]["efficiency"] for v in vals],
+                        mode="lines+markers",
+                        name=f"{label} eff",
+                    ),
+                    row=1,
+                    col=3,
+                )
+            fig.update_xaxes(title_text=x_label, row=1, col=1)
+            fig.update_xaxes(title_text=x_label, row=1, col=2)
+            fig.update_xaxes(title_text=x_label, row=1, col=3)
+            fig.update_yaxes(title_text="Yield", row=1, col=1)
+            fig.update_yaxes(title_text="Pinch Time", row=1, col=2)
+            fig.update_yaxes(title_text="Efficiency", row=1, col=3)
             return fig
 
-        cfg = _make_config(preset, pressure, voltage)
+        cfg = _make_config(preset, pressure, voltage, anode, cathode, length)
 
         if button_id == "sweep_voltage":
             values: List[float] = [voltage * f for f in [0.8, 1.0, 1.2]]
-            results = run_parametric_sweep(cfg, "charging_voltage", values)
-            metrics = compute_sweep_metrics(cfg, results)
-            pm.metrics[f"voltage_{len(pm.metrics)}"] = metrics
+            metrics = pm.run_sweep(
+                f"voltage_{len(pm.metrics)}", cfg, "charging_voltage", values
+            )
             vals = sorted(metrics.keys())
         else:
             values = [pressure * f for f in [0.5, 1.0, 1.5]]
-            results = run_parametric_sweep(cfg, "initial_pressure", values)
-            metrics = compute_sweep_metrics(cfg, results)
-            pm.metrics[f"pressure_{len(pm.metrics)}"] = metrics
+            metrics = pm.run_sweep(
+                f"pressure_{len(pm.metrics)}", cfg, "initial_pressure", values
+            )
             vals = sorted(metrics.keys())
 
-        fig = go.Figure()
-        fig.add_trace(go.Scatter(x=vals, y=[metrics[v]["yield"] for v in vals],
-                                 mode="lines+markers", name="yield"))
-        fig.add_trace(go.Scatter(x=vals, y=[metrics[v]["pinch_time"] for v in vals],
-                                 mode="lines+markers", name="pinch time"))
-        fig.add_trace(go.Scatter(x=vals, y=[metrics[v]["efficiency"] for v in vals],
-                                 mode="lines+markers", name="efficiency"))
+        fig = make_subplots(rows=1, cols=3, subplot_titles=("Yield", "Pinch Time", "Efficiency"))
+        fig.add_trace(
+            go.Scatter(x=vals, y=[metrics[v]["yield"] for v in vals], mode="lines+markers"),
+            row=1,
+            col=1,
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=vals, y=[metrics[v]["pinch_time"] for v in vals], mode="lines+markers"
+            ),
+            row=1,
+            col=2,
+        )
+        fig.add_trace(
+            go.Scatter(
+                x=vals, y=[metrics[v]["efficiency"] for v in vals], mode="lines+markers"
+            ),
+            row=1,
+            col=3,
+        )
+        fig.update_xaxes(title_text="parameter", row=1, col=1)
+        fig.update_xaxes(title_text="parameter", row=1, col=2)
+        fig.update_xaxes(title_text="parameter", row=1, col=3)
+        fig.update_yaxes(title_text="Yield", row=1, col=1)
+        fig.update_yaxes(title_text="Pinch Time", row=1, col=2)
+        fig.update_yaxes(title_text="Efficiency", row=1, col=3)
         return fig
 
     app.run_server(host=host, port=port)

--- a/src/dpf2/gui/project_manager.py
+++ b/src/dpf2/gui/project_manager.py
@@ -33,6 +33,7 @@ class ProjectManager:
 
     def __init__(self) -> None:
         self.metrics: Dict[str, Dict[float, Dict[str, float]]] = {}
+        self.params: Dict[str, str] = {}
 
     def run_sweep(
         self,
@@ -59,9 +60,12 @@ class ProjectManager:
             Directory where individual run results should be written.
         """
 
-        results = run_parametric_sweep(base_config, parameter, values, output_dir=output_dir)
+        results = run_parametric_sweep(
+            base_config, parameter, values, output_dir=output_dir
+        )
         metrics = compute_sweep_metrics(base_config, results)
         self.metrics[label] = metrics
+        self.params[label] = parameter
         return metrics
 
     def overlay_yield_pressure(self, path: str | Path) -> Path:
@@ -69,14 +73,29 @@ class ProjectManager:
 
         return plot_yield_pressure_overlay(self.metrics, path)
 
-    def overlay_metrics(self, parameter: str, path: str | Path) -> Path:
-        """Overlay yield, pinch time and efficiency curves for stored sweeps."""
+    def overlay_metrics(
+        self, path: str | Path, parameter: str | None = None
+    ) -> Path:
+        """Overlay yield, pinch time and efficiency curves for stored sweeps.
+
+        Parameters
+        ----------
+        path:
+            Destination image path.
+        parameter:
+            Optional axis label. If omitted and all recorded sweeps share a
+            common parameter, that name is used automatically.
+        """
 
         import matplotlib.pyplot as plt
 
+        if parameter is None:
+            params = {self.params.get(k, "") for k in self.metrics}
+            parameter = params.pop() if len(params) == 1 else "parameter"
+
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
-        fig, axes = plt.subplots(3, 1, sharex=True, figsize=(6, 9))
+        fig, axes = plt.subplots(1, 3, sharex=False, figsize=(12, 4))
 
         for label, metrics in self.metrics.items():
             vals = sorted(metrics.keys())
@@ -90,8 +109,8 @@ class ProjectManager:
         axes[0].set_ylabel("Yield")
         axes[1].set_ylabel("Pinch Time")
         axes[2].set_ylabel("Efficiency")
-        axes[2].set_xlabel(parameter)
         for ax in axes:
+            ax.set_xlabel(parameter)
             ax.grid(True)
             ax.legend()
         fig.tight_layout()


### PR DESCRIPTION
## Summary
- extend Dash GUI with geometry inputs, sweep plotting and export controls
- track sweep parameters and create side-by-side overlay plots

## Testing
- `pytest` *(fails: NameError: name 'types' is not defined, AttributeError: 'types.SimpleNamespace' object has no attribute 'use', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b917f5c9bc832ab03ac2cc0a1395e9