### PR TITLE
Add beam-target angular diagnostics and ToF alignment

### DIFF
--- a/src/dpf2/fusion.py
+++ b/src/dpf2/fusion.py
@@ -2,9 +2,18 @@ from __future__ import annotations
 
 """Fusion reaction models and neutron yield utilities."""
 
+import math
+from typing import Sequence
+
 import numpy as np
 
-__all__ = ["bosch_hale_dd", "dd_fusion_rates", "dd_channel_fractions"]
+__all__ = [
+    "bosch_hale_dd",
+    "dd_fusion_rates",
+    "dd_channel_fractions",
+    "dd_beam_target_angular_spectrum",
+    "dd_directional_yields",
+]
 
 
 def bosch_hale_dd(T_keV: float | np.ndarray) -> float | np.ndarray:
@@ -84,4 +93,61 @@ def dd_channel_fractions(
         "thermonuclear": thermo / total,
         "beam_target": beam / total,
     }
+
+
+def dd_beam_target_angular_spectrum(
+    beam_energy_keV: float,
+    n_beam: float,
+    n_target: float,
+    angles_deg: Sequence[float],
+) -> np.ndarray:
+    """Return simple beam–target yield per angle.
+
+    The distribution assumes a ``0.5*(1+cos^2(theta))`` dependence which captures
+    the forward/backward peaking of D–D beam–target fusion in a very crude
+    fashion.  ``angles_deg`` should span ``-180`` to ``180`` degrees.
+    """
+
+    if n_beam <= 0 or n_target <= 0:
+        return np.zeros(len(list(angles_deg)))
+    # ``bosch_hale_dd`` returns <sigma v>; approximate cross section by dividing
+    # by beam speed to provide a yield per solid angle.
+    sigma_v = bosch_hale_dd(beam_energy_keV)
+    e_j = beam_energy_keV * 1.0e3 * 1.602176634e-19
+    m_d = 3.343583719e-27  # deuteron mass in kg
+    v = math.sqrt(2.0 * e_j / m_d)
+    sigma = sigma_v / v
+    weights = [0.5 * (1.0 + math.cos(math.radians(a)) ** 2) for a in angles_deg]
+    return np.asarray([n_beam * n_target * sigma * w for w in weights])
+
+
+def dd_directional_yields(
+    beam_energy_keV: float,
+    n_beam: float,
+    n_target: float,
+    bins: int = 360,
+) -> dict[str, float]:
+    """Return forward, radial and backward yield components.
+
+    The angular domain is partitioned into three sectors covering the forward
+    (``|theta| < 30°``), radial (``30° ≤ |theta| ≤ 150°``) and backward
+    (``|theta| > 150°``) directions.  The sum of the three components equals the
+    total beam–target yield.
+    """
+
+    angles = [-180.0 + i * (360.0 / bins) for i in range(bins)]
+    spectrum = dd_beam_target_angular_spectrum(
+        beam_energy_keV, n_beam, n_target, angles
+    )
+    forward = radial = backward = 0.0
+    for ang, val in zip(angles, spectrum):
+        a = abs(float(ang))
+        v = float(val)
+        if a < 30.0:
+            forward += v
+        elif a > 150.0:
+            backward += v
+        else:
+            radial += v
+    return {"forward": forward, "radial": radial, "backward": backward}
 

--- a/src/dpf2/synthetic_diagnostics.py
+++ b/src/dpf2/synthetic_diagnostics.py
@@ -30,6 +30,7 @@ from .diagnostics.synthetic_signals import (
     rogowski_signal,
     bdot_signal,
 )
+from .fusion import dd_beam_target_angular_spectrum, dd_directional_yields
 
 
 class AngularDistribution:
