### PR TITLE
Add UQ inference and Sobol analysis

### DIFF
--- a/docs/tutorials/advanced_physics.md
+++ b/docs/tutorials/advanced_physics.md
@@ -31,3 +31,35 @@ dpf2 simulate -c advanced.yml -o run --diagnostics
 Current and voltage traces now include the effects of the activated
 models. Inspect the history file or use the plotting helpers to compare
 runs.
+
+## 3. Calibrate model parameters
+
+Experimental campaigns often require tuning uncertain parameters to fit
+diagnostics.  The :mod:`dpf2.uq.inference` module provides wrappers
+around modern samplers such as ``emcee`` and ``dynesty``:
+
+```python
+from dpf2.uq.inference import emcee_infer
+
+def model(params):
+    return run_simulation(params)  # user-defined helper
+
+samples = emcee_infer(model, {"charging_voltage": (8e3, 12e3)}, data)
+```
+
+The returned dictionary maps each parameter to an array of posterior
+samples that can be analysed or passed to downstream studies.
+
+## 4. Quantify sensitivity and uncertainty
+
+The ``uq-sweep`` command now reports Sobol indices and a 95% uncertainty
+band for the output metric:
+
+```bash
+dpf2 uq-sweep --config cfg.json --parameters '{"charging_voltage":[1e4,2e4]}' \
+    --samples 16 --method sobol
+```
+
+The generated JSON file contains per-run results along with a
+``sobol_indices`` block and an ``uncertainty_band`` describing the mean
+response and confidence interval.

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -45,6 +45,7 @@ from dpf2.optimization.param_sweep import (
 
 from dpf2.scaling_laws import sweep_yield_scaling
 from dpf2.uq.sampling import latin_hypercube, sobol_sample
+from dpf2.uq.analysis import sobol_indices, uncertainty_band
 
 from .errors import format_error
 from .lab import write_manifest
@@ -798,13 +799,23 @@ def uq_sweep_cmd(
         sample = sampler(bounds, samples)
         results: list[dict[str, Any]] = []
         names = list(bounds)
+        peak_currents: list[float] = []
         for row in sample:
             params = {n: float(v) for n, v in zip(names, row)}
             cfg_i = dataclasses.replace(cfg, **params)
             sim = DPFSimulation(cfg_i)
             _, currents, _ = sim.run()
-            results.append({"params": params, "peak_current": max(currents)})
-        Path(output).write_text(json.dumps(results, indent=2))
+            peak = max(currents)
+            peak_currents.append(peak)
+            results.append({"params": params, "peak_current": peak})
+        sobol = sobol_indices(sample, peak_currents, names)
+        band = uncertainty_band(peak_currents)
+        Path(output).write_text(
+            json.dumps(
+                {"results": results, "sobol_indices": sobol, "uncertainty_band": band},
+                indent=2,
+            )
+        )
     except Exception as e:
         raise click.ClickException(format_error("UQ", str(e)))
 
@@ -872,7 +883,8 @@ def uq_stats_cmd(input: str) -> None:
 
     try:
         data = json.loads(Path(input).read_text())
-        currents = [r["peak_current"] for r in data]
+        rows = data if isinstance(data, list) else data.get("results", [])
+        currents = [r["peak_current"] for r in rows]
         stats = {
             "mean_peak_current": statistics.mean(currents),
             "std_peak_current": statistics.pstdev(currents),

--- a/src/dpf2/uq/__init__.py
+++ b/src/dpf2/uq/__init__.py
@@ -2,10 +2,13 @@
 
 from .sampling import latin_hypercube, sobol_sample
 from .calibration import bayesian_calibration, nested_calibration
+from .inference import emcee_infer, dynesty_infer
 
 __all__ = [
     "latin_hypercube",
     "sobol_sample",
     "bayesian_calibration",
     "nested_calibration",
+    "emcee_infer",
+    "dynesty_infer",
 ]

--- a/src/dpf2/uq/analysis.py
+++ b/src/dpf2/uq/analysis.py
@@ -1,0 +1,71 @@
+"""Post-processing helpers for uncertainty quantification."""
+from __future__ import annotations
+
+from typing import Dict, Sequence
+
+import statistics
+
+
+def _to_matrix(samples: Sequence[Sequence[float]]) -> list[list[float]]:
+    """Convert ``samples`` to a list-of-lists without requiring ``numpy``."""
+
+    if hasattr(samples, "__array__"):
+        try:
+            return samples.tolist()  # type: ignore[attr-defined]
+        except Exception:
+            pass
+    return [list(row) for row in samples]
+
+
+def sobol_indices(
+    samples: Sequence[Sequence[float]],
+    values: Sequence[float],
+    names: Sequence[str],
+) -> Dict[str, float]:
+    """Estimate first-order Sobol indices from ``samples`` and ``values``.
+
+    The implementation uses a squared correlation coefficient as a cheap
+    approximation of the sensitivity indices and avoids heavy numerical
+    dependencies so it can run with the lightweight test ``numpy`` stub.
+    """
+
+    matrix = _to_matrix(samples)
+    y = list(values)
+    if len(y) < 2:
+        return {name: 0.0 for name in names}
+    mean_y = statistics.fmean(y)
+    var_y = statistics.pvariance(y)
+    indices: Dict[str, float] = {}
+    for idx, name in enumerate(names):
+        x = [row[idx] for row in matrix]
+        if len(x) < 2:
+            indices[name] = 0.0
+            continue
+        mean_x = statistics.fmean(x)
+        var_x = statistics.pvariance(x)
+        if var_x == 0 or var_y == 0:
+            indices[name] = 0.0
+            continue
+        cov = sum((xi - mean_x) * (yi - mean_y) for xi, yi in zip(x, y)) / len(x)
+        indices[name] = (cov ** 2) / (var_x * var_y)
+    return indices
+
+
+def uncertainty_band(values: Sequence[float], alpha: float = 0.95) -> Dict[str, float]:
+    """Compute mean, standard deviation and a central interval for ``values``."""
+
+    vals = list(values)
+    if not vals:
+        return {"mean": 0.0, "std": 0.0, "lower": 0.0, "upper": 0.0}
+    mean = statistics.fmean(vals)
+    std = statistics.pstdev(vals) if len(vals) > 1 else 0.0
+    vals_sorted = sorted(vals)
+    n = len(vals_sorted) - 1
+    lower_idx = int((1 - alpha) / 2 * n)
+    upper_idx = int((alpha + (1 - alpha) / 2) * n)
+    lower = vals_sorted[lower_idx]
+    upper = vals_sorted[upper_idx]
+    return {"mean": mean, "std": std, "lower": lower, "upper": upper}
+
+
+__all__ = ["sobol_indices", "uncertainty_band"]

--- a/src/dpf2/uq/inference.py
+++ b/src/dpf2/uq/inference.py
@@ -1,0 +1,110 @@
+"""Advanced parameter inference routines leveraging external samplers."""
+from __future__ import annotations
+
+from typing import Callable, Dict, Tuple
+
+import numpy as np
+
+Bounds = Dict[str, Tuple[float, float]]
+
+
+def emcee_infer(
+    model: Callable[[np.ndarray], np.ndarray],
+    bounds: Bounds,
+    data: np.ndarray,
+    n_walkers: int = 32,
+    n_steps: int = 1000,
+    sigma: float = 1.0,
+    seed: int | None = None,
+) -> Dict[str, np.ndarray]:
+    """Infer parameters using the :mod:`emcee` ensemble sampler.
+
+    The sampler uses uniform priors within ``bounds`` and a Gaussian
+    likelihood with standard deviation ``sigma``.
+
+    Parameters
+    ----------
+    model:
+        Callable accepting an array of parameters and returning model
+        predictions aligned with ``data``.
+    bounds:
+        Mapping of parameter names to ``(min, max)`` tuples.
+    data:
+        Experimental measurements to calibrate against.
+    n_walkers:
+        Number of walkers in the ensemble.
+    n_steps:
+        Total number of MCMC steps to draw.
+    sigma:
+        Standard deviation of the observational noise.
+    seed:
+        Optional seed for reproducibility.
+    """
+
+    try:  # pragma: no cover - dependency not installed in some environments
+        import emcee  # type: ignore
+    except Exception as exc:  # pragma: no cover - import error path
+        raise RuntimeError("emcee is required for emcee_infer") from exc
+
+    rng = np.random.default_rng(seed)
+    names = list(bounds)
+    lower = np.array([bounds[n][0] for n in names])
+    upper = np.array([bounds[n][1] for n in names])
+    ndim = len(names)
+
+    def log_prob(theta: np.ndarray) -> float:
+        if np.any(theta < lower) or np.any(theta > upper):
+            return -np.inf
+        pred = np.asarray(model(theta))
+        resid = (data - pred) / sigma
+        return -0.5 * np.dot(resid, resid)
+
+    p0 = lower + (upper - lower) * rng.random((n_walkers, ndim))
+    sampler = emcee.EnsembleSampler(n_walkers, ndim, log_prob)
+    sampler.run_mcmc(p0, n_steps, progress=False)
+    chain = sampler.get_chain(discard=n_steps // 2, flat=True)
+    return {name: chain[:, idx] for idx, name in enumerate(names)}
+
+
+def dynesty_infer(
+    model: Callable[[np.ndarray], np.ndarray],
+    bounds: Bounds,
+    data: np.ndarray,
+    n_live: int = 50,
+    n_iter: int = 500,
+    sigma: float = 1.0,
+    seed: int | None = None,
+) -> Dict[str, np.ndarray]:
+    """Infer parameters using the :mod:`dynesty` nested sampler.
+
+    Parameters mirror :func:`emcee_infer` but use a nested sampling
+    approach suitable for multi-modal posteriors.
+    """
+
+    try:  # pragma: no cover - dependency not installed in some environments
+        import dynesty  # type: ignore
+    except Exception as exc:  # pragma: no cover - import error path
+        raise RuntimeError("dynesty is required for dynesty_infer") from exc
+
+    names = list(bounds)
+    lower = np.array([bounds[n][0] for n in names])
+    upper = np.array([bounds[n][1] for n in names])
+    ndim = len(names)
+
+    def prior_transform(u: np.ndarray) -> np.ndarray:
+        return lower + u * (upper - lower)
+
+    def log_like(theta: np.ndarray) -> float:
+        pred = np.asarray(model(theta))
+        resid = (data - pred) / sigma
+        return -0.5 * np.dot(resid, resid)
+
+    sampler = dynesty.NestedSampler(
+        log_like, prior_transform, ndim, nlive=n_live, seed=seed
+    )
+    sampler.run_nested(maxiter=n_iter, print_progress=False)
+    res = sampler.results
+    return {name: res.samples[:, idx] for idx, name in enumerate(names)}
+
+
+__all__ = ["emcee_infer", "dynesty_infer"]

--- a/tests/test_cli_uq.py
+++ b/tests/test_cli_uq.py
@@ -45,6 +45,11 @@ def test_uq_sweep_and_stats(tmp_path, monkeypatch):
     assert res.exit_code == 0, res.output
     assert out_file.exists()
 
+    data = json.loads(out_file.read_text())
+    assert "sobol_indices" in data
+    assert "uncertainty_band" in data
+    assert len(data["results"]) == 2
+
     res2 = runner.invoke(cli_main.main, ["uq-stats", "--input", str(out_file)])
     assert res2.exit_code == 0, res2.output
     stats = json.loads(res2.output.strip())

--- a/tests/test_uq_inference.py
+++ b/tests/test_uq_inference.py
@@ -1,0 +1,32 @@
+import random
+import numpy as np
+import pytest
+
+from dpf2.uq.inference import emcee_infer
+
+
+def test_emcee_infer_linear_model():
+    pytest.importorskip("emcee")
+    rng = random.Random(0)
+
+    def model(params):
+        a = params[0]
+        x = np.linspace(0, 1, 5)
+        return a * x
+
+    true_a = 2.0
+    x = np.linspace(0, 1, 5)
+    noise = np.array([rng.gauss(0, 0.01) for _ in x])
+    data = true_a * x + noise
+
+    samples = emcee_infer(
+        model,
+        {"a": (0.0, 4.0)},
+        data,
+        n_walkers=6,
+        n_steps=20,
+        sigma=0.01,
+        seed=0,
+    )
+    mean_a = float(np.mean(samples["a"]))
+    assert abs(mean_a - true_a) < 0.5


### PR DESCRIPTION
## Summary
- add emcee/dynesty-based parameter inference helpers
- compute Sobol indices and uncertainty bands in `uq-sweep`
- document advanced workflow and add tests for new UQ features

## Testing
- `pytest tests/test_uq_sampling.py tests/test_cli_uq.py tests/test_uq_inference.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9b7459968832a8810383ed9a2ef3d