### PR TITLE
feat(web): add WebGL sheath sandbox and guided labs

### DIFF
--- a/web/frontend/src/App.jsx
+++ b/web/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import ProjectManager from './ProjectManager.jsx';
 import InstabilityVisualizer from './InstabilityVisualizer.jsx';
 import SheathBeamOverlay from './SheathBeamOverlay.jsx';
+import GuidedLabs from './GuidedLabs.jsx';
 
 export default function App() {
   const [token, setToken] = useState('');
@@ -154,7 +155,8 @@ export default function App() {
             </details>
           </div>
           <InstabilityVisualizer />
-          <SheathBeamOverlay />
+          <SheathBeamOverlay voltage={voltage} pressure={pressure} />
+          <GuidedLabs setVoltage={setVoltage} setPressure={setPressure} />
         </div>
       )}
     </div>

--- a/web/frontend/src/GuidedLabs.jsx
+++ b/web/frontend/src/GuidedLabs.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+/**
+ * Provides preset experiments for common discharge phases.
+ * Selecting a lab adjusts the main voltage and pressure sliders.
+ */
+export default function GuidedLabs({ setVoltage, setPressure }) {
+  const labs = [
+    {
+      name: 'Breakdown',
+      voltage: 1.5,
+      pressure: 0.2,
+      description:
+        'Increase voltage to ionize the gas. Observe initial sheath growth.',
+    },
+    {
+      name: 'Rundown',
+      voltage: 3.0,
+      pressure: 0.1,
+      description:
+        'Current drives the sheath toward the axis; track J×B direction.',
+    },
+    {
+      name: 'Pinch',
+      voltage: 4.5,
+      pressure: 0.05,
+      description:
+        'Sheath collapses and compresses plasma into a dense pinch.',
+    },
+  ];
+
+  return (
+    <div className="overlay" title="Step-by-step exploration of discharge phases">
+      <h4>Guided Labs</h4>
+      {labs.map((lab) => (
+        <div key={lab.name}>
+          <button
+            type="button"
+            onClick={() => {
+              setVoltage(lab.voltage);
+              setPressure(lab.pressure);
+            }}
+            title={`Configure parameters for the ${lab.name} phase`}
+          >
+            {lab.name}
+          </button>
+          <p>{lab.description}</p>
+        </div>
+      ))}
+      <details>
+        <summary>What is this?</summary>
+        Each lab loads representative parameters for a given phase. Use it to
+        rapidly explore how voltage and pressure influence the simulation.
+      </details>
+    </div>
+  );
+}

--- a/web/frontend/src/SheathBeamOverlay.jsx
+++ b/web/frontend/src/SheathBeamOverlay.jsx
@@ -1,61 +1,117 @@
 import React, { useEffect, useRef } from 'react';
 
 /**
- * Displays a mock real-time overlay of sheath position, J×B vectors,
- * and a forming beam. The visual is synthetic and intended as a
- * development placeholder.
+ * Renders sheath evolution and J×B vectors using WebGL.
+ * The sheath radius scales with voltage while arrow length
+ * scales with pressure. Animation is synthetic for sandbox use.
  */
