### PR TITLE
Add parameterized geometry and mesh readers

### DIFF
--- a/src/dpf2/geometry/__init__.py
+++ b/src/dpf2/geometry/__init__.py
@@ -6,6 +6,11 @@ from .loaders import (
     load_cad_geometry,
     load_unstructured_mesh,
 )
+from .parameterized import (
+    TaperedGeometry,
+    HollowGeometry,
+    ReentrantGeometry,
+)
 
 __all__ = [
     "coaxial_inductance",
@@ -13,4 +18,7 @@ __all__ = [
     "load_cad_geometry",
     "load_axisymmetric_mesh",
     "load_unstructured_mesh",
+    "TaperedGeometry",
+    "HollowGeometry",
+    "ReentrantGeometry",
 ]

--- a/src/dpf2/geometry/parameterized.py
+++ b/src/dpf2/geometry/parameterized.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Parameterized geometry classes for simple electrode shapes."""
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+
+@dataclass
+class TaperedGeometry:
+    """Simple tapered column geometry.
+
+    Parameters
+    ----------
+    length: float
+        Total length of the column [m].
+    r_base: float
+        Base radius at ``z=0`` [m].
+    r_top: float
+        Radius at the top of the column [m].
+    """
+
+    length: float
+    r_base: float
+    r_top: float
+
+    def radius_profile(self, n: int = 50) -> List[Tuple[float, float]]:
+        """Return ``(z, r)`` pairs describing the taper."""
+        if n < 2:  # pragma: no cover - input validation
+            raise ValueError("n must be >= 2")
+        dz = self.length / (n - 1)
+        dr = (self.r_top - self.r_base) / (n - 1)
+        return [(i * dz, self.r_base + i * dr) for i in range(n)]
+
+
+@dataclass
+class HollowGeometry:
+    """Cylindrical geometry with an inner bore.
+
+    Parameters
+    ----------
+    length: float
+        Length of the cylinder [m].
+    r_outer: float
+        Outer radius [m].
+    r_inner: float
+        Inner radius (hollow region) [m].
+    """
+
+    length: float
+    r_outer: float
+    r_inner: float
+
+    def volume(self) -> float:
+        """Return the volume of material."""
+        import math
+
+        return math.pi * self.length * (self.r_outer**2 - self.r_inner**2)
+
+
+@dataclass
+class ReentrantGeometry:
+    """Re-entrant cavity geometry defined by straight segments.
+
+    Parameters
+    ----------
+    segments: list of ``(z, r)`` pairs
+        Describes the cavity profile along the axis.
+    """
+
+    segments: List[Tuple[float, float]]
+
+    def profile(self) -> List[Tuple[float, float]]:
+        """Return the profile coordinates."""
+        return list(self.segments)

--- a/src/dpf2/materials/library.py
+++ b/src/dpf2/materials/library.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Dict
+import math
 
 
 @dataclass(frozen=True)
@@ -10,15 +11,60 @@ class Material:
     density: float  # kg/m^3
     atomic_mass: float  # atomic mass units
     sputter_yield: float  # atoms removed per incident particle
+    resistivity: float | None = None  # ohm-m at ``frequency_ref``
+    frequency_ref: float = 1.0  # reference frequency for resistivity [Hz]
+    surface_conditioning: float | None = None  # multiplier for breakdown field
+
+    def resistivity_at(self, frequency: float) -> float:
+        """Return resistivity at ``frequency`` using a skin-effect model."""
+        if self.resistivity is None:
+            raise ValueError("Material does not have resistivity data")
+        if frequency <= 0:
+            return self.resistivity
+        return self.resistivity * math.sqrt(frequency / self.frequency_ref)
+
+    def conditioned_field(self, base: float) -> float:
+        """Apply surface conditioning factor to ``base`` field."""
+        if self.surface_conditioning is None:
+            return base
+        return base * self.surface_conditioning
 
 
 class MaterialLibrary:
     """Simple registry of materials with basic properties."""
 
     _materials: Dict[str, Material] = {
-        "copper": Material("copper", density=8960.0, atomic_mass=63.546, sputter_yield=0.01),
-        "tungsten": Material("tungsten", density=19300.0, atomic_mass=183.84, sputter_yield=0.005),
-        "stainless_steel": Material("stainless_steel", density=8000.0, atomic_mass=55.845, sputter_yield=0.02),
+        "copper": Material(
+            "copper",
+            density=8960.0,
+            atomic_mass=63.546,
+            sputter_yield=0.01,
+            resistivity=1.68e-8,
+            frequency_ref=1e5,
+        ),
+        "tungsten": Material(
+            "tungsten",
+            density=19300.0,
+            atomic_mass=183.84,
+            sputter_yield=0.005,
+            resistivity=5.6e-8,
+            frequency_ref=1e5,
+        ),
+        "stainless_steel": Material(
+            "stainless_steel",
+            density=8000.0,
+            atomic_mass=55.845,
+            sputter_yield=0.02,
+            resistivity=7.4e-7,
+            frequency_ref=1e5,
+        ),
+        "quartz": Material(
+            "quartz",
+            density=2648.0,
+            atomic_mass=60.08,
+            sputter_yield=0.0,
+            surface_conditioning=1.2,
+        ),
     }
 
     @classmethod

--- a/src/dpf2/mesh/__init__.py
+++ b/src/dpf2/mesh/__init__.py
@@ -4,6 +4,7 @@ from .mesh2d import Mesh2D, MeshCell
 from .mesh3d import Mesh3D, MeshCell3D
 from .boundaries import apply_bc
 from .amr import AMRMesh, plasma_gradient_refinement, wavefront_refinement
+from .readers import read_stl, read_vtk
 
 __all__ = [
     "Mesh2D",
@@ -14,4 +15,6 @@ __all__ = [
     "AMRMesh",
     "plasma_gradient_refinement",
     "wavefront_refinement",
+    "read_stl",
+    "read_vtk",
 ]

--- a/src/dpf2/mesh/readers.py
+++ b/src/dpf2/mesh/readers.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Mesh import utilities for common CAD formats."""
+
+from pathlib import Path
+from typing import Dict, Any, List
+
+try:  # pragma: no cover - optional dependency
+    import meshio  # type: ignore
+except Exception:  # pragma: no cover - meshio may not be installed
+    meshio = None
+
+
+def _ensure_meshio() -> None:
+    if meshio is None:  # pragma: no cover - import guard
+        raise RuntimeError("meshio is required for mesh import")
+
+
+def read_stl(path: Path) -> Dict[str, Any]:
+    """Read an STL surface mesh from ``path``."""
+    _ensure_meshio()
+    m = meshio.read(Path(path))
+    nodes = m.points.tolist()
+    elements: List[List[int]] = []
+    for block in m.cells:
+        if block.type == "triangle":
+            elements.extend(block.data.tolist())
+    return {"nodes": nodes, "elements": elements}
+
+
+def read_vtk(path: Path) -> Dict[str, Any]:
+    """Read an unstructured VTK mesh from ``path``."""
+    _ensure_meshio()
+    m = meshio.read(Path(path))
+    elements: List[List[int]] = []
+    for block in m.cells:
+        elements.extend(block.data.tolist())
+    return {"nodes": m.points.tolist(), "elements": elements}

--- a/tests/geometry/test_parameterized.py
+++ b/tests/geometry/test_parameterized.py
@@ -1,0 +1,22 @@
+import math
+
+from dpf2.geometry import TaperedGeometry, HollowGeometry, ReentrantGeometry
+
+
+def test_tapered_profile():
+    geom = TaperedGeometry(length=1.0, r_base=0.1, r_top=0.05)
+    prof = geom.radius_profile(3)
+    assert prof[0] == (0.0, 0.1)
+    assert prof[-1] == (1.0, 0.05)
+
+
+def test_hollow_volume():
+    geom = HollowGeometry(length=1.0, r_outer=0.1, r_inner=0.05)
+    expected = math.pi * (0.1**2 - 0.05**2)
+    assert math.isclose(geom.volume(), expected)
+
+
+def test_reentrant_profile():
+    points = [(0.0, 0.1), (0.5, 0.05)]
+    geom = ReentrantGeometry(points)
+    assert geom.profile() == points

--- a/tests/materials/test_material_properties.py
+++ b/tests/materials/test_material_properties.py
@@ -1,0 +1,15 @@
+import pytest
+
+from dpf2.materials import MaterialLibrary
+
+
+def test_resistivity_vs_frequency():
+    copper = MaterialLibrary.get("copper")
+    r1 = copper.resistivity_at(1e5)
+    r4 = copper.resistivity_at(4e5)
+    assert pytest.approx(r4, rel=1e-12) == r1 * 2
+
+
+def test_surface_conditioning():
+    quartz = MaterialLibrary.get("quartz")
+    assert pytest.approx(quartz.conditioned_field(100.0), rel=1e-12) == 120.0

--- a/tests/mesh/test_readers.py
+++ b/tests/mesh/test_readers.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+import pytest
+
+import dpf2.mesh.readers as readers
+
+
+def test_read_stl_requires_meshio(monkeypatch):
+    monkeypatch.setattr(readers, "meshio", None)
+    with pytest.raises(RuntimeError):
+        readers.read_stl(Path("dummy.stl"))
+
+
+def test_read_vtk_requires_meshio(monkeypatch):
+    monkeypatch.setattr(readers, "meshio", None)
+    with pytest.raises(RuntimeError):
+        readers.read_vtk(Path("dummy.vtk"))


### PR DESCRIPTION
## Summary
- add parameterized geometry classes for tapered, hollow, and re-entrant shapes
- expand material library with frequency-dependent resistivity and surface conditioning
- enable STL/VTK mesh import utilities

## Testing
- `pytest` *(fails: 51 errors during collection)*
- `pytest tests/geometry/test_parameterized.py tests/materials/test_material_properties.py tests/mesh/test_readers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9b742a840832a9cf2be93b93280fc