### PR TITLE
Add lab-mode manifest generation and ensemble support

### DIFF
--- a/src/dpf2/cli/lab.py
+++ b/src/dpf2/cli/lab.py
@@ -34,6 +34,7 @@ def write_manifest(
     output_dir: str | Path,
     *,
     config_paths: Sequence[str] | None = None,
+    config: Mapping[str, object] | None = None,
     ppc: int | None = None,
     seeds: Mapping[str, int] | None = None,
     warnings: Sequence[str] | None = None,
@@ -46,6 +47,9 @@ def write_manifest(
         Directory where the manifest should be written.
     config_paths:
         Sequence of configuration files used for the run.
+    config:
+        Configuration dictionary for the executed run. When provided, this is
+        embedded directly in the manifest to aid exact reproducibility.
     ppc:
         Particle-per-cell setting, if applicable.
     seeds:
@@ -73,6 +77,13 @@ def write_manifest(
         "particle_per_cell": ppc,
         "config_paths": [str(p) for p in (config_paths or [])],
     }
+    if config is not None:
+        # ``config`` may contain non-serialisable objects; best effort to cast
+        # via ``json.dumps`` when writing the manifest.
+        try:
+            manifest["config"] = json.loads(json.dumps(config))
+        except Exception:
+            manifest["config"] = {k: str(v) for k, v in config.items()}
     if warnings:
         manifest["warnings"] = list(warnings)
 

--- a/src/dpf2/cli/legacy_cli.py
+++ b/src/dpf2/cli/legacy_cli.py
@@ -44,18 +44,25 @@ def main(argv: list[str] | None = None) -> None:
         cfg = DPFConfig.from_file(args.config)
         engine = SimulationEngine(cfg)
         if args.lab_mode:
-            seeds = {
-                "python": random.getstate()[1][0],
-                "numpy": int(np.random.get_state()[1][0]),
-            }
+            seeds = {"python": random.getstate()[1][0]}
+            try:
+                seeds["numpy"] = int(np.random.get_state()[1][0])
+            except Exception:
+                try:
+                    rng = np.random.default_rng()
+                    seeds["numpy"] = int(rng.bit_generator.state["state"]["state"])
+                except Exception:
+                    seeds["numpy"] = 0
         results = engine.run(method=args.method, pinch_model=args.pinch_model)
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(json.dumps(results.to_dict(), indent=2))
         if args.lab_mode:
             ppc = getattr(getattr(cfg, "warpx_settings", None), "max_particles_per_cell", None)
+            cfg_dict = cfg.model_dump(mode="python") if hasattr(cfg, "model_dump") else cfg.__dict__
             write_manifest(
                 args.output.parent,
                 config_paths=[str(args.config)],
+                config=cfg_dict,
                 ppc=ppc,
                 seeds=seeds,
             )

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -332,6 +332,13 @@ def main(ctx: click.Context, notebook: bool, lab_mode: bool) -> None:
     help="Save key waveforms and diagnostics at completion",
 )
 @click.option("--wizard", is_flag=True, help="Interactive mode to build configuration")
+@click.option(
+    "--shots",
+    type=int,
+    default=1,
+    show_default=True,
+    help="Number of jittered shots to run when lab-mode is enabled",
+)
 @click.pass_context
 def simulate(
     ctx: click.Context,
@@ -344,6 +351,7 @@ def simulate(
     synthetic: str | None,
     diagnostics: bool,
     wizard: bool,
+    shots: int,
 ) -> None:
     """Run a DPF simulation."""
     try:
@@ -403,10 +411,17 @@ def simulate(
 
         sim = DPFSimulation(cfg)
 
-        seeds = {
-            "python": random.getstate()[1][0],
-            "numpy": int(np.random.get_state()[1][0]),
-        }
+        warnings_list: list[str] = []
+
+        seeds = {"python": random.getstate()[1][0]}
+        try:
+            seeds["numpy"] = int(np.random.get_state()[1][0])
+        except Exception:
+            try:
+                rng = np.random.default_rng()
+                seeds["numpy"] = int(rng.bit_generator.state["state"]["state"])
+            except Exception:
+                seeds["numpy"] = 0
 
         live_times: list[float] = []
         live_currents: list[float] = []
@@ -572,6 +587,49 @@ def simulate(
             diag_file.write_text(json.dumps(diag))
             click.echo(f"Diagnostics written to {diag_file}")
 
+        if ctx.obj.get("lab_mode") and shots > 1:
+            # In lab mode with multiple shots requested, run an ensemble with
+            # simple jitter applied to key inputs for each realization.
+            for idx in range(shots):
+                shot_cfg = dataclasses.replace(
+                    cfg,
+                    charging_voltage=random.gauss(
+                        cfg.charging_voltage, cfg.charging_voltage * 0.02
+                    ),
+                    initial_pressure=random.gauss(
+                        cfg.initial_pressure, cfg.initial_pressure * 0.02
+                    ),
+                )
+                shot_sim = DPFSimulation(shot_cfg)
+                shot_dir = Path(output) / f"shot_{idx:03d}"
+                shot_seeds = {"python": random.getstate()[1][0]}
+                try:
+                    shot_seeds["numpy"] = int(np.random.get_state()[1][0])
+                except Exception:
+                    try:
+                        rng = np.random.default_rng()
+                        shot_seeds["numpy"] = int(
+                            rng.bit_generator.state["state"]["state"]
+                        )
+                    except Exception:
+                        shot_seeds["numpy"] = 0
+                shot_sim.run(output_dir=str(shot_dir))
+                ppc = getattr(
+                    getattr(shot_cfg, "warpx_settings", None),
+                    "max_particles_per_cell",
+                    None,
+                )
+                cfg_paths = [p for p in [config, synthetic] if p]
+                write_manifest(
+                    shot_dir,
+                    config_paths=cfg_paths,
+                    config=asdict(shot_cfg),
+                    ppc=ppc,
+                    seeds=shot_seeds,
+                    warnings=warnings_list,
+                )
+            return
+
         if ctx.obj.get("lab_mode"):
 
             ppc = getattr(
@@ -582,6 +640,7 @@ def simulate(
             write_manifest(
                 output,
                 config_paths=cfg_paths,
+                config=asdict(cfg),
                 ppc=ppc,
                 seeds=seeds,
                 warnings=warnings_list,

--- a/src/dpf2/cli/validate.py
+++ b/src/dpf2/cli/validate.py
@@ -137,10 +137,15 @@ def run_validation(
     cfg = DPFConfig.from_file(config)
     engine = SimulationEngine(cfg)
     if lab_mode:
-        seeds = {
-            "python": random.getstate()[1][0],
-            "numpy": int(np.random.get_state()[1][0]),
-        }
+    seeds = {"python": random.getstate()[1][0]}
+    try:
+        seeds["numpy"] = int(np.random.get_state()[1][0])
+    except Exception:
+        try:
+            rng = np.random.default_rng()
+            seeds["numpy"] = int(rng.bit_generator.state["state"]["state"])
+        except Exception:
+            seeds["numpy"] = 0
     results = engine.run()
 
     vsuite = _build_validation_suite(dataset)
@@ -179,7 +184,16 @@ def run_validation(
 
     if lab_mode:
         ppc = getattr(getattr(cfg, "warpx_settings", None), "max_particles_per_cell", None)
-        write_manifest(outdir, config_paths=[str(config)], ppc=ppc, seeds=seeds)
+        cfg_dict = (
+            cfg.model_dump(mode="python") if hasattr(cfg, "model_dump") else cfg.__dict__
+        )
+        write_manifest(
+            outdir,
+            config_paths=[str(config)],
+            config=cfg_dict,
+            ppc=ppc,
+            seeds=seeds,
+        )
 
     for name, score in report["scores"].items():
         print(f"{name}: {score:.3f}")

--- a/src/dpf2/core/simulation.py
+++ b/src/dpf2/core/simulation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable
 import logging
+from dataclasses import asdict
 
 from ..mesh import Mesh2D
 from .config import DPFConfig
@@ -78,7 +79,7 @@ class DPFSimulation:
         interval = output_interval or end
 
         Path(out).mkdir(parents=True, exist_ok=True)
-        self.writer = DataWriter(out)
+        self.writer = DataWriter(out, config=asdict(self.config))
 
         # Write initial state
         self.writer.write_hdf5({"current": self.current, "voltage": self.voltage}, time=self.time)

--- a/src/dpf2/optimization/param_sweep.py
+++ b/src/dpf2/optimization/param_sweep.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Dict, Iterable, List, Tuple
 
+from dataclasses import asdict
+
 from ..core.config import DPFConfig
 from ..core.simulation import DPFSimulation
 from dpf2.cli.lab import write_manifest
@@ -53,15 +55,26 @@ def run_parametric_sweep(
         sim = DPFSimulation(cfg)
         run_dir = out_root / f"{parameter}_{val}"
         if lab_mode:
-            seeds = {
-                "python": random.getstate()[1][0],
-                "numpy": int(np.random.get_state()[1][0]),
-            }
+            seeds = {"python": random.getstate()[1][0]}
+            try:
+                seeds["numpy"] = int(np.random.get_state()[1][0])
+            except Exception:
+                try:
+                    rng = np.random.default_rng()
+                    seeds["numpy"] = int(rng.bit_generator.state["state"]["state"])
+                except Exception:
+                    seeds["numpy"] = 0
         t, i, v = sim.run(output_dir=str(run_dir))
         if lab_mode:
             ppc = getattr(getattr(cfg, "warpx_settings", None), "max_particles_per_cell", None)
             paths = [str(config_path)] if config_path else []
-            write_manifest(run_dir, config_paths=paths, ppc=ppc, seeds=seeds)
+            write_manifest(
+                run_dir,
+                config_paths=paths,
+                config=asdict(cfg),
+                ppc=ppc,
+                seeds=seeds,
+            )
         results[val] = (t, i, v)
     return results
 

--- a/tests/test_lab_mode_ensemble.py
+++ b/tests/test_lab_mode_ensemble.py
@@ -1,0 +1,29 @@
+import h5py_stub  # register h5py stub
+from click.testing import CliRunner
+from dpf2.core.config import DPFConfig
+from dpf2.cli.main import main
+
+
+def test_lab_mode_runs_multiple_shots(tmp_path):
+    cfg = DPFConfig()
+    cfg.to_file(tmp_path / "cfg.json")
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--lab-mode",
+            "simulate",
+            "--config",
+            str(tmp_path / "cfg.json"),
+            "--output",
+            str(tmp_path / "out"),
+            "--shots",
+            "2",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    shot0 = tmp_path / "out" / "shot_000"
+    shot1 = tmp_path / "out" / "shot_001"
+    assert (shot0 / "manifest.json").exists()
+    assert (shot1 / "manifest.json").exists()
+    assert any(p.suffix == ".h5" for p in shot0.iterdir())

--- a/tests/test_manifest_metadata.py
+++ b/tests/test_manifest_metadata.py
@@ -1,0 +1,13 @@
+import json
+
+from dpf2.cli.lab import write_manifest
+
+
+def test_manifest_includes_config_and_seeds(tmp_path):
+    cfg = {"foo": 1}
+    seeds = {"python": 42, "numpy": 99}
+    path = write_manifest(tmp_path, config=cfg, seeds=seeds)
+    data = json.loads(path.read_text())
+    assert data["code_hash"]
+    assert data["config"] == cfg
+    assert data["random_seeds"] == seeds

--- a/tests/test_simulation_hdf5_metadata.py
+++ b/tests/test_simulation_hdf5_metadata.py
@@ -1,0 +1,25 @@
+import json
+import hashlib
+import dataclasses
+
+import h5py_stub  # registers stub as h5py
+from dpf2.core.config import DPFConfig
+from dpf2.core.simulation import DPFSimulation
+import h5py  # type: ignore
+
+
+def test_hdf5_contains_metadata(tmp_path):
+    cfg = DPFConfig()
+    sim = DPFSimulation(cfg)
+    sim.run(end_time=0.0, output_dir=tmp_path)
+    with h5py.File(tmp_path / "data_0.000000e+00.h5", "r") as f:
+        meta_raw = f["metadata"][()]
+        if hasattr(meta_raw, "data"):
+            meta_raw = meta_raw.data
+        if hasattr(meta_raw, "item"):
+            meta_raw = meta_raw.item()
+        meta = json.loads(meta_raw)
+    expected = hashlib.sha256(
+        json.dumps(dataclasses.asdict(cfg), sort_keys=True).encode()
+    ).hexdigest()
+    assert meta["config_hash"] == expected


### PR DESCRIPTION
## Summary
- enhance `write_manifest` to record config data and RNG seeds
- write HDF5 outputs with config-aware metadata
- add `--shots` lab-mode option to run jittered ensembles and save manifests

## Testing
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*
- `pytest tests/test_manifest_metadata.py tests/test_simulation_hdf5_metadata.py tests/test_lab_mode_ensemble.py tests/test_manifest_warnings.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9b7469fe0832aba43ae5290154620