### PR TITLE
Add sweep plotting and optimization hooks

### DIFF
--- a/src/dpf2/gui/interactive.py
+++ b/src/dpf2/gui/interactive.py
@@ -100,6 +100,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050) -> None:
             html.Button("Sweep Voltage", id="sweep_voltage"),
             html.Button("Sweep Pressure", id="sweep_pressure"),
             html.Button("Overlay Runs", id="overlay_runs"),
+            html.Button("Pareto Search", id="pareto"),
             html.Button("Export Metrics", id="export"),
             html.Button("Export Overlay", id="export_overlay"),
             dcc.Graph(id="metrics_plot"),
@@ -135,6 +136,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050) -> None:
         Input("sweep_voltage", "n_clicks"),
         Input("sweep_pressure", "n_clicks"),
         Input("overlay_runs", "n_clicks"),
+        Input("pareto", "n_clicks"),
         Input("export", "n_clicks"),
         Input("export_overlay", "n_clicks"),
         State("preset", "value"),
@@ -149,6 +151,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050) -> None:
         v_clicks: int,
         p_clicks: int,
         o_clicks: int,
+        pa_clicks: int,
         e_clicks: int,
         eo_clicks: int,
         preset: str | None,
@@ -194,7 +197,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050) -> None:
                 fig.add_trace(
                     go.Scatter(
                         x=vals,
-                        y=[metrics[v]["pinch_time"] for v in vals],
+                        y=[metrics[v].get("pinch_time", 0.0) for v in vals],
                         mode="lines+markers",
                         name=f"{label} pinch",
                     ),
@@ -219,6 +222,24 @@ def launch(host: str = "127.0.0.1", port: int = 8050) -> None:
             fig.update_yaxes(title_text="Efficiency", row=1, col=3)
             return fig
 
+        if button_id == "pareto":
+            cfg = _make_config(preset, pressure, voltage, anode, cathode, length)
+            bounds = {
+                "charging_voltage": (voltage * 0.8, voltage * 1.2),
+                "initial_pressure": (pressure * 0.5, pressure * 1.5),
+            }
+            pareto = pm.pareto_search(cfg, bounds, n_samples=20)
+            fig = go.Figure(
+                go.Scatter(
+                    x=[p["spot_size"] for p in pareto],
+                    y=[p["yield"] for p in pareto],
+                    mode="markers",
+                )
+            )
+            fig.update_xaxes(title_text="Spot Size")
+            fig.update_yaxes(title_text="Yield")
+            return fig
+
         cfg = _make_config(preset, pressure, voltage, anode, cathode, length)
 
         if button_id == "sweep_voltage":
@@ -226,40 +247,19 @@ def launch(host: str = "127.0.0.1", port: int = 8050) -> None:
             metrics = pm.run_sweep(
                 f"voltage_{len(pm.metrics)}", cfg, "charging_voltage", values
             )
-            vals = sorted(metrics.keys())
         else:
             values = [pressure * f for f in [0.5, 1.0, 1.5]]
             metrics = pm.run_sweep(
                 f"pressure_{len(pm.metrics)}", cfg, "initial_pressure", values
             )
-            vals = sorted(metrics.keys())
 
-        fig = make_subplots(rows=1, cols=3, subplot_titles=("Yield", "Pinch Time", "Efficiency"))
-        fig.add_trace(
-            go.Scatter(x=vals, y=[metrics[v]["yield"] for v in vals], mode="lines+markers"),
-            row=1,
-            col=1,
+        s_vals = [metrics[v].get("S", 0.0) for v in sorted(metrics)]
+        y_vals = [metrics[v]["yield"] for v in sorted(metrics)]
+        fig = go.Figure(
+            go.Scatter(x=s_vals, y=y_vals, mode="lines+markers")
         )
-        fig.add_trace(
-            go.Scatter(
-                x=vals, y=[metrics[v]["pinch_time"] for v in vals], mode="lines+markers"
-            ),
-            row=1,
-            col=2,
-        )
-        fig.add_trace(
-            go.Scatter(
-                x=vals, y=[metrics[v]["efficiency"] for v in vals], mode="lines+markers"
-            ),
-            row=1,
-            col=3,
-        )
-        fig.update_xaxes(title_text="parameter", row=1, col=1)
-        fig.update_xaxes(title_text="parameter", row=1, col=2)
-        fig.update_xaxes(title_text="parameter", row=1, col=3)
-        fig.update_yaxes(title_text="Yield", row=1, col=1)
-        fig.update_yaxes(title_text="Pinch Time", row=1, col=2)
-        fig.update_yaxes(title_text="Efficiency", row=1, col=3)
+        fig.update_xaxes(title_text="S")
+        fig.update_yaxes(title_text="Yield")
         return fig
 
     app.run_server(host=host, port=port)

--- a/src/dpf2/gui/project_manager.py
+++ b/src/dpf2/gui/project_manager.py
@@ -10,14 +10,18 @@ metrics from multiple sweeps which can then be overlaid or written to disk.
 
 from pathlib import Path
 import csv
-from typing import Dict, Iterable
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
 
 from ..core.config import DPFConfig
 from ..optimization.param_sweep import (
     run_parametric_sweep,
     compute_sweep_metrics,
     plot_yield_pressure_overlay,
+    plot_yield_vs_S as _plot_yield_vs_S,
 )
+from ..optimization.multi_objective import random_pareto_search
 
 
 class ProjectManager:
@@ -34,6 +38,21 @@ class ProjectManager:
     def __init__(self) -> None:
         self.metrics: Dict[str, Dict[float, Dict[str, float]]] = {}
         self.params: Dict[str, str] = {}
+
+    @staticmethod
+    def _spot_size(t: Iterable[float], current: Iterable[float]) -> float:
+        """Estimate spot size as the FWHM of the current trace."""
+
+        t_arr = np.array(list(t))
+        i_arr = np.array(list(current))
+        if len(t_arr) == 0:
+            return 0.0
+        peak = float(i_arr.max())
+        half = 0.5 * peak
+        mask = i_arr >= half
+        if not mask.any():
+            return 0.0
+        return float(t_arr[mask][-1] - t_arr[mask][0])
 
     def run_sweep(
         self,
@@ -63,7 +82,7 @@ class ProjectManager:
         results = run_parametric_sweep(
             base_config, parameter, values, output_dir=output_dir
         )
-        metrics = compute_sweep_metrics(base_config, results)
+        metrics = compute_sweep_metrics(base_config, results, parameter)
         self.metrics[label] = metrics
         self.params[label] = parameter
         return metrics
@@ -72,6 +91,46 @@ class ProjectManager:
         """Generate a yield-versus-pressure overlay plot for stored metrics."""
 
         return plot_yield_pressure_overlay(self.metrics, path)
+
+    def plot_yield_vs_S(self, label: str, path: str | Path) -> Path:
+        """Plot yield versus shock parameter ``S`` for a stored sweep."""
+
+        metrics = self.metrics.get(label, {})
+        return _plot_yield_vs_S(metrics, path)
+
+    def pareto_search(
+        self,
+        base_config: DPFConfig,
+        bounds: Dict[str, Tuple[float, float]],
+        n_samples: int = 100,
+    ) -> List[Dict[str, float]]:
+        """Run a random Pareto search for yield versus spot size."""
+
+        eval_cache: Dict[Tuple[float, ...], Tuple[float, float]] = {}
+
+        names = list(bounds)
+
+        def evaluate(params: np.ndarray) -> Tuple[float, float]:
+            cfg_dict = base_config.__dict__.copy()
+            for idx, name in enumerate(names):
+                cfg_dict[name] = float(params[idx])
+            cfg = DPFConfig(**cfg_dict)
+            from ..core.simulation import DPFSimulation
+
+            sim = DPFSimulation(cfg)
+            t, i, v = sim.run()
+            yield_val = float(max(i)) if len(i) else 0.0
+            spot = self._spot_size(t, i)
+            eval_cache[tuple(params)] = (yield_val, spot)
+            return yield_val, spot
+
+        pareto_params = random_pareto_search(evaluate, bounds, n_samples=n_samples)
+        front: List[Dict[str, float]] = []
+        for param_dict in pareto_params:
+            params = tuple(param_dict[name] for name in names)
+            y, s = eval_cache[params]
+            front.append({**param_dict, "yield": y, "spot_size": s})
+        return front
 
     def overlay_metrics(
         self, path: str | Path, parameter: str | None = None

--- a/src/dpf2/optimization/param_sweep.py
+++ b/src/dpf2/optimization/param_sweep.py
@@ -89,7 +89,9 @@ def plot_sweep_results(
 
 
 def compute_sweep_metrics(
-    base_config: DPFConfig, results: Dict[float, SweepResult]
+    base_config: DPFConfig,
+    results: Dict[float, SweepResult],
+    parameter: str | None = None,
 ) -> Dict[float, Dict[str, float]]:
     """Compute simple yield, pinch time and efficiency estimates for sweep results.
 
@@ -107,7 +109,10 @@ def compute_sweep_metrics(
         Mapping of parameter value to metrics ``{"yield", "pinch_time",
         "efficiency"}``.  Yield is estimated as the peak current, pinch time is
         the time at which the peak current occurs and efficiency is the ratio of
-        the time-integrated ``I*V`` product to the initial stored energy.
+        the time-integrated ``I*V`` product to the initial stored energy.  If
+        ``parameter`` is provided and equals ``"initial_pressure"``, the
+        dimensionless shock parameter ``S = I/(a*p0)`` is also recorded for each
+        sweep value.
     """
 
     import numpy as np
@@ -125,11 +130,19 @@ def compute_sweep_metrics(
         peak_idx = int(i_arr.argmax()) if len(i_arr) else 0
         yield_est = float(i_arr[peak_idx])
         pinch_time = float(t_arr[peak_idx]) if len(t_arr) else 0.0
-        metrics[val] = {
+        metric = {
             "yield": yield_est,
             "efficiency": efficiency,
             "pinch_time": pinch_time,
         }
+        if parameter == "initial_pressure":
+            pressure = val
+        else:
+            pressure = base_config.initial_pressure
+        a = getattr(base_config, "anode_radius", 0.0)
+        if a > 0 and pressure > 0:
+            metric["S"] = yield_est / (a * pressure)
+        metrics[val] = metric
 
     return metrics
 
@@ -171,6 +184,25 @@ def plot_metric_overlay(
     return path
 
 
+def plot_yield_vs_S(metrics: Dict[float, Dict[str, float]], path: str | Path) -> Path:
+    """Plot yield as a function of the shock parameter ``S``."""
+
+    import matplotlib.pyplot as plt
+
+    pairs = sorted((m.get("S", 0.0), m.get("yield", 0.0)) for m in metrics.values())
+    s_vals = [p[0] for p in pairs]
+    y_vals = [p[1] for p in pairs]
+    plt.figure()
+    plt.plot(s_vals, y_vals, marker="o")
+    plt.xlabel("S")
+    plt.ylabel("Yield")
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(path)
+    plt.close()
+    return path
+
+
 def plot_yield_pressure_overlay(
     metric_sets: Dict[str, Dict[float, Dict[str, float]]],
     path: str | Path,
@@ -198,6 +230,7 @@ __all__ = [
     "plot_sweep_results",
     "compute_sweep_metrics",
     "plot_metric_overlay",
+    "plot_yield_vs_S",
     "plot_yield_pressure_overlay",
     "SweepResult",
 ]

--- a/tests/test_param_sweep.py
+++ b/tests/test_param_sweep.py
@@ -10,6 +10,7 @@ from dpf2.optimization.param_sweep import (
     plot_sweep_results,
     run_parametric_sweep,
     compute_sweep_metrics,
+    plot_yield_vs_S,
 )
 import pytest
 pytest.importorskip("matplotlib")
@@ -32,3 +33,15 @@ def test_compute_sweep_metrics_includes_pinch(tmp_path: Path) -> None:
     metrics = compute_sweep_metrics(cfg, results)
     for val in values:
         assert "pinch_time" in metrics[val]
+
+
+def test_yield_vs_s_plot(tmp_path: Path) -> None:
+    cfg = DPFConfig()
+    values = [0.5, 1.0]
+    results = run_parametric_sweep(cfg, "initial_pressure", values, output_dir=tmp_path)
+    metrics = compute_sweep_metrics(cfg, results, parameter="initial_pressure")
+    path = tmp_path / "ys.png"
+    plot_yield_vs_S(metrics, path)
+    assert path.exists()
+    for val in values:
+        assert "S" in metrics[val]


### PR DESCRIPTION
## Summary
- compute shock parameter S during sweeps and support yield-vs-S plots
- extend GUI project manager with Pareto optimizer hooks and spot-size estimation
- update interactive dashboard to plot yield vs. S and expose Pareto search

## Testing
- `pytest` *(fails: NameError: name 'types' is not defined, plus missing dependencies in numerous tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b7414398832aa7b563fa71a3897a