### PR TITLE
Log run metadata in HDF5 outputs and document reproducibility

### DIFF
--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -1,0 +1,29 @@
+# Reproducibility Workflow
+
+DPF2 provides tooling to capture provenance for each simulation run.
+
+## CLI Metadata
+
+Running simulations through the command line interface writes metadata into
+every generated HDF5 output.  Each file records:
+
+- the git commit hash of the codebase at run time,
+- the full configuration used for the run, and
+- random number generator seeds used by Python and NumPy.
+
+This information allows exact reproduction of results from a single HDF5
+output file.
+
+## Run Manifests
+
+When executing in lab mode or other batch-oriented commands, a manifest is
+stored in each run directory.  The manifest is available as both
+`manifest.json` and `manifest.h5` and mirrors the metadata embedded in the
+HDF5 outputs.
+
+Manifests include paths to configuration files, computed seeds and additional
+provenance details such as maximum particles-per-cell or any warnings
+encountered during the run.
+
+These files enable auditing of large parameter sweeps or shot ensembles.
+

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -523,7 +523,7 @@ def simulate(
 
             progress_cb = _update
 
-        run_kwargs = {"output_dir": output, "verbose": verbose}
+        run_kwargs = {"output_dir": output, "verbose": verbose, "seeds": seeds}
         if progress_cb is not None:
             run_kwargs["progress_cb"] = progress_cb
         times, currents, voltages = sim.run(**run_kwargs)
@@ -614,7 +614,7 @@ def simulate(
                         )
                     except Exception:
                         shot_seeds["numpy"] = 0
-                shot_sim.run(output_dir=str(shot_dir))
+                shot_sim.run(output_dir=str(shot_dir), seeds=shot_seeds)
                 ppc = getattr(
                     getattr(shot_cfg, "warpx_settings", None),
                     "max_particles_per_cell",

--- a/src/dpf2/core/simulation.py
+++ b/src/dpf2/core/simulation.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Dict
 import logging
 from dataclasses import asdict
 
@@ -50,6 +50,7 @@ class DPFSimulation:
         end_time: float | None = None,
         output_dir: str | None = None,
         output_interval: float | None = None,
+        seeds: Dict[str, int] | None = None,
         verbose: bool = False,
         progress_cb: Callable[[int, float], None] | None = None,
     ) -> tuple[list[float], list[float], list[float]]:
@@ -79,7 +80,7 @@ class DPFSimulation:
         interval = output_interval or end
 
         Path(out).mkdir(parents=True, exist_ok=True)
-        self.writer = DataWriter(out, config=asdict(self.config))
+        self.writer = DataWriter(out, config=asdict(self.config), seeds=seeds)
 
         # Write initial state
         self.writer.write_hdf5({"current": self.current, "voltage": self.voltage}, time=self.time)

--- a/src/dpf2/io/data_writer.py
+++ b/src/dpf2/io/data_writer.py
@@ -23,13 +23,27 @@ from ..mesh import Mesh2D
 class DataWriter:
     """Write simulation data to disk with provenance metadata."""
 
-    def __init__(self, output_dir: str, config: Dict[str, Any] | None = None) -> None:
+    def __init__(
+        self,
+        output_dir: str,
+        config: Dict[str, Any] | None = None,
+        seeds: Dict[str, int] | None = None,
+    ) -> None:
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.metadata = {
             "config_hash": self._hash_config(config),
             "git_commit": self._git_commit(),
         }
+        if config is not None:
+            try:
+                self.metadata["config"] = json.loads(
+                    json.dumps(config, sort_keys=True)
+                )
+            except Exception:
+                self.metadata["config"] = {k: str(v) for k, v in config.items()}
+        if seeds is not None:
+            self.metadata["seeds"] = seeds
 
     @staticmethod
     def _hash_config(config: Dict[str, Any] | None) -> str:

--- a/src/dpf2/optimization/param_sweep.py
+++ b/src/dpf2/optimization/param_sweep.py
@@ -54,6 +54,7 @@ def run_parametric_sweep(
         cfg = DPFConfig(**cfg_dict)
         sim = DPFSimulation(cfg)
         run_dir = out_root / f"{parameter}_{val}"
+        seeds = None
         if lab_mode:
             seeds = {"python": random.getstate()[1][0]}
             try:
@@ -64,7 +65,7 @@ def run_parametric_sweep(
                     seeds["numpy"] = int(rng.bit_generator.state["state"]["state"])
                 except Exception:
                     seeds["numpy"] = 0
-        t, i, v = sim.run(output_dir=str(run_dir))
+        t, i, v = sim.run(output_dir=str(run_dir), seeds=seeds)
         if lab_mode:
             ppc = getattr(getattr(cfg, "warpx_settings", None), "max_particles_per_cell", None)
             paths = [str(config_path)] if config_path else []

--- a/tests/test_simulation_hdf5_metadata.py
+++ b/tests/test_simulation_hdf5_metadata.py
@@ -11,7 +11,8 @@ import h5py  # type: ignore
 def test_hdf5_contains_metadata(tmp_path):
     cfg = DPFConfig()
     sim = DPFSimulation(cfg)
-    sim.run(end_time=0.0, output_dir=tmp_path)
+    seeds = {"python": 1, "numpy": 2}
+    sim.run(end_time=0.0, output_dir=tmp_path, seeds=seeds)
     with h5py.File(tmp_path / "data_0.000000e+00.h5", "r") as f:
         meta_raw = f["metadata"][()]
         if hasattr(meta_raw, "data"):
@@ -23,3 +24,6 @@ def test_hdf5_contains_metadata(tmp_path):
         json.dumps(dataclasses.asdict(cfg), sort_keys=True).encode()
     ).hexdigest()
     assert meta["config_hash"] == expected
+    assert meta["config"] == dataclasses.asdict(cfg)
+    assert meta["seeds"] == seeds
+    assert "git_commit" in meta


### PR DESCRIPTION
## Summary
- Record git commit, configuration, and RNG seeds in HDF5 metadata
- Pass seed metadata through CLI simulations and parameter sweeps
- Document reproducibility workflow and manifests

## Testing
- `pytest tests/test_simulation_hdf5_metadata.py tests/test_lab_mode_ensemble.py tests/test_param_sweep.py`
- `pytest tests/test_param_sweep.py -vv` *(skipped: requires matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c1ccace8832a91c2c083f35db808