### PR TITLE
Add calibration and multi-objective optimization utilities

### DIFF
--- a/docs/examples/calibration_example.py
+++ b/docs/examples/calibration_example.py
@@ -1,0 +1,24 @@
+import numpy as np
+
+from dpf2.uq import bayesian_calibration, nested_calibration
+
+
+def model(params):
+    a = params[0]
+    x = np.linspace(0, 1, 20)
+    return a * x
+
+
+true_a = 1.2
+x = np.linspace(0, 1, 20)
+noise = np.random.default_rng(0).normal(0, 0.01, size=x.shape)
+data = true_a * x + noise
+
+bounds = {"a": (0.0, 2.0)}
+
+mcmc_samples = bayesian_calibration(model, bounds, data, n_samples=500, seed=0)
+nested_samples = nested_calibration(model, bounds, data, n_live=20, n_iter=200, seed=0)
+
+print("MCMC mean:", float(np.mean(mcmc_samples["a"])))
+print("Nested mean:", float(np.mean(nested_samples["a"])))
+

--- a/docs/examples/optimization_example.py
+++ b/docs/examples/optimization_example.py
@@ -1,0 +1,13 @@
+from dpf2.optimization import random_pareto_search
+
+
+def evaluate(params):
+    x = params[0]
+    yield_val = -(x - 1) ** 2
+    spot = (x - 1) ** 2
+    return yield_val, spot
+
+
+pareto = random_pareto_search(evaluate, {"x": (0.0, 2.0)}, n_samples=200, seed=0)
+print("Pareto-optimal samples:", pareto)
+

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,26 @@
+# Workflows
+
+This section demonstrates common workflows for calibrating simulations
+against laboratory diagnostics and exploring trade-offs between neutron
+yield and spot size.
+
+## Bayesian and Nested Calibration
+
+The `dpf2.uq.calibration` module provides both a Metropolis-Hastings MCMC
+routine and a lightweight nested sampler.  The script below illustrates
+calibration of a simple linear model against synthetic data:
+
+```python
+python docs/examples/calibration_example.py
+```
+
+## Multi-objective Optimization
+
+To study yield versus spot size trade-offs, the `random_pareto_search`
+function performs a random search and returns the estimated Pareto front.
+An example run is provided in:
+
+```python
+python docs/examples/optimization_example.py
+```
+

--- a/src/dpf2/optimization/__init__.py
+++ b/src/dpf2/optimization/__init__.py
@@ -2,11 +2,13 @@
 
 from .bayesian import BayesianParameterInference, ParameterEstimate
 from .param_sweep import plot_sweep_results, run_parametric_sweep
+from .multi_objective import random_pareto_search
 
 __all__ = [
     "BayesianParameterInference",
     "ParameterEstimate",
     "run_parametric_sweep",
     "plot_sweep_results",
+    "random_pareto_search",
 ]
 

