### PR TITLE
feat(diagnostics): add power cross-correlation and anisotropy notebook

### DIFF
--- a/examples/notebooks/anisotropy_analysis.ipynb
+++ b/examples/notebooks/anisotropy_analysis.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Anisotropy Analysis\n",
+    "This notebook demonstrates computing beam-target and thermal yield anisotropy using `dpf2.diagnostics`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dpf2.diagnostics import IonBeamEDF, yield_components_with_anisotropy, angular_yield_map\n",
+    "\n",
+    "class SimpleBeam(IonBeamEDF):\n",
+    "    def energy_distribution(self, angle_deg):\n",
+    "        return [1.0, 2.0], [1.0, 1.0]\n",
+    "\n",
+    "beam = SimpleBeam()\n",
+    "angles = [0.0, 90.0]\n",
+    "cross_section = lambda e: e\n",
+    "distance = 1.0\n",
+    "time_bins = [0.0, 1.0]\n",
+    "reactivity = [1e-20, 1e-20]\n",
+    "ion_density = [1e19, 1e19]\n",
+    "dt = 1e-6\n",
+    "\n",
+    "result = yield_components_with_anisotropy(\n",
+    "    beam,\n",
+    "    cross_section,\n",
+    "    angles,\n",
+    "    distance,\n",
+    "    time_bins,\n",
+    "    reactivity,\n",
+    "    ion_density,\n",
+    "    dt,\n",
+    ")\n",
+    "result\n",
+    "\n",
+    "energy_bins = [0.0, 1.0, 2.0]\n",
+    "angular_map = angular_yield_map(beam, cross_section, angles, energy_bins)\n",
+    "angular_map"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dpf2/diagnostics/neutron_yield.py
+++ b/src/dpf2/diagnostics/neutron_yield.py
@@ -323,7 +323,13 @@ def tof_iv_cross_correlation(
     current: Sequence[float],
     voltage: Sequence[float],
 ) -> Dict[str, float]:
-    """Return zero-lag correlation between TOF signal and I/V traces."""
+    """Return zero-lag correlation between TOF signal and I/V traces.
+
+    In addition to individual current and voltage correlations the
+    correlation with instantaneous electrical power (``I*V``) is also
+    returned.  All inputs must be the same length and are treated as
+    uniformly sampled in time.
+    """
 
     if not (len(tof) == len(current) == len(voltage)):
         raise ValueError("signals must have the same length")
@@ -337,9 +343,11 @@ def tof_iv_cross_correlation(
         )
         return num / den if den != 0 else 0.0
 
+    power = [i * v for i, v in zip(current, voltage)]
     return {
         "current": _corr(tof, current),
         "voltage": _corr(tof, voltage),
+        "power": _corr(tof, power),
     }
 
 

--- a/tests/test_neutron_yield_diagnostics.py
+++ b/tests/test_neutron_yield_diagnostics.py
@@ -104,3 +104,4 @@ def test_tof_iv_cross_correlation():
     corr = tof_iv_cross_correlation(tof, current, voltage)
     assert np.isclose(corr["current"], 1.0)
     assert np.isclose(corr["voltage"], -1.0)
+    assert np.isclose(corr["power"], 0.0)


### PR DESCRIPTION
## Summary
- extend TOF/I-V cross-correlation to include power channel
- add regression test for power correlation output
- provide example notebook for yield anisotropy analysis

## Testing
- `pytest tests/test_neutron_yield_diagnostics.py::test_tof_iv_cross_correlation -q`
- `pytest` *(fails: tests/test_photon_scatter.py ... NameError: name 'types' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b917f91aa0832abd9ae0635dc8fc81