-export default function SheathBeamOverlay() {
+export default function SheathBeamOverlay({ voltage, pressure }) {
   const canvasRef = useRef(null);
+  const voltageRef = useRef(voltage);
+  const pressureRef = useRef(pressure);
+
+  useEffect(() => {
+    voltageRef.current = voltage;
+  }, [voltage]);
+
+  useEffect(() => {
+    pressureRef.current = pressure;
+  }, [pressure]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
-    const ctx = canvas.getContext('2d');
-    let t = 0;
-    const draw = () => {
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const gl = canvas.getContext('webgl');
+    if (!gl) return;
 
-      // Sheath position as an oscillating cyan circle
-      const r = 30 + 10 * Math.sin(t);
-      ctx.strokeStyle = 'cyan';
-      ctx.beginPath();
-      ctx.arc(canvas.width / 2, canvas.height / 2, r, 0, Math.PI * 2);
-      ctx.stroke();
-
-      // J×B vectors as orange arrows around the sheath edge
-      ctx.strokeStyle = 'orange';
-      for (let angle = 0; angle < Math.PI * 2; angle += Math.PI / 4) {
-        const x = canvas.width / 2 + Math.cos(angle) * r;
-        const y = canvas.height / 2 + Math.sin(angle) * r;
-        ctx.beginPath();
-        ctx.moveTo(x, y);
-        ctx.lineTo(x + 10 * Math.cos(angle + Math.PI / 2), y + 10 * Math.sin(angle + Math.PI / 2));
-        ctx.stroke();
+    // Vertex shader
+    const vsSource = `
+      attribute vec2 a_position;
+      void main() {
+        gl_Position = vec4(a_position, 0.0, 1.0);
       }
+    `;
+    // Fragment shader with solid color
+    const fsSource = `
+      precision mediump float;
+      uniform vec4 u_color;
+      void main() {
+        gl_FragColor = u_color;
+      }
+    `;
 
-      // Beam formation as a magenta line extending from the center
-      ctx.strokeStyle = 'magenta';
-      ctx.beginPath();
-      ctx.moveTo(canvas.width / 2, canvas.height / 2);
-      ctx.lineTo(canvas.width / 2, canvas.height / 2 - 40 - 5 * t);
-      ctx.stroke();
+    function compile(type, source) {
+      const shader = gl.createShader(type);
+      gl.shaderSource(shader, source);
+      gl.compileShader(shader);
+      return shader;
+    }
 
-      t += 0.05;
-      requestAnimationFrame(draw);
+    const vs = compile(gl.VERTEX_SHADER, vsSource);
+    const fs = compile(gl.FRAGMENT_SHADER, fsSource);
+    const program = gl.createProgram();
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    gl.useProgram(program);
+
+    const positionLoc = gl.getAttribLocation(program, 'a_position');
+    const colorLoc = gl.getUniformLocation(program, 'u_color');
+
+    function drawShape(data, mode, color) {
+      const buffer = gl.createBuffer();
+      gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+      gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(data), gl.STREAM_DRAW);
+      gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 0, 0);
+      gl.enableVertexAttribArray(positionLoc);
+      gl.uniform4fv(colorLoc, color);
+      gl.drawArrays(mode, 0, data.length / 2);
+    }
+
+    const render = () => {
+      gl.viewport(0, 0, canvas.width, canvas.height);
+      gl.clearColor(0, 0, 0, 1);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+
+      const v = voltageRef.current;
+      const p = pressureRef.current;
+      const radius = 0.2 + (v / 5) * 0.6; // scale radius with voltage
+
+      // Build circle as triangle fan
+      const circle = [0, 0];
+      const segments = 32;
+      for (let i = 0; i <= segments; i++) {
+        const angle = (i / segments) * Math.PI * 2;
+        circle.push(Math.cos(angle) * radius, Math.sin(angle) * radius);
+      }
+      drawShape(circle, gl.TRIANGLE_FAN, [0, 1, 1, 1]);
+
+      // JxB arrows as line segments
+      const arrows = [];
+      const arrowLen = 0.05 + p * 0.15;
+      for (let i = 0; i < 8; i++) {
+        const angle = (i / 8) * Math.PI * 2;
+        const x = Math.cos(angle) * radius;
+        const y = Math.sin(angle) * radius;
+        const dx = -Math.sin(angle) * arrowLen;
+        const dy = Math.cos(angle) * arrowLen;
+        arrows.push(x, y, x + dx, y + dy);
+      }
+      drawShape(arrows, gl.LINES, [1, 0.5, 0, 1]);
+
+      requestAnimationFrame(render);
     };
-    draw();
+    render();
   }, []);
 
   return (
-    <div className="overlay" title="Shows sheath edge, J×B drift, and beam emergence">
-      <h4>Sheath & Beam</h4>
-      <canvas ref={canvasRef} width="200" height="200" title="Live overlay canvas" />
+    <div className="overlay" title="Shows sheath edge and J×B drift using WebGL">
+      <h4>Sheath &amp; J×B</h4>
+      <canvas ref={canvasRef} width="200" height="200" title="Live WebGL canvas" />
       <details>
         <summary>What is this?</summary>
-        The cyan circle estimates the sheath boundary, orange arrows depict J×B drift,
-        and the magenta line illustrates beam formation. Data is synthesized for demo
-        purposes.
+        The cyan disc approximates the sheath boundary and orange lines depict
+        J×B drift. Radius follows voltage; arrow length scales with pressure.
       </details>
     </div>
   );


### PR DESCRIPTION
## Summary
- Render sheath evolution and J×B vectors with a new WebGL overlay
- Provide preset guided labs for breakdown, rundown, and pinch phases
- Wire WebGL overlay and guided labs into existing sandbox

## Testing
- `npm --prefix web/frontend install` *(fails: 403 Forbidden)*
- `npm --prefix web/frontend run build` *(fails: vite: not found)*
- `pytest` *(fails: 51 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b744db8c832a85e63b3deed0955e