### PR TITLE
Integrate lower-hybrid resistivity into MHD pinch model

### DIFF
--- a/src/dpf2/physics/lower_hybrid_drift.py
+++ b/src/dpf2/physics/lower_hybrid_drift.py
@@ -28,7 +28,14 @@ def _to_array(val: Any) -> np.ndarray:
 
 @dataclass
 class LowerHybridDrift:
-    """Minimal lower-hybrid drift instability model."""
+    """Minimal lower-hybrid drift instability model.
+
+    The model evolves a perturbation amplitude representing the strength of
+    lower‑hybrid waves and exposes an ``anomalous_resistivity`` callback
+    compatible with :class:`~dpf2.hall_mhd_solver.HallMHDSolver`.  When the
+    solver requests a resistivity field the stored amplitude is returned along
+    with an optional electric‑field contribution.
+    """
 
     B: float  # Magnetic field strength [T]
     n_i: float  # Ion number density [m^-3]
@@ -56,7 +63,8 @@ class LowerHybridDrift:
 
 
     def anomalous_resistivity(self, J: np.ndarray):
-        eta = self.amplitude if self.amplitude is not None else np.zeros(J.shape[:-1])
+        base = np.zeros(J.shape[:-1])
+        eta = base if self.amplitude is None else np.broadcast_to(self.amplitude, base.shape)
         return eta, np.zeros_like(J)
 
 __all__ = ["LowerHybridDrift"]

--- a/src/dpf2/pinch_models.py
+++ b/src/dpf2/pinch_models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, Any
 
 import numpy as np
 try:  # pragma: no cover - allow running without SciPy
@@ -52,6 +52,8 @@ class PinchResult:
     alfven_mach: np.ndarray | None = None
     magnetic_reynolds: np.ndarray | None = None
     lundquist: np.ndarray | None = None
+    voltage: np.ndarray | None = None
+    current: np.ndarray | None = None
 
 
 class PinchModelBase:
@@ -172,11 +174,13 @@ class MHDPinchModel(PinchModelBase):
         init_density: float = 1.0,
         init_pressure: float = 1e5,
         current_norm: float = 1e4,
+        resistivity_model: Any | None = None,
     ) -> None:
         self.grid_shape = grid_shape
         self.init_density = init_density
         self.init_pressure = init_pressure
         self.current_norm = current_norm
+        self.resistivity_model = resistivity_model
         nx, ny, nz = grid_shape
         x = (np.arange(nx) - nx / 2) * 1e-3
         y = (np.arange(ny) - ny / 2) * 1e-3
@@ -187,9 +191,15 @@ class MHDPinchModel(PinchModelBase):
 
     def run(self, time: Iterable[float], current: Iterable[float]) -> PinchResult:
         t = np.asarray(time)
-        I = np.asarray(current)
+        I = np.asarray(current).copy()
         gamma = 5.0 / 3.0
-        solver = HallMHDSolver()
+        solver = HallMHDSolver(
+            anomalous_resistivity=(
+                self.resistivity_model.anomalous_resistivity
+                if self.resistivity_model is not None
+                else None
+            )
+        )
 
         rho = np.full(self.grid_shape, self.init_density)
         mom = np.zeros(self.grid_shape + (3,))
@@ -240,11 +250,21 @@ class MHDPinchModel(PinchModelBase):
         alfven_hist.append(a)
         rm_hist.append(rm)
         s_hist.append(s_num)
+        voltage_hist: list[float] = [0.0]
 
         neutron_yield = 0.0
+        k_field = None
+        if self.resistivity_model is not None:
+            if self.resistivity_model.amplitude is None:
+                self.resistivity_model.amplitude = np.zeros(self.grid_shape)
+            k_field = np.zeros(self.grid_shape) + 0.1
         for k in range(len(t) - 1):
             dt = t[k + 1] - t[k]
-            state = solver.step(state, dt)
+            if self.resistivity_model is not None and k_field is not None:
+                self.resistivity_model.evolve(
+                    self.resistivity_model.amplitude, k_field, dt
+                )
+            state = solver.step(state, dt, current=float(I[k]))
             rad, temp, pres, Etot, b, a, rm, s_num = diagnostics(state)
             radius.append(rad)
             temperature.append(temp)
