### PR TITLE
Add CR-39/RCF and Faraday cup synthetic diagnostics

### DIFF
--- a/examples/diagnostics/csv_export_example.ipynb
+++ b/examples/diagnostics/csv_export_example.ipynb
@@ -1,0 +1,45 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Synthetic diagnostics CSV export"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "from dpf2.synthetic_diagnostics import SyntheticDiagnostics, run_diagnostic_calculations, export_diagnostic_data\n",
+        "from dpf2.core.bases import CouplingState\n",
+        "history = [CouplingState(current=i, voltage=i*2.0) for i in range(5)]\n",
+        "cfg = SyntheticDiagnostics.with_defaults().model_copy(update={\n",
+        "    'synthetic_cr39_image_enabled': True,\n",
+        "    'synthetic_rcf_image_enabled': True,\n",
+        "    'synthetic_faraday_iedf_enabled': True,\n",
+        "    'synthetic_faraday_eedf_enabled': True,\n",
+        "    'diagnostic_output_type': {'cr39_image': 'image', 'rcf_image': 'image'},\n",
+        "})\n",
+        "results = run_diagnostic_calculations(history, cfg, dt=1.0)\n",
+        "export_diagnostic_data(results, cfg.model_copy(update={'output_format': 'csv'}), Path('output_csv'))\n",
+        "list(Path('output_csv').glob('*'))\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3",
+      "language": "python"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/examples/diagnostics/hdf5_export_example.ipynb
+++ b/examples/diagnostics/hdf5_export_example.ipynb
@@ -1,0 +1,45 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Synthetic diagnostics HDF5 export"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from pathlib import Path\n",
+        "from dpf2.synthetic_diagnostics import SyntheticDiagnostics, run_diagnostic_calculations, export_diagnostic_data\n",
+        "from dpf2.core.bases import CouplingState\n",
+        "history = [CouplingState(current=i, voltage=i*2.0) for i in range(5)]\n",
+        "cfg = SyntheticDiagnostics.with_defaults().model_copy(update={\n",
+        "    'synthetic_cr39_image_enabled': True,\n",
+        "    'synthetic_rcf_image_enabled': True,\n",
+        "    'synthetic_faraday_iedf_enabled': True,\n",
+        "    'synthetic_faraday_eedf_enabled': True,\n",
+        "    'diagnostic_output_type': {'cr39_image': 'image', 'rcf_image': 'image'},\n",
+        "})\n",
+        "results = run_diagnostic_calculations(history, cfg, dt=1.0)\n",
+        "export_diagnostic_data(results, cfg.model_copy(update={'output_format': 'hdf5'}), Path('output_hdf5'))\n",
+        "list(Path('output_hdf5').glob('*'))\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3",
+      "language": "python"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/examples/diagnostics/run_csv_export.py
+++ b/examples/diagnostics/run_csv_export.py
@@ -11,8 +11,16 @@ from dpf2.core.bases import CouplingState
 # Generate a small history of coupling states
 history = [CouplingState(current=i, voltage=i * 2.0) for i in range(5)]
 
-# Use default diagnostic settings which enable current and voltage waveforms
-cfg = SyntheticDiagnostics.with_defaults()
+# Enable additional diagnostics including CR-39/RCF images and Faraday cup
+cfg = SyntheticDiagnostics.with_defaults().model_copy(
+    update={
+        "synthetic_cr39_image_enabled": True,
+        "synthetic_rcf_image_enabled": True,
+        "synthetic_faraday_iedf_enabled": True,
+        "synthetic_faraday_eedf_enabled": True,
+        "diagnostic_output_type": {"cr39_image": "image", "rcf_image": "image"},
+    }
+)
 
 # Compute diagnostic signals and export them to CSV files in ``output_csv``
 results = run_diagnostic_calculations(history, cfg, dt=1.0)

--- a/examples/diagnostics/run_hdf5_export.py
+++ b/examples/diagnostics/run_hdf5_export.py
@@ -10,9 +10,19 @@ from dpf2.core.bases import CouplingState
 
 history = [CouplingState(current=i, voltage=i * 2.0) for i in range(5)]
 