--- a/src/dpf2/optimization/multi_objective.py
+++ b/src/dpf2/optimization/multi_objective.py
@@ -1,0 +1,77 @@
+"""Multi-objective optimization helpers."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, List, Tuple
+
+import random
+
+import numpy as np
+
+Bounds = Dict[str, Tuple[float, float]]
+
+
+def random_pareto_search(
+    evaluate: Callable[[np.ndarray], Tuple[float, float]],
+    bounds: Bounds,
+    n_samples: int = 1000,
+    seed: int | None = None,
+) -> List[Dict[str, float]]:
+    """Approximate the Pareto front for yield and spot size.
+
+    This routine performs a random search over the parameter space defined by
+    ``bounds``.  The ``evaluate`` callable should return ``(yield, spot_size)``
+    for a given parameter vector.  Solutions with higher ``yield`` and lower
+    ``spot_size`` are preferred.  The method returns the set of nondominated
+    parameter dictionaries representing the estimated Pareto front.
+
+    Parameters
+    ----------
+    evaluate:
+        Callable accepting an array of parameters and returning
+        ``(yield, spot_size)``.
+    bounds:
+        Mapping of parameter names to ``(min, max)`` bounds.
+    n_samples:
+        Number of random samples to draw.
+    seed:
+        Optional random seed for reproducibility.
+
+    Returns
+    -------
+    List[Dict[str, float]]
+        Parameter dictionaries corresponding to the estimated Pareto front.
+    """
+
+    rng = random.Random(seed)
+    names = list(bounds)
+    lower = [bounds[n][0] for n in names]
+    upper = [bounds[n][1] for n in names]
+
+    params = [[rng.uniform(l, u) for l, u in zip(lower, upper)] for _ in range(n_samples)]
+    scores = [evaluate(np.array(p)) for p in params]
+
+    yields = [s[0] for s in scores]
+    spots = [s[1] for s in scores]
+    pareto_mask = [True] * n_samples
+
+    for i in range(n_samples):
+        if not pareto_mask[i]:
+            continue
+        for j in range(n_samples):
+            if j == i:
+                continue
+            if (
+                yields[j] >= yields[i]
+                and spots[j] <= spots[i]
+                and (yields[j] > yields[i] or spots[j] < spots[i])
+            ):
+                pareto_mask[i] = False
+                break
+
+    pareto_params = [p for p, keep in zip(params, pareto_mask) if keep]
+    return [{name: float(p[idx]) for idx, name in enumerate(names)} for p in pareto_params]
+
+
+__all__ = ["random_pareto_search"]
+

--- a/src/dpf2/uq/__init__.py
+++ b/src/dpf2/uq/__init__.py
@@ -1,6 +1,11 @@
 """Uncertainty quantification utilities."""
 
 from .sampling import latin_hypercube, sobol_sample
-from .calibration import bayesian_calibration
+from .calibration import bayesian_calibration, nested_calibration
 
-__all__ = ["latin_hypercube", "sobol_sample", "bayesian_calibration"]
+__all__ = [
+    "latin_hypercube",
+    "sobol_sample",
+    "bayesian_calibration",
+    "nested_calibration",
+]

--- a/src/dpf2/uq/calibration.py
+++ b/src/dpf2/uq/calibration.py
@@ -1,11 +1,13 @@
-"""Bayesian calibration routines for model parameter inference."""
+"""Calibration routines for inferring model parameters from diagnostics."""
 
 from __future__ import annotations
 
 from typing import Callable, Dict, Tuple
 
-import numpy as np
 import math
+import random
+
+import numpy as np
 
 Bounds = Dict[str, Tuple[float, float]]
 
@@ -51,28 +53,111 @@ def bayesian_calibration(
         samples.
     """
 
-    rng = np.random.default_rng(seed)
+    rng = random.Random(seed)
     names = list(bounds)
-    lower = np.array([bounds[n][0] for n in names])
-    upper = np.array([bounds[n][1] for n in names])
-    current = (lower + upper) / 2.0
+    lower = [bounds[n][0] for n in names]
+    upper = [bounds[n][1] for n in names]
+    current = [(l + u) / 2.0 for l, u in zip(lower, upper)]
 
     def log_like(params: np.ndarray) -> float:
         pred = np.asarray(model(params))
         resid = (data - pred) / sigma
         return -0.5 * np.dot(resid, resid)
 
-    samples = np.zeros((n_samples, len(names)))
+    samples: list[list[float]] = []
     current_logp = log_like(current)
-    widths = proposal_scale * (upper - lower)
+    widths = [proposal_scale * (u - l) for l, u in zip(lower, upper)]
 
-    for i in range(n_samples):
-        proposal = rng.normal(current, widths)
-        if np.all((proposal >= lower) & (proposal <= upper)):
+    for _ in range(n_samples):
+        proposal = [rng.gauss(c, w) for c, w in zip(current, widths)]
+        if all(l <= p <= u for p, l, u in zip(proposal, lower, upper)):
             logp = log_like(proposal)
             if math.log(rng.random()) < (logp - current_logp):
                 current = proposal
                 current_logp = logp
-        samples[i] = current
+        samples.append(list(current))
 