@@ -254,6 +274,10 @@ class MHDPinchModel(PinchModelBase):
             alfven_hist.append(a)
             rm_hist.append(rm)
             s_hist.append(s_num)
+            spike = solver.voltage_spikes[-1] if solver.voltage_spikes else 0.0
+            voltage_hist.append(spike)
+            if k + 1 < len(I):
+                I[k + 1] = max(I[k + 1] - spike * dt / self.current_norm, 0.0)
             n_i = np.mean(state.rho) / (3.344e-27)
             reactivity = bosch_hale_dd(max(temp, 0.0) / 1e3)
             mag = np.mean(np.sum(state.B**2, axis=-1))
@@ -271,6 +295,8 @@ class MHDPinchModel(PinchModelBase):
             alfven_mach=np.asarray(alfven_hist),
             magnetic_reynolds=np.asarray(rm_hist),
             lundquist=np.asarray(s_hist),
+            voltage=np.asarray(voltage_hist),
+            current=I,
         )
 
 

--- a/tests/physics/test_anomalous_resistivity.py
+++ b/tests/physics/test_anomalous_resistivity.py
@@ -1,10 +1,12 @@
 from pathlib import Path
 import numpy as np
+import pytest
 from dpf2.hall_mhd_solver import HallMHDSolver
 from dpf2.validation_suite import load_pinch_dataset
 
 
-def test_voltage_spike_matches_dataset():
+@pytest.mark.parametrize("device", ["PF1000", "LLNL_MJOLNIR"])
+def test_voltage_spike_matches_dataset(device):
     if not hasattr(np, "loadtxt"):
         import csv
 
@@ -16,8 +18,8 @@ def test_voltage_spike_matches_dataset():
 
         np.loadtxt = _loadtxt  # type: ignore[attr-defined]
 
-    bench = load_pinch_dataset(Path("data/benchmarks/NX2"))
-    _, voltage = bench['voltage']
+    bench = load_pinch_dataset(Path(f"data/benchmarks/{device}"))
+    _, voltage = bench["voltage"]
     expected = float(np.max(voltage))
 
     def model(J):

--- a/tests/test_pinch_models.py
+++ b/tests/test_pinch_models.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from dpf2.pinch_models import AnalyticPinchModel, SemiAnalyticPinchModel, MHDPinchModel
+from dpf2.physics import LowerHybridDrift
 
 
 def test_analytic_model():
@@ -39,3 +40,15 @@ def test_mhd_model_yield_scaling():
     res2 = model.run(t, I2)
     assert res2.neutron_yield > res1.neutron_yield
     assert res2.neutron_yield == pytest.approx(res1.neutron_yield * 4, rel=0.5)
+
+
+@pytest.mark.skipif(not hasattr(np, "roll"), reason="requires full NumPy")
+def test_mhd_model_resistive_voltage():
+    t = np.linspace(0, 1e-7, 5)
+    I = np.asarray(t) * 0 + 1e4
+    instab = LowerHybridDrift(B=1.0, n_i=1e19)
+    model = MHDPinchModel(grid_shape=(4, 4, 4), resistivity_model=instab)
+    res = model.run(t, I)
+    assert res.voltage is not None
+    assert res.current is not None
+    assert res.voltage.shape == res.current.shape


### PR DESCRIPTION
## Summary
- Expose lower-hybrid drift instability model with Hall-MHD compatible resistivity callback
- Couple anomalous resistivity into MHDPinchModel to update current and track voltage spikes
- Validate PF‑1000 and LLNL MJOLNIR voltage spike benchmarks and exercise resistive coupling in tests

## Testing
- `pytest tests/physics/test_instabilities.py::test_lower_hybrid_grid_evolution tests/physics/test_anomalous_resistivity.py tests/test_pinch_models.py::test_mhd_model_resistive_voltage -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9b73d2e68832a97bef2325a4969b5