### PR TITLE
Enhance geometry and circuit material handling

### DIFF
--- a/examples/geometry/__init__.py
+++ b/examples/geometry/__init__.py
@@ -1,0 +1,1 @@
+"""Geometry loading validation examples."""

--- a/examples/geometry/tagged.stl
+++ b/examples/geometry/tagged.stl
@@ -1,0 +1,18 @@
+solid steel
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 0
+      vertex 1 0 0
+      vertex 0 1 0
+    endloop
+  endfacet
+endsolid steel
+solid copper
+  facet normal 0 0 1
+    outer loop
+      vertex 0 0 1
+      vertex 1 0 1
+      vertex 0 1 1
+    endloop
+  endfacet
+endsolid copper

--- a/examples/geometry/tagged.vtk
+++ b/examples/geometry/tagged.vtk
@@ -1,0 +1,18 @@
+# vtk DataFile Version 2.0
+Example with material tags
+ASCII
+DATASET POLYDATA
+POINTS 6 float
+0 0 0
+1 0 0
+0 1 0
+0 0 1
+1 0 1
+0 1 1
+POLYGONS 2 8
+3 0 1 2
+3 3 4 5
+CELL_DATA 2
+SCALARS material int 1
+LOOKUP_TABLE default
+1 2

--- a/examples/geometry/validate_loaders.py
+++ b/examples/geometry/validate_loaders.py
@@ -1,0 +1,22 @@
+"""Demonstration of loading geometry files with per-surface material tags."""
+
+from pathlib import Path
+from dpf2.geometry.loaders import load_cad_geometry
+
+
+HERE = Path(__file__).resolve().parent
+
+
+def show(path: Path) -> None:
+    data = load_cad_geometry(path)
+    mats = data.get("materials", [])
+    print(f"{path.name}: {mats}")
+
+
+def main() -> None:
+    show(HERE / "tagged.stl")
+    show(HERE / "tagged.vtk")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dpf2/circuit/distributed.py
+++ b/src/dpf2/circuit/distributed.py
@@ -92,6 +92,28 @@ class TransmissionLineSegment:
     propagation_velocity: float | None = None
     skin_effect_coeff: float = 0.0
     dielectric_loss_coeff: float = 0.0
+    material: str | None = None
+
+    def __post_init__(self) -> None:
+        """Populate electrical properties from material tables when available."""
+
+        if self.material:
+            try:
+                from dpf2.materials import get_resistivity, get_skin_effect_coeff
+
+                if self.R_per_m == 0.0:
+                    try:
+                        self.R_per_m = get_resistivity(self.material)
+                    except KeyError:
+                        pass
+                if self.skin_effect_coeff == 0.0:
+                    try:
+                        self.skin_effect_coeff = get_skin_effect_coeff(self.material)
+                    except KeyError:
+                        pass
+            except Exception:
+                # Material tables are optional; fail silently if unavailable
+                pass
 
     def delay(self) -> float:
         """Return propagation delay for this segment in seconds."""

--- a/src/dpf2/geometry/loaders.py
+++ b/src/dpf2/geometry/loaders.py
@@ -61,7 +61,7 @@ def load_cad_geometry(path: Path) -> Dict[str, Any]:
     suffix = p.suffix.lower()
     if suffix == ".json":
         return json.loads(p.read_text())
-    if suffix in {".step", ".stp", ".iges", ".igs"}:
+    if suffix in {".step", ".stp", ".iges", ".igs", ".stl", ".vtk"}:
         if meshio is not None:
             try:  # pragma: no cover - exercised when meshio is available
                 m = meshio.read(p)
@@ -71,7 +71,6 @@ def load_cad_geometry(path: Path) -> Dict[str, Any]:
                     if block.type in {"triangle", "quad"}:
                         data = block.data.tolist()
                         elements.extend(data)
-                        # try to pull material tags from cell data
                         tag = None
                         if m.cell_data:
                             for key in ("material", "gmsh:physical", "cell_tags"):