+    arr = np.array(samples)
+    return {name: arr[:, idx] for idx, name in enumerate(names)}
+
+
+def nested_calibration(
+    model: Callable[[np.ndarray], np.ndarray],
+    bounds: Bounds,
+    data: np.ndarray,
+    n_live: int = 50,
+    n_iter: int = 500,
+    sigma: float = 1.0,
+    seed: int | None = None,
+) -> Dict[str, np.ndarray]:
+    """Calibrate model parameters using a basic nested sampler.
+
+    The implementation follows the classic nested sampling algorithm
+    with uniform priors over ``bounds`` and a Gaussian likelihood with
+    standard deviation ``sigma``.  It is intended for quick exploration
+    against laboratory diagnostics where evaluating the forward model is
+    expensive but derivatives are unavailable.
+
+    Parameters
+    ----------
+    model:
+        Callable accepting an array of parameters and returning model
+        predictions aligned with ``data``.
+    bounds:
+        Mapping of parameter names to ``(min, max)`` bounds.
+    data:
+        Experimental measurements to calibrate against.
+    n_live:
+        Number of live points to maintain in the active set.
+    n_iter:
+        Number of nested sampling iterations to perform.
+    sigma:
+        Standard deviation of the observational noise.
+    seed:
+        Optional random seed for reproducibility.
+
+    Returns
+    -------
+    Dict[str, np.ndarray]
+        Dictionary mapping parameter names to posterior samples gathered
+        during the nested sampling procedure.
+    """
+
+    rng = random.Random(seed)
+    names = list(bounds)
+    lower = [bounds[n][0] for n in names]
+    upper = [bounds[n][1] for n in names]
+
+    def log_like(params: np.ndarray) -> float:
+        pred = np.asarray(model(params))
+        resid = (data - pred) / sigma
+        return -0.5 * np.dot(resid, resid)
+
+    # Draw initial live points uniformly within bounds
+    live = [
+        [rng.uniform(l, u) for l, u in zip(lower, upper)]
+        for _ in range(n_live)
+    ]
+    logl = [log_like(p) for p in live]
+
+    collected: list[list[float]] = []
+    for _ in range(n_iter):
+        worst = min(range(len(logl)), key=lambda i: logl[i])
+        collected.append(list(live[worst]))
+        threshold = logl[worst]
+
+        # Replace the worst point with a new sample above the threshold
+        while True:
+            cand = [rng.uniform(l, u) for l, u in zip(lower, upper)]
+            cand_logl = log_like(cand)
+            if cand_logl > threshold:
+                live[worst] = cand
+                logl[worst] = cand_logl
+                break
+
+    samples = np.array(collected)
     return {name: samples[:, idx] for idx, name in enumerate(names)}
+
+
+__all__ = ["bayesian_calibration", "nested_calibration"]
+

--- a/tests/test_bayesian_calibration.py
+++ b/tests/test_bayesian_calibration.py
@@ -1,7 +1,7 @@
 import random
 import numpy as np
 
-from dpf2.uq.calibration import bayesian_calibration
+from dpf2.uq.calibration import bayesian_calibration, nested_calibration
 
 
 def test_bayesian_calibration_linear_model():
@@ -18,5 +18,25 @@ def test_bayesian_calibration_linear_model():
     data = true_a * x + noise
 
     samples = bayesian_calibration(model, {"a": (0.0, 4.0)}, data, n_samples=500, seed=0)
+    mean_a = sum(samples["a"]) / len(samples["a"])
+    assert abs(mean_a - true_a) < 0.5
+
+
+def test_nested_calibration_linear_model():
+    rng = random.Random(0)
+
+    def model(params):
+        a = params[0]
+        x = np.linspace(0, 1, 10)
+        return a * x
+
+    true_a = 2.0
+    x = np.linspace(0, 1, 10)
+    noise = np.array([rng.gauss(0, 0.01) for _ in x])
+    data = true_a * x + noise
+
+    samples = nested_calibration(
+        model, {"a": (0.0, 4.0)}, data, n_live=20, n_iter=200, seed=0
+    )
     mean_a = sum(samples["a"]) / len(samples["a"])
     assert abs(mean_a - true_a) < 0.5

--- a/tests/test_multi_objective_optimization.py
+++ b/tests/test_multi_objective_optimization.py
@@ -1,0 +1,14 @@
+from dpf2.optimization import random_pareto_search
+
+
+def test_random_pareto_search_simple():
+    def evaluate(params):
+        x = params[0]
+        yield_val = -(x - 1) ** 2
+        spot = (x - 1) ** 2
+        return yield_val, spot
+
+    pareto = random_pareto_search(evaluate, {"x": (0.0, 2.0)}, n_samples=200, seed=0)
+    xs = [p["x"] for p in pareto]
+    assert any(abs(x - 1.0) < 0.2 for x in xs)
+


### PR DESCRIPTION
## Summary
- expand `uq.calibration` with a lightweight nested sampler alongside existing MCMC routine
- add `random_pareto_search` for yield/spot-size trade-offs
- document calibration and optimization workflows with runnable examples

## Testing
- `pytest tests/test_bayesian_calibration.py tests/test_multi_objective_optimization.py`


------
https://chatgpt.com/codex/tasks/task_e_68b917fff9f0832a9fa10de3a9006f1c