-cfg = SyntheticDiagnostics.with_defaults()
+cfg = SyntheticDiagnostics.with_defaults().model_copy(
+    update={
+        "synthetic_cr39_image_enabled": True,
+        "synthetic_rcf_image_enabled": True,
+        "synthetic_faraday_iedf_enabled": True,
+        "synthetic_faraday_eedf_enabled": True,
+        "diagnostic_output_type": {"cr39_image": "image", "rcf_image": "image"},
+    }
+)
 
 results = run_diagnostic_calculations(history, cfg, dt=1.0)
-export_diagnostic_data(results, cfg.model_copy(update={"output_format": "hdf5"}), Path("output_hdf5"))
+export_diagnostic_data(
+    results, cfg.model_copy(update={"output_format": "hdf5"}), Path("output_hdf5")
+)
 
 print("HDF5 files:", [p.name for p in Path("output_hdf5").glob("*")])

--- a/src/dpf2/synthetic_diagnostics.py
+++ b/src/dpf2/synthetic_diagnostics.py
@@ -72,6 +72,51 @@ def generate_tof_spectrum(
     return centers, counts
 
 
+def _cr39_image(history: Sequence[CouplingState], size: int = 64) -> List[List[float]]:
+    """Return a simple Gaussian spot image scaled by peak current."""
+
+    amp = max((abs(s.current) for s in history), default=0.0)
+    x = np.linspace(-1.0, 1.0, size)
+    y = np.linspace(-1.0, 1.0, size)
+    xv, yv = np.meshgrid(x, y)
+    sigma = 0.3
+    img = amp * np.exp(-(xv ** 2 + yv ** 2) / (2.0 * sigma ** 2))
+    return img.tolist()
+
+
+def _rcf_image(history: Sequence[CouplingState], size: int = 64) -> List[List[float]]:
+    """Return a ring-shaped image scaled by peak voltage."""
+
+    amp = max((abs(s.voltage) for s in history), default=0.0)
+    x = np.linspace(-1.0, 1.0, size)
+    y = np.linspace(-1.0, 1.0, size)
+    xv, yv = np.meshgrid(x, y)
+    r = np.sqrt(xv ** 2 + yv ** 2)
+    sigma = 0.1
+    img = amp * np.exp(-((r - 0.5) ** 2) / (2.0 * sigma ** 2))
+    return img.tolist()
+
+
+def _faraday_iedf(history: Sequence[CouplingState], bins: int = 50) -> List[float]:
+    """Generate a synthetic ion energy distribution function."""
+
+    max_energy = max((abs(s.voltage) for s in history), default=1.0)
+    energies = np.linspace(0.0, max_energy, bins)
+    temp = max_energy / 5.0 if max_energy > 0 else 1.0
+    dist = energies * np.exp(-energies / temp)
+    return dist.tolist()
+
+
+def _faraday_eedf(history: Sequence[CouplingState], bins: int = 50) -> List[float]:
+    """Generate a synthetic electron energy distribution function."""
+
+    max_energy = max((abs(s.voltage) for s in history), default=1.0)
+    energies = np.linspace(0.0, max_energy, bins)
+    temp = max_energy / 7.0 if max_energy > 0 else 1.0
+    dist = np.sqrt(energies) * np.exp(-energies / temp)
+    return dist.tolist()
+
+
 class SyntheticInstrument(BaseModel):
     """Per-instrument overrides for synthetic diagnostics."""
 
@@ -133,6 +178,10 @@ class SyntheticDiagnostics(ConfigSectionBase):
     synthetic_xray_pinhole_enabled: bool = Field(True, alias="syntheticXrayPinholeEnabled")
     synthetic_thomson_parabola_enabled: bool = Field(False, alias="syntheticThomsonParabolaEnabled")
     synthetic_optical_interferogram_enabled: bool = Field(False, alias="syntheticOpticalInterferogramEnabled")
+    synthetic_cr39_image_enabled: bool = Field(False, alias="syntheticCr39ImageEnabled")
+    synthetic_rcf_image_enabled: bool = Field(False, alias="syntheticRcfImageEnabled")
+    synthetic_faraday_iedf_enabled: bool = Field(False, alias="syntheticFaradayIedfEnabled")
+    synthetic_faraday_eedf_enabled: bool = Field(False, alias="syntheticFaradayEedfEnabled")
 
     # Diagnostic classification and labeling
     detector_ids: Optional[List[str]] = Field(None, alias="detectorIds")
@@ -208,6 +257,10 @@ class SyntheticDiagnostics(ConfigSectionBase):
             (self.synthetic_bdot_signal_enabled, "B-dot"),
             (self.synthetic_neutron_tof_enabled, "TOF"),
             (self.synthetic_xray_pinhole_enabled, "X-ray"),
+            (self.synthetic_cr39_image_enabled, "CR39"),
+            (self.synthetic_rcf_image_enabled, "RCF"),
+            (self.synthetic_faraday_iedf_enabled, "IEDF"),
+            (self.synthetic_faraday_eedf_enabled, "EEDF"),
         ]
         active = [name for flag, name in diag_flags if flag]
         filt = "None"