@@ -80,7 +79,9 @@ def load_cad_geometry(path: Path) -> Dict[str, Any]:
                                     tag = vals[idx]
                                     break
                         if tag is not None:
-                            materials.extend(tag.tolist() if hasattr(tag, "tolist") else list(tag))
+                            materials.extend(
+                                tag.tolist() if hasattr(tag, "tolist") else list(tag)
+                            )
                 if not elements and m.cells:
                     elements = m.cells[0].data.tolist()
                 result: Dict[str, Any] = {"nodes": m.points.tolist(), "elements": elements}
@@ -89,9 +90,84 @@ def load_cad_geometry(path: Path) -> Dict[str, Any]:
                 return result
             except Exception:
                 pass
-        # fallback simple text representation
+        # fallback simple text representation for a tiny subset of the formats
         lines = [ln.strip() for ln in p.read_text().splitlines() if ln.strip()]
-        return _parse_step_like(lines)
+        if suffix in {".step", ".stp", ".iges", ".igs"}:
+            return _parse_step_like(lines)
+        if suffix == ".stl":
+            nodes: List[List[float]] = []
+            elements: List[List[int]] = []
+            materials: List[Any] = []
+            node_idx: Dict[tuple[float, float, float], int] = {}
+            current: List[int] = []
+            current_mat: Any | None = None
+            for ln in lines:
+                parts = ln.split()
+                if not parts:
+                    continue
+                tag = parts[0].lower()
+                if tag == "solid":
+                    current_mat = parts[1] if len(parts) > 1 else None
+                elif tag == "facet":
+                    current = []
+                elif tag == "vertex" and len(parts) == 4:
+                    pt = tuple(float(v) for v in parts[1:])
+                    idx = node_idx.get(pt)
+                    if idx is None:
+                        idx = len(nodes)
+                        nodes.append(list(pt))
+                        node_idx[pt] = idx
+                    current.append(idx)
+                elif tag == "endfacet" and len(current) == 3:
+                    elements.append(current[:3])
+                    if current_mat is not None:
+                        materials.append(current_mat)
+            result: Dict[str, Any] = {"nodes": nodes, "elements": elements}
+            if materials:
+                result["materials"] = materials
+            return result
+        if suffix == ".vtk":
+            nodes: List[List[float]] = []
+            elements: List[List[int]] = []
+            materials: List[Any] = []
+            it = iter(lines)
+            for ln in it:
+                up = ln.upper()
+                if up.startswith("POINTS"):
+                    parts = ln.split()
+                    npts = int(parts[1])
+                    for _ in range(npts):
+                        x, y, z = next(it).split()[:3]
+                        nodes.append([float(x), float(y), float(z)])
+                elif up.startswith("POLYGONS") or up.startswith("TRIANGLE") or up.startswith("TRIANGLES"):
+                    parts = ln.split()
+                    ntri = int(parts[1])
+                    for _ in range(ntri):
+                        vals = next(it).split()
+                        if int(vals[0]) >= 3:
+                            elements.append([int(vals[1]), int(vals[2]), int(vals[3])])
+                elif up.startswith("CELL_DATA"):
+                    ncell = int(ln.split()[1])
+                    # expect "SCALARS" followed by lookup table and values
+                    ln = next(it).strip()
+                    if ln.upper().startswith("SCALARS"):
+                        name = ln.split()[1].lower()
+                        if name in {"material", "materials", "gmsh:physical", "cell_tags"}:
+                            ln = next(it).strip()
+                            vals: List[str] = []
+                            if not ln.upper().startswith("LOOKUP_TABLE"):
+                                vals.extend(ln.split())
+                            while len(vals) < ncell:
+                                vals.extend(next(it).split())
+                            for v in vals[:ncell]:
+                                try:
+                                    materials.append(int(v))
+                                except ValueError:
+                                    materials.append(v)
+            result: Dict[str, Any] = {"nodes": nodes, "elements": elements}
+            if materials:
+                result["materials"] = materials
+            return result
     raise ValueError(f"Unsupported CAD format: {suffix}")
 
 

