### PR TITLE
feat: add sharing and overlays

### DIFF
--- a/examples/export_import_example.py
+++ b/examples/export_import_example.py
@@ -1,0 +1,15 @@
+"""Demonstrate JSON export/import for simulation setups."""
+from pathlib import Path
+
+from dpf2.dpf_config import DPFConfig
+from dpf2.io import export_config, import_config
+
+cfg_path = Path(__file__).with_name("config.json")
+config = DPFConfig.model_validate_json(cfg_path.read_text())
+
+out_path = Path(__file__).with_name("shared_config.json")
+export_config(config, out_path)
+print(f"Exported configuration to {out_path}")
+
+loaded = import_config(out_path)
+print(f"Reloaded geometry: {loaded.simulation_control.geometry}")

--- a/examples/web_app_tutorial.md
+++ b/examples/web_app_tutorial.md
@@ -1,0 +1,37 @@
+# Web App Tutorial
+
+This walkthrough demonstrates how to use the experimental web interface.
+
+## 1. Start the server
+
+```bash
+uvicorn web.backend.main:app --reload
+```
+
+Navigate to `http://localhost:8000` in your browser.
+
+## 2. Log in
+
+Use the sample credentials `admin/secret` or `user/secret`.
+Tooltips on each field describe their purpose.
+
+## 3. Submit a configuration
+
+Paste a JSON configuration into the text area.  The `What is this?` dropdown
+explains what the configuration represents.
+
+## 4. Import or export setups
+
+Use the **Export Snapshot** button to download the current setup as
+`snapshot.json`.  Choose a JSON file with the file input to import a shared
+setup.
+
+## 5. Explore overlays
+
+After submitting, voltage and pressure sliders become active.  The page shows
+real‑time overlays:
+
+* **Instability Growth** – visualizes phase‑dependent motion.
+* **Sheath & Beam** – illustrates sheath position, J×B drift, and beam formation.
+
+Each overlay contains a `What is this?` section describing the plot.

--- a/src/dpf2/io/__init__.py
+++ b/src/dpf2/io/__init__.py
@@ -2,10 +2,13 @@ from .data_writer import DataWriter
 from .structured import StructuredOutputWriter
 from .restart import RestartManager
 from .datasets import load_dataset_manifest
+from .json_io import export_config, import_config
 
 __all__ = [
     "DataWriter",
     "StructuredOutputWriter",
     "RestartManager",
     "load_dataset_manifest",
+    "export_config",
+    "import_config",
 ]

--- a/src/dpf2/io/json_io.py
+++ b/src/dpf2/io/json_io.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from dpf2.dpf_config import DPFConfig
+
+
+def export_config(cfg: DPFConfig, path: Path) -> None:
+    """Write a :class:`~dpf2.dpf_config.DPFConfig` to ``path`` in JSON format."""
+    path = Path(path)
+    path.write_text(cfg.model_dump_json(indent=2))
+
+
+def import_config(path: Path) -> DPFConfig:
+    """Read ``path`` and return a :class:`~dpf2.dpf_config.DPFConfig`."""
+    path = Path(path)
+    return DPFConfig.model_validate_json(path.read_text())
+
+__all__ = ["export_config", "import_config"]

--- a/web/frontend/src/App.jsx
+++ b/web/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import axios from 'axios';
 import ProjectManager from './ProjectManager.jsx';
 import InstabilityVisualizer from './InstabilityVisualizer.jsx';
+import SheathBeamOverlay from './SheathBeamOverlay.jsx';
 
 export default function App() {
   const [token, setToken] = useState('');
@@ -153,6 +154,7 @@ export default function App() {
             </details>
           </div>
           <InstabilityVisualizer />
+          <SheathBeamOverlay />
         </div>
       )}
     </div>

--- a/web/frontend/src/SheathBeamOverlay.jsx
+++ b/web/frontend/src/SheathBeamOverlay.jsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useRef } from 'react';
+
+/**
+ * Displays a mock real-time overlay of sheath position, J×B vectors,
+ * and a forming beam. The visual is synthetic and intended as a
+ * development placeholder.
+ */
+export default function SheathBeamOverlay() {
+  const canvasRef = useRef(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    let t = 0;
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      // Sheath position as an oscillating cyan circle
+      const r = 30 + 10 * Math.sin(t);
+      ctx.strokeStyle = 'cyan';
+      ctx.beginPath();
+      ctx.arc(canvas.width / 2, canvas.height / 2, r, 0, Math.PI * 2);
+      ctx.stroke();
+
+      // J×B vectors as orange arrows around the sheath edge
+      ctx.strokeStyle = 'orange';
+      for (let angle = 0; angle < Math.PI * 2; angle += Math.PI / 4) {
+        const x = canvas.width / 2 + Math.cos(angle) * r;
+        const y = canvas.height / 2 + Math.sin(angle) * r;
+        ctx.beginPath();
+        ctx.moveTo(x, y);
+        ctx.lineTo(x + 10 * Math.cos(angle + Math.PI / 2), y + 10 * Math.sin(angle + Math.PI / 2));
+        ctx.stroke();
+      }
+
+      // Beam formation as a magenta line extending from the center
+      ctx.strokeStyle = 'magenta';
+      ctx.beginPath();
+      ctx.moveTo(canvas.width / 2, canvas.height / 2);
+      ctx.lineTo(canvas.width / 2, canvas.height / 2 - 40 - 5 * t);
+      ctx.stroke();
+
+      t += 0.05;
+      requestAnimationFrame(draw);
+    };
+    draw();
+  }, []);
+
+  return (
+    <div className="overlay" title="Shows sheath edge, J×B drift, and beam emergence">
+      <h4>Sheath & Beam</h4>
+      <canvas ref={canvasRef} width="200" height="200" title="Live overlay canvas" />
+      <details>
+        <summary>What is this?</summary>
+        The cyan circle estimates the sheath boundary, orange arrows depict J×B drift,
+        and the magenta line illustrates beam formation. Data is synthesized for demo
+        purposes.
+      </details>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add utility functions to import/export `DPFConfig` setups as JSON
- document web workflow and sharing snapshots
- add Sheath & Beam overlay with tooltips to web client

## Testing
- `pytest` *(fails: attempted relative import with no known parent package and other ImportErrors)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68b918025438832a94e93fac941cbb2e