@@ -240,6 +293,10 @@ class SyntheticDiagnostics(ConfigSectionBase):
             "bdot_signal": self.synthetic_bdot_signal_enabled,
             "neutron_tof": self.synthetic_neutron_tof_enabled,
             "xray_pinhole": self.synthetic_xray_pinhole_enabled,
+            "cr39_image": self.synthetic_cr39_image_enabled,
+            "rcf_image": self.synthetic_rcf_image_enabled,
+            "faraday_iedf": self.synthetic_faraday_iedf_enabled,
+            "faraday_eedf": self.synthetic_faraday_eedf_enabled,
         }
         return [name for name, flag in mapping.items() if flag]
 
@@ -318,6 +375,14 @@ def run_diagnostic_calculations(
         outputs["rogowski"] = rogowski_signal(hist, dt)
     if cfg.synthetic_bdot_signal_enabled:
         outputs["bdot"] = bdot_signal(hist, bdot_radius, dt)
+    if cfg.synthetic_cr39_image_enabled:
+        outputs["cr39_image"] = _cr39_image(hist)
+    if cfg.synthetic_rcf_image_enabled:
+        outputs["rcf_image"] = _rcf_image(hist)
+    if cfg.synthetic_faraday_iedf_enabled:
+        outputs["faraday_iedf"] = _faraday_iedf(hist)
+    if cfg.synthetic_faraday_eedf_enabled:
+        outputs["faraday_eedf"] = _faraday_eedf(hist)
     return outputs
 
 

--- a/tests/test_synthetic_diagnostics.py
+++ b/tests/test_synthetic_diagnostics.py
@@ -170,3 +170,33 @@ def test_export_image_and_map(tmp_path):
     with h5py.File(tmp_path / "img.h5", "r") as fh:
         assert fh["img"].shape == (2, 2)
 
+
+def test_new_diagnostics(tmp_path):
+    history = [
+        CouplingState(current=1.0, voltage=2.0),
+        CouplingState(current=2.0, voltage=4.0),
+    ]
+    cfg = SyntheticDiagnostics.with_defaults().model_copy(
+        update={
+            "synthetic_cr39_image_enabled": True,
+            "synthetic_rcf_image_enabled": True,
+            "synthetic_faraday_iedf_enabled": True,
+            "synthetic_faraday_eedf_enabled": True,
+            "diagnostic_output_type": {"cr39_image": "image", "rcf_image": "image"},
+            "output_format": "csv",
+        }
+    )
+    data = run_diagnostic_calculations(history, cfg, dt=1.0)
+    assert "cr39_image" in data and len(data["cr39_image"]) > 0
+    assert "rcf_image" in data and len(data["rcf_image"]) > 0
+    assert "faraday_iedf" in data and len(data["faraday_iedf"]) == 50
+    assert "faraday_eedf" in data and len(data["faraday_eedf"]) == 50
+    export_diagnostic_data(data, cfg, tmp_path)
+    assert (tmp_path / "cr39_image.csv").exists()
+    assert (tmp_path / "faraday_iedf.csv").exists()
+
+    cfg_h5 = cfg.model_copy(update={"output_format": "hdf5"})
+    export_diagnostic_data(data, cfg_h5, tmp_path)
+    with h5py.File(tmp_path / "rcf_image.h5", "r") as fh:
+        assert fh["rcf_image"].shape[0] == len(data["rcf_image"])
+


### PR DESCRIPTION
## Summary
- model CR-39 and RCF image diagnostics and Faraday cup IEDF/EEDF distributions
- support exporting these diagnostics to CSV/HDF5 with new example notebooks
- test coverage for additional synthetic diagnostics

## Testing
- `pytest` *(fails: missing dependencies in unrelated tests)*
- `pytest tests/test_synthetic_diagnostics.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9c1c8d290832ab4268704f200bedf