--- a/src/dpf2/materials/__init__.py
+++ b/src/dpf2/materials/__init__.py
@@ -7,6 +7,12 @@ from .library import MaterialLibrary
 
 from .state import ComponentMaterialState
 from .mdm import MaterialDamageModel
+from .tables import (
+    RESISTIVITY_TABLE,
+    SKIN_EFFECT_TABLE,
+    get_resistivity,
+    get_skin_effect_coeff,
+)
 
 __all__ = [
     "MaterialRef",
@@ -14,5 +20,9 @@ __all__ = [
     "MaterialLibrary",
     "ComponentMaterialState",
     "MaterialDamageModel",
+    "RESISTIVITY_TABLE",
+    "SKIN_EFFECT_TABLE",
+    "get_resistivity",
+    "get_skin_effect_coeff",
 ]
 

--- a/src/dpf2/materials/tables.py
+++ b/src/dpf2/materials/tables.py
@@ -1,0 +1,65 @@
+"""Lookup tables for basic material electrical properties.
+
+The real project stores extensive tabulated data for many materials.  For the
+purposes of the exercises we provide only a tiny subset used by the unit tests.
+The values are intentionally simple and should not be interpreted as rigorous
+engineering data.  They merely capture the order of magnitude of resistivity and
+skin‑effect behaviour to exercise the surrounding code.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+# Resistivity in ohm metre at room temperature.  Only a couple of materials are
+# required for the tests, additional entries can be added easily if needed.
+RESISTIVITY_TABLE: Dict[str, float] = {
+    "copper": 1.68e-8,
+    "aluminum": 2.82e-8,
+    "stainless_steel": 7.4e-7,
+}
+
+# Empirical coefficients for the simplistic skin effect model used by
+# :class:`dpf2.circuit.distributed.TransmissionLineSegment`.  The coefficient is
+# multiplied by ``sqrt(frequency)`` to obtain an additional per‑metre resistance
+# contribution.  Units are ohm / metre / sqrt(Hz).
+SKIN_EFFECT_TABLE: Dict[str, float] = {
+    "copper": 6.0e-5,
+    "aluminum": 7.5e-5,
+    "stainless_steel": 1.2e-4,
+}
+
+
+def get_resistivity(material: str) -> float:
+    """Return the resistivity for ``material``.
+
+    ``material`` is matched case‑insensitively.  A :class:`KeyError` is raised if
+    the material is unknown.
+    """
+
+    key = material.lower()
+    if key not in RESISTIVITY_TABLE:
+        raise KeyError(f"Unknown material '{material}'")
+    return RESISTIVITY_TABLE[key]
+
+
+def get_skin_effect_coeff(material: str) -> float:
+    """Return the skin effect coefficient for ``material``.
+
+    ``material`` is matched case‑insensitively.  A :class:`KeyError` is raised if
+    the material is unknown.
+    """
+
+    key = material.lower()
+    if key not in SKIN_EFFECT_TABLE:
+        raise KeyError(f"Unknown material '{material}'")
+    return SKIN_EFFECT_TABLE[key]
+
+
+__all__ = [
+    "RESISTIVITY_TABLE",
+    "SKIN_EFFECT_TABLE",
+    "get_resistivity",
+    "get_skin_effect_coeff",
+]
+


### PR DESCRIPTION
## Summary
- extend CAD loader to parse STL and VTK files with per-surface material tags
- add resistivity and skin-effect tables and wire them into transmission line segments
- provide geometry validation examples demonstrating tagged STL/VTK usage

## Testing
- `pytest` *(fails: NameError: name 'types' is not defined. Did you forget to import 'types' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ca7f7b80832a920359211783a4a4