### PR TITLE
feat(web): add drag-and-drop geometry presets

### DIFF
--- a/web/frontend/src/GeometryPresets.jsx
+++ b/web/frontend/src/GeometryPresets.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+/**
+ * Drag-and-drop selection for common DPF geometries.
+ * Dropping a preset notifies the parent via onSelect.
+ */
+export default function GeometryPresets({ onSelect }) {
+  const presets = [
+    {
+      name: 'Mather',
+      value: 'mather',
+      description:
+        'Classic coaxial Mather-type geometry suited for high-density operation.',
+    },
+    {
+      name: 'Filippov',
+      value: 'filippov',
+      description:
+        'Filippov geometry with a broad anode offering a short rundown time.',
+    },
+  ];
+
+  const handleDragStart = (e, value) => {
+    e.dataTransfer.setData('text/plain', value);
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    const val = e.dataTransfer.getData('text/plain');
+    if (val && onSelect) onSelect(val);
+  };
+
+  const handleDragOver = (e) => e.preventDefault();
+
+  return (
+    <div className="overlay" title="Choose a preset electrode geometry">
+      <h4>Geometry Presets</h4>
+      <div className="presets">
+        {presets.map((p) => (
+          <div
+            key={p.value}
+            draggable
+            onDragStart={(e) => handleDragStart(e, p.value)}
+            className="preset"
+            title={p.description}
+          >
+            {p.name}
+          </div>
+        ))}
+      </div>
+      <div
+        className="dropzone"
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        title="Drag a preset here to select it"
+      >
+        Drop Here
+      </div>
+      <details>
+        <summary>What is this?</summary>
+        Drag either the Mather or Filippov option into the drop zone to apply
+        that geometry to a new configuration set.
+      </details>
+    </div>
+  );
+}
+

--- a/web/frontend/src/ProjectManager.jsx
+++ b/web/frontend/src/ProjectManager.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import axios from 'axios';
 import YieldPressureOverlay from './YieldPressureOverlay.jsx';
 import EfficiencyCurveOverlay from './EfficiencyCurveOverlay.jsx';
+import GeometryPresets from './GeometryPresets.jsx';
 
 export default function ProjectManager({ projects = [] }) {
   const [configSets, setConfigSets] = useState(projects);
@@ -162,28 +163,20 @@ export default function ProjectManager({ projects = [] }) {
 
       <form onSubmit={addConfigSet}>
         <h4>Add Configuration Set</h4>
-        <select
-          value={preset}
-          onChange={(e) => setPreset(e.target.value)}
-          title="Choose a starting geometry"
-        >
-          <option value="">Geometry Preset</option>
-          <option value="tapered">Tapered</option>
-          <option value="hollow">Hollow</option>
-          <option value="re-entrant">Re-entrant</option>
-        </select>
+        <GeometryPresets onSelect={setPreset} />
+        {preset && <p>Selected geometry: {preset}</p>}
 
         <input
           type="file"
-          onChange={(e) => setCad(e.target.files[0])}
+          onChange={handleFile}
           title="Optional CAD file for custom geometry"
         />
         <button type="submit" title="Upload the configuration set">Add</button>
         <details>
           <summary>What is this?</summary>
-          Select a preset geometry or upload a CAD file to create a new
-          configuration set. These settings can later be exported for
-          sharing.
+          Drag a geometry preset into the drop zone or upload a CAD file to
+          create a new configuration set. These settings can later be exported
+          for sharing.
         </details>
 
       </form>


### PR DESCRIPTION
## Summary
- Introduce GeometryPresets component with drag-and-drop Mather and Filippov options
- Hook presets into project manager and expose selected geometry
- Document geometry selection with tooltips for sandbox users

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs/plugin-react)*
- `pytest` *(fails: 52 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c1c74308832a9c87388aa41fc6a8