@@ -63,13 +64,85 @@ def generate_tof_spectrum(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Create a synthetic time-of-flight spectrum from neutron energies."""
 
-    energies_j = np.asarray(energies_mev) * 1.602176634e-13
     m_n = 1.67492749804e-27  # neutron mass (kg)
-    v = np.sqrt(2.0 * energies_j / m_n)
-    tof = distance_m / v
-    counts, edges = np.histogram(tof, bins=bins)
+    tof_vals: List[float] = []
+    for e in energies_mev:
+        e_j = float(e) * 1.602176634e-13
+        v = (2.0 * e_j / m_n) ** 0.5
+        tof_vals.append(distance_m / v)
+    try:  # pragma: no cover - prefer numpy implementation
+        counts, edges = np.histogram(tof_vals, bins=bins)
+    except Exception:  # pragma: no cover - fallback for stub numpy
+        if not tof_vals:
+            edges = np.linspace(0.0, 1.0, bins + 1)
+            counts = np.zeros(bins)
+        else:
+            t_min = min(tof_vals)
+            t_max = max(tof_vals)
+            if t_max == t_min:
+                t_max = t_min + 1e-12
+            edges = np.linspace(t_min, t_max, bins + 1)
+            counts = np.zeros(bins)
+            span = t_max - t_min
+            for t in tof_vals:
+                idx = int((t - t_min) / span * bins)
+                if idx >= bins:
+                    idx = bins - 1
+                counts[idx] += 1.0
     centers = 0.5 * (edges[:-1] + edges[1:])
     return centers, counts
+
+
+def beam_target_angular_spectrum(
+    angles_deg: Sequence[float],
+    n_beam: float,
+    n_target: float,
+    beam_energy_keV: float,
+) -> np.ndarray:
+    """Normalized angular distribution for beam–target fusion."""
+
+    raw = dd_beam_target_angular_spectrum(
+        beam_energy_keV, n_beam, n_target, angles_deg
+    )
+    total = float(sum(raw))
+    if total > 0.0:
+        return raw / total
+    return raw
+
+
+def synthetic_tof_trace(
+    history: Sequence[CouplingState],
+    dt: float,
+    distance_m: float,
+    energies_mev: Sequence[float] | None = None,
+    align_to: Literal["current", "voltage"] = "current",
+    bins: int = 200,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Generate a synthetic TOF trace aligned to a current/voltage spike."""
+
+    energies = energies_mev if energies_mev is not None else (2.45,)
+    wave = (
+        current_waveform(history)
+        if align_to == "current"
+        else voltage_waveform(history)
+    )
+    if not wave:
+        return np.zeros(0), np.zeros(0)
+    arr = np.asarray(wave)
+    idx = int(np.argmax(np.abs(np.gradient(arr, dt))))
+    t0 = idx * dt
+    centers, counts = generate_tof_spectrum(energies, distance_m, bins)
+    return centers + t0, counts
+
+
+def export_directional_yields(
+    path: str | Path, yields: Dict[str, float]
+) -> Path:
+    """Write directional yield components to a JSON file."""
+
+    p = Path(path)
+    p.write_text(json.dumps(yields, indent=2))
+    return p
 
 
 class SyntheticInstrument(BaseModel):
@@ -318,6 +391,10 @@ def run_diagnostic_calculations(
         outputs["rogowski"] = rogowski_signal(hist, dt)
     if cfg.synthetic_bdot_signal_enabled:
         outputs["bdot"] = bdot_signal(hist, bdot_radius, dt)
+    if cfg.synthetic_neutron_tof_enabled:
+        times, counts = synthetic_tof_trace(hist, dt, 1.0)
+        outputs["neutron_tof_time"] = list(times)
+        outputs["neutron_tof_counts"] = list(counts)
     return outputs
 
 
@@ -390,5 +467,8 @@ __all__ = [
     "SyntheticInstrument",
     "run_diagnostic_calculations",
     "export_diagnostic_data",
-
+    "generate_tof_spectrum",
+    "beam_target_angular_spectrum",
+    "synthetic_tof_trace",
+    "export_directional_yields",
 ]

--- a/tests/test_directional_yields.py
+++ b/tests/test_directional_yields.py
@@ -1,0 +1,18 @@
+import json
+import math
+import pytest
+import numpy as np
+
+from dpf2.fusion import dd_beam_target_angular_spectrum, dd_directional_yields
+from dpf2.synthetic_diagnostics import export_directional_yields
+
+
+def test_directional_yields_symmetry(tmp_path):
+    angles = [-180.0 + i for i in range(360)]
+    spec = dd_beam_target_angular_spectrum(100.0, 1e18, 1e20, angles)
+    totals = dd_directional_yields(100.0, 1e18, 1e20, bins=360)
+    assert pytest.approx(sum(totals.values())) == float(sum(spec))
+    assert totals["forward"] == pytest.approx(totals["backward"], rel=1e-3)
+    out = export_directional_yields(tmp_path / "yields.json", totals)
+    data = json.loads(out.read_text())
+    assert data["forward"] == pytest.approx(totals["forward"])

--- a/tests/test_synthetic_tof_trace.py
+++ b/tests/test_synthetic_tof_trace.py
@@ -1,0 +1,18 @@
+import math
+import numpy as np
+
+from dpf2.synthetic_diagnostics import synthetic_tof_trace
+from dpf2.core.bases import CouplingState
+
+
+def test_tof_alignment():
+    history = [CouplingState(current=c, voltage=c) for c in [0.0, 1.0, 5.0, 1.0, 0.0]]
+    dt = 1e-9
+    times, counts = synthetic_tof_trace(history, dt, 1.0, energies_mev=[2.45])
+    idx = next(i for i, v in enumerate(counts) if v > 0)
+    tof_time = times[idx]
+    m_n = 1.67492749804e-27
+    E = 2.45 * 1.602176634e-13
+    v = math.sqrt(2.0 * E / m_n)
+    expected = 2 * dt + 1.0 / v
+    assert abs(tof_time - expected) / expected < 0.1


### PR DESCRIPTION
## Summary
- add beam–target angular spectrum and directional yield utilities
- generate synthetic time-of-flight traces aligned to current/voltage spikes
- support exporting forward/radial/backward yield components

## Testing
- `pytest tests/test_directional_yields.py tests/test_synthetic_tof_trace.py -q`
- `pytest tests/test_physics_extensions.py::test_bosch_hale_positive tests/test_physics_extensions.py::test_dd_fusion_rates_components tests/test_physics_extensions.py::test_dd_channel_fractions_normalized -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9c1c2bad4832a8cd6f1f36ff1322f