### PR TITLE
Add quality metrics dashboard for solvers

### DIFF
--- a/src/dpf2/diagnostics/quality_dashboard.py
+++ b/src/dpf2/diagnostics/quality_dashboard.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class QualityDashboard:
+    """Collect and persist basic quality metrics for simulation steps."""
+
+    output_dir: Path = Path("synthetic_diagnostics/quality")
+    min_cfl: float | None = None
+    min_lambda_D: float | None = None
+    min_ppc: float | None = None
+    history: list[dict[str, float]] = field(default_factory=list)
+
+    def log(
+        self,
+        step: int,
+        dt: float,
+        cell_size: float,
+        ppc: float,
+        cfl: float,
+        lambda_D: float,
+    ) -> None:
+        """Record a step's metrics and emit warnings if thresholds violated."""
+        entry = {
+            "step": step,
+            "dt": dt,
+            "cell_size": cell_size,
+            "ppc": ppc,
+            "cfl": cfl,
+            "lambda_D": lambda_D,
+        }
+        self.history.append(entry)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        with open(self.output_dir / "dashboard.json", "w", encoding="utf-8") as fh:
+            json.dump(self.history, fh, indent=2)
+
+        if self.min_cfl is not None and cfl < self.min_cfl:
+            logger.warning("CFL below threshold: %g < %g", cfl, self.min_cfl)
+        if self.min_lambda_D is not None and lambda_D < self.min_lambda_D:
+            logger.warning(
+                "Debye length below threshold: %g < %g", lambda_D, self.min_lambda_D
+            )
+        if self.min_ppc is not None and ppc < self.min_ppc:
+            logger.warning(
+                "Particles per cell below threshold: %g < %g", ppc, self.min_ppc
+            )

--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Tuple
 from typing import Protocol
 
+import logging
 import numpy as np
 try:  # pragma: no cover - allow running without SciPy
     from scipy.constants import mu_0
@@ -30,6 +31,9 @@ from dpf2.core.bases import CircuitSolverBase, PlasmaSolverBase, CouplingState
 from .eos import EOSBase, IdealGasEOS
 from .boundary_conditions import KineticSheath
 from .physics.energy import EnergyTracker
+from .diagnostics.quality_dashboard import QualityDashboard
+
+logger = logging.getLogger(__name__)
 
 class ChemistryModule(Protocol):
     """Minimal interface for chemistry plugins."""
@@ -337,6 +341,8 @@ class HallMHDSolver(PlasmaSolverBase):
     last_opacity: np.ndarray | None = field(init=False, default=None)
     last_emissivity: np.ndarray | None = field(init=False, default=None)
     cart_comm: Any | None = field(init=False, default=None)
+    quality: QualityDashboard | None = None
+    step_count: int = 0
 
     def __post_init__(self) -> None:
         """Initialise MPI cartesian communicator for domain decomposition."""
@@ -710,6 +716,34 @@ class HallMHDSolver(PlasmaSolverBase):
                 thermal=float(np.sum(thermal_final)),
                 magnetic=float(np.sum(magnetic_final)),
                 radiative=rad,
+            )
+
+        if self.quality is not None:
+            self.step_count += 1
+            dx = getattr(self.mesh, "dx", 1.0)
+            dy = getattr(self.mesh, "dy", dx)
+            dz = getattr(self.mesh, "dz", dx)
+            cell_size = min(dx, dy, dz)
+            cell_volume = dx * dy * dz
+            max_speed = float(np.max(np.linalg.norm(v_final, axis=-1)))
+            cfl = max_speed * dt / cell_size if cell_size > 0 else 0.0
+            ion_mass = getattr(self, "ion_mass", getattr(self.sheath, "ion_mass", 1.6726219e-27))
+            ne = rho * np.maximum(zbar, 1e-30) / ion_mass
+            try:
+                from scipy.constants import e, epsilon_0, k
+            except Exception:  # pragma: no cover
+                e = 1.602176634e-19
+                epsilon_0 = 8.8541878128e-12
+                k = 1.380649e-23
+            lambda_D = np.sqrt(epsilon_0 * k * T / (ne * e**2))
+            ppc = float(np.mean(ne) * cell_volume)
+            self.quality.log(
+                self.step_count,
+                dt,
+                cell_size,
+                ppc,
+                cfl,
+                float(np.mean(lambda_D)),
             )
 
         return new_state

