### PR TITLE
feat: add emcee-based calibration for mass and current factors

### DIFF
--- a/examples/notebooks/mass_current_calibration.ipynb
+++ b/examples/notebooks/mass_current_calibration.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Mass/Current Calibration Demo\n",
+    "This notebook demonstrates using `dpf2.uq.calibration.emcee_calibrate_mass_current` to\n",
+    "estimate posterior distributions of mass and current scaling factors\n",
+    "from time-of-flight and current waveform data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from dpf2.uq.calibration import emcee_calibrate_mass_current\n",
+    "\n",
+    "rng = np.random.default_rng(0)\n",
+    "time = np.linspace(0, 1e-6, 50)\n",
+    "current_sim = 1e5 * np.sin(2 * np.pi * time / time[-1])\n",
+    "tof_sim = np.array([100e-9])\n",
+    "\n",
+    "true_mass = 1.2\n",
+    "true_current = 0.8\n",
+    "\n",
+    "current_data = true_current * current_sim + rng.normal(0, 1e4, size=current_sim.shape)\n",
+    "tof_data = true_mass * tof_sim + rng.normal(0, 5e-9, size=tof_sim.shape)\n",
+    "\n",
+    "samples = emcee_calibrate_mass_current(\n",
+    "    current_sim,\n",
+    "    current_data,\n",
+    "    tof_sim,\n",
+    "    tof_data,\n",
+    "    bounds={\"mass_factor\": (0.5, 1.5), \"current_factor\": (0.5, 1.5)},\n",
+    "    n_steps=500,\n",
+    "    seed=123,\n",
+    ")\n",
+    "print({k: (np.mean(v), np.std(v)) for k, v in samples.items()})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dpf2/uq/__init__.py
+++ b/src/dpf2/uq/__init__.py
@@ -1,7 +1,11 @@
 """Uncertainty quantification utilities."""
 
 from .sampling import latin_hypercube, sobol_sample
-from .calibration import bayesian_calibration, nested_calibration
+from .calibration import (
+    bayesian_calibration,
+    nested_calibration,
+    emcee_calibrate_mass_current,
+)
 from .inference import emcee_infer, dynesty_infer
 
 __all__ = [
@@ -9,6 +13,7 @@ __all__ = [
     "sobol_sample",
     "bayesian_calibration",
     "nested_calibration",
+    "emcee_calibrate_mass_current",
     "emcee_infer",
     "dynesty_infer",
 ]

--- a/src/dpf2/uq/calibration.py
+++ b/src/dpf2/uq/calibration.py
@@ -159,5 +159,77 @@ def nested_calibration(
     return {name: samples[:, idx] for idx, name in enumerate(names)}
 
 
-__all__ = ["bayesian_calibration", "nested_calibration"]
+def emcee_calibrate_mass_current(
+    current_sim: np.ndarray,
+    current_data: np.ndarray,
+    tof_sim: np.ndarray,
+    tof_data: np.ndarray,
+    bounds: Bounds | None = None,
+    n_walkers: int = 32,
+    n_steps: int = 1000,
+    sigma_current: float = 1.0,
+    sigma_tof: float = 1.0,
+    seed: int | None = None,
+) -> Dict[str, np.ndarray]:
+    """Estimate mass and current scaling factors using :mod:`emcee`.
+
+    The function assumes ``current_sim`` and ``tof_sim`` represent baseline
+    model predictions.  The unknown multiplicative ``mass_factor`` and
+    ``current_factor`` scale these predictions to best match the measured
+    ``current_data`` and ``tof_data``.
+
+    Parameters
+    ----------
+    current_sim, current_data:
+        Arrays of simulated and measured current waveforms.
+    tof_sim, tof_data:
+        Arrays of simulated and measured time-of-flight values.
+    bounds:
+        Optional mapping providing ``(min, max)`` pairs for ``mass_factor`` and
+        ``current_factor``.  Defaults to ``(0.5, 1.5)`` for each if omitted.
+    n_walkers, n_steps:
+        Controls for the ensemble sampler.
+    sigma_current, sigma_tof:
+        Standard deviations of the observational noise for each dataset.
+    seed:
+        Optional seed for reproducibility.
+    """
+
+    try:  # pragma: no cover - dependency may be optional
+        import emcee  # type: ignore
+    except Exception as exc:  # pragma: no cover - import error path
+        raise RuntimeError("emcee is required for emcee_calibrate_mass_current") from exc
+
+    if bounds is None:
+        bounds = {"mass_factor": (0.5, 1.5), "current_factor": (0.5, 1.5)}
+
+    names = ["mass_factor", "current_factor"]
+    lower = np.array([bounds[n][0] for n in names])
+    upper = np.array([bounds[n][1] for n in names])
+
+    def log_prob(theta: np.ndarray) -> float:
+        if np.any(theta < lower) or np.any(theta > upper):
+            return -np.inf
+        mass_factor, current_factor = theta
+        curr_pred = current_factor * np.asarray(current_sim)
+        tof_pred = mass_factor * np.asarray(tof_sim)
+        resid_current = (np.asarray(current_data) - curr_pred) / sigma_current
+        resid_tof = (np.asarray(tof_data) - tof_pred) / sigma_tof
+        return -0.5 * (
+            np.dot(resid_current, resid_current) + np.dot(resid_tof, resid_tof)
+        )
+
+    rng = np.random.default_rng(seed)
+    p0 = lower + (upper - lower) * rng.random((n_walkers, len(names)))
+    sampler = emcee.EnsembleSampler(n_walkers, len(names), log_prob)
+    sampler.run_mcmc(p0, n_steps, progress=False)
+    chain = sampler.get_chain(discard=n_steps // 2, flat=True)
+    return {name: chain[:, idx] for idx, name in enumerate(names)}
+
+
+__all__ = [
+    "bayesian_calibration",
+    "nested_calibration",
+    "emcee_calibrate_mass_current",
+]
 

--- a/tests/test_emcee_calibration.py
+++ b/tests/test_emcee_calibration.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from dpf2.uq.calibration import emcee_calibrate_mass_current
+
+
+def test_emcee_calibrate_mass_current():
+    pytest.importorskip("emcee")
+    rng = np.random.default_rng(0)
+
+    current_sim = np.linspace(0.0, 1.0, 5)
+    tof_sim = np.array([1.0])
+
+    true_mass = 1.2
+    true_current = 0.8
+
+    current_data = true_current * current_sim + rng.normal(0, 0.01, size=current_sim.shape)
+    tof_data = true_mass * tof_sim + rng.normal(0, 0.01, size=tof_sim.shape)
+
+    samples = emcee_calibrate_mass_current(
+        current_sim,
+        current_data,
+        tof_sim,
+        tof_data,
+        bounds={"mass_factor": (0.5, 2.0), "current_factor": (0.5, 2.0)},
+        n_walkers=10,
+        n_steps=50,
+        sigma_current=0.01,
+        sigma_tof=0.01,
+        seed=0,
+    )
+
+    mean_mass = float(np.mean(samples["mass_factor"]))
+    mean_current = float(np.mean(samples["current_factor"]))
+
+    assert abs(mean_mass - true_mass) < 0.2
+    assert abs(mean_current - true_current) < 0.2


### PR DESCRIPTION
## Summary
- extend calibration utilities with `emcee_calibrate_mass_current` for joint mass/current inference
- expose new calibration helper in `dpf2.uq` package
- add tutorial notebook demonstrating mass/current posterior estimation

## Testing
- `pytest tests/test_bayesian_calibration.py tests/test_uq_inference.py tests/test_emcee_calibration.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9c1ce0be8832a8359624d766a01a3