--- a/src/dpf2/simulation/pic_solver.py
+++ b/src/dpf2/simulation/pic_solver.py
@@ -23,6 +23,7 @@ from typing import List, Dict, Tuple, Optional, Callable
 from pathlib import Path
 from ..core.bases import CouplingState
 from ..diagnostics import synthetic_signals
+from ..diagnostics.quality_dashboard import QualityDashboard
 from .config_schema import PICConfig
 from .models import PhysicsModule
 from .utils import FieldManager, SimulationState
@@ -100,7 +101,7 @@ class PICSolver(PhysicsModule):
     # Miscellaneous constants
     ionization_energy = 13.6     # eV, used for Bethe-Bloch stopping
 
-    def __init__(self, config: PICConfig, field_manager: FieldManager):
+    def __init__(self, config: PICConfig, field_manager: FieldManager, quality: QualityDashboard | None = None):
         """
         Initializes the PICSolver with configuration parameters.
 
@@ -156,6 +157,8 @@ class PICSolver(PhysicsModule):
         self.history: List[CouplingState] = []
         self.m0_instability_model: Optional[MZeroInstability] = None
         self.anomalous_resistivity_model: Optional[AnomalousResistivity] = None
+        self.quality = quality
+        self.step_count = 0
         logger.info('PIC solver initialized')
 
     def add_species(self, name, charge, mass, positions, velocities):
@@ -521,6 +524,39 @@ class PICSolver(PhysicsModule):
             emf = axial_E * length
             self.coupling_state = CouplingState(emf=emf, current=current, voltage=voltage, back_reaction=emf)
             self.history.append(self.coupling_state)
+            if self.quality:
+                self.step_count += 1
+                cell_size = min(self.dx, self.dy, self.dz)
+                cell_volume = self.dx * self.dy * self.dz
+                total_particles = sum(spc['pos'].shape[0] for spc in self.species.values())
+                ppc = total_particles / (self.nx * self.ny * self.nz)
+                max_v = 0.0
+                for spc in self.species.values():
+                    speeds = np.linalg.norm(spc['vel'], axis=1)
+                    if speeds.size:
+                        max_v = max(max_v, float(np.max(speeds)))
+                cfl = max_v * self.dt / cell_size if cell_size > 0 else 0.0
+                ne = 0.0
+                Te = 0.0
+                for spc in self.species.values():
+                    if spc['q'] < 0 and spc['pos'].size:
+                        ne = spc['pos'].shape[0] / (self.nx * self.ny * self.nz * cell_volume)
+                        ke = 0.5 * spc['m'] * np.mean(np.sum(spc['vel']**2, axis=1))
+                        Te = (2.0 / 3.0) * ke / PICSolver.k_B
+                        break
+                e = 1.602176634e-19
+                lambda_D = (
+                    np.sqrt(PICSolver.epsilon0 * PICSolver.k_B * Te / (ne * e**2))
+                    if ne > 0 else float("inf")
+                )
+                self.quality.log(
+                    self.step_count,
+                    self.dt,
+                    cell_size,
+                    ppc,
+                    cfl,
+                    lambda_D,
+                )
         except Exception as e:
             logger.error(f"Error during PIC step: {e}")
 


### PR DESCRIPTION
## Summary
- track timestep, cell size, and particles per cell in Hall MHD and PIC solvers
- warn on low CFL, Debye length, or particle-per-cell via new QualityDashboard
- persist quality metrics to `synthetic_diagnostics/quality/dashboard.json`

## Testing
- `pytest` *(fails: 54 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_68b9ca7e1a24832a82ef3189a7b3d114