### PR TITLE
Capture environment details in run manifest

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,8 +16,8 @@ specified output directory.
 
 Most commands accept the ``--lab-mode`` flag to capture a manifest for
 reproducibility. The manifest records the current code hash, RNG seeds,
-particle-per-cell setting and any configuration file paths. Both
-``manifest.json`` and an accompanying ``manifest.h5`` (with the same
+particle-per-cell setting, environment details and any configuration file paths. Both
+``run_manifest.json`` and an accompanying ``run_manifest.h5`` (with the same
 metadata stored as HDF5 attributes) are written inside the command's
 output directory.
 

--- a/docs/hpc.md
+++ b/docs/hpc.md
@@ -4,6 +4,11 @@ DPF2 provides a minimal ``JobManager`` to help launch simulations on
 clusters.  When running on shared systems, enable the ``--lab-mode`` flag
 to capture metadata for reproducibility and auditing.
 
+The job manager can automatically stage run manifests by providing the
+``manifest`` argument to :meth:`~dpf2.hpc.JobManager.submit`. Passing the
+manifest path again via ``restart`` allows a job to resume from recorded
+metadata.
+
 ## Example SLURM batch script
 
 ```bash
@@ -22,7 +27,7 @@ python -m dpf2.cli --lab-mode simulate --config config.json --output run
 ```
 
 After the job completes the ``run`` directory will contain simulation outputs
-alongside ``manifest.json`` (and ``manifest.h5`` when ``h5py`` is installed).
-The manifest records the git commit, random seeds and particles-per-cell setting,
-allowing each run to be audited and reproduced.
+alongside ``run_manifest.json`` (and ``run_manifest.h5`` when ``h5py`` is installed).
+The manifest records the git commit, random seeds, environment details and
+particles-per-cell setting, allowing each run to be audited and reproduced.
 

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -18,7 +18,7 @@ output file.
 
 When executing in lab mode or other batch-oriented commands, a manifest is
 stored in each run directory.  The manifest is available as both
-`manifest.json` and `manifest.h5` and mirrors the metadata embedded in the
+`run_manifest.json` and `run_manifest.h5` and mirrors the metadata embedded in the
 HDF5 outputs.
 
 Manifests include paths to configuration files, computed seeds and additional

--- a/docs/workflows/reproducibility.md
+++ b/docs/workflows/reproducibility.md
@@ -1,0 +1,20 @@
+# Reproducibility Workflow
+
+DPF2 records detailed provenance for every run. When CLI commands are invoked
+with the `--lab-mode` flag, a `run_manifest.json` is written alongside the
+outputs. The manifest captures:
+
+- git commit hash of the code
+- full configuration used for the run
+- random number generator seeds for Python and NumPy
+- basic environment information such as Python version, platform and exported
+  environment variables
+
+These details allow results to be precisely reproduced even when runs are moved
+between systems.
+
+When launching jobs through :class:`dpf2.hpc.JobManager`, provide the manifest
+path via the ``manifest`` argument. The manager will stage the manifest file
+with other outputs and accepts a manifest path in ``restart`` to resume a run
+using recorded metadata.
+

--- a/examples/hpc/README.md
+++ b/examples/hpc/README.md
@@ -11,11 +11,11 @@ paths and particle-per-cell settings for reproducibility.
   directory and launches ``dpf2 simulate`` with ``--lab-mode`` using
   ``srun``. The ``CUDA_VISIBLE_DEVICES`` environment variable may be set by
   the :class:`~dpf2.hpc.JobManager` to pin the job to specific GPUs. A
-  ``manifest.json`` and ``manifest.h5`` files are written inside the run
+  ``run_manifest.json`` and ``run_manifest.h5`` files are written inside the run
   directory capturing reproducibility metadata.
 
 * ``slurm_restart.sh`` – similar to ``slurm_run.sh`` but demonstrates how
-  to restart from a checkpoint while still capturing a manifest with
+  to restart from a manifest or checkpoint while still capturing a manifest with
   ``--lab-mode``. The script checks the ``DPF_RESTART`` environment
   variable, which is automatically exported by
   :meth:`JobManager.restart <dpf2.hpc.manager.JobManager.restart>`.

--- a/examples/hpc/slurm_restart.sh
+++ b/examples/hpc/slurm_restart.sh
@@ -18,7 +18,7 @@ cp "$checkpoint" "$tmp/"
 cd "$tmp"
 
 # Restart the simulation from the checkpoint using the CLI and record a manifest
-# in ``restart_run/manifest.json`` and ``restart_run/manifest.h5``
+# in ``restart_run/run_manifest.json`` and ``restart_run/run_manifest.h5``
 chk_file=$(basename "$checkpoint")
 echo "Restarting from $chk_file"
 srun dpf2 simulate --config config.json --output restart_run --lab-mode

--- a/examples/hpc/slurm_run.sh
+++ b/examples/hpc/slurm_run.sh
@@ -12,7 +12,7 @@ cp $SLURM_SUBMIT_DIR/examples/config.json "$tmp/"
 cd "$tmp"
 
 # Execute the simulation using the CLI with lab-mode manifest. This creates
-# ``run/manifest.json`` and ``run/manifest.h5`` capturing reproducibility
+# ``run/run_manifest.json`` and ``run/run_manifest.h5`` capturing reproducibility
 # metadata. GPU affinity can be controlled by setting ``CUDA_VISIBLE_DEVICES``
 # prior to submission (e.g. via the JobManager).
 srun dpf2 simulate --config config.json --output run --lab-mode

--- a/src/dpf2/cli/lab.py
+++ b/src/dpf2/cli/lab.py
@@ -1,7 +1,10 @@
 """Utilities for lab-mode reproducibility manifests."""
 from __future__ import annotations
 import json
+import os
+import platform
 import subprocess
+import sys
 import random
 from pathlib import Path
 from typing import Sequence, Mapping
@@ -14,8 +17,8 @@ except Exception:  # pragma: no cover - h5py may be absent
     h5py = None  # type: ignore[assignment]
 
 
-MANIFEST_FILENAME = "manifest.json"
-MANIFEST_H5_FILENAME = "manifest.h5"
+RUN_MANIFEST_FILENAME = "run_manifest.json"
+RUN_MANIFEST_H5_FILENAME = "run_manifest.h5"
 
 
 def _code_hash() -> str:
@@ -28,6 +31,15 @@ def _code_hash() -> str:
         )
     except Exception:
         return "unknown"
+
+
+def _environment() -> dict[str, object]:
+    """Capture basic execution environment details."""
+    return {
+        "python": sys.version.split()[0],
+        "platform": platform.platform(),
+        "env": dict(os.environ),
+    }
 
 
 def write_manifest(
@@ -76,6 +88,7 @@ def write_manifest(
         "random_seeds": dict(seeds),
         "particle_per_cell": ppc,
         "config_paths": [str(p) for p in (config_paths or [])],
+        "environment": _environment(),
     }
     if config is not None:
         # ``config`` may contain non-serialisable objects; best effort to cast
@@ -87,11 +100,11 @@ def write_manifest(
     if warnings:
         manifest["warnings"] = list(warnings)
 
-    path = out / MANIFEST_FILENAME
+    path = out / RUN_MANIFEST_FILENAME
     path.write_text(json.dumps(manifest, indent=2))
 
     if h5py is not None:  # pragma: no cover - only when h5py available
-        h5_path = out / MANIFEST_H5_FILENAME
+        h5_path = out / RUN_MANIFEST_H5_FILENAME
         with h5py.File(h5_path, "w") as h5:
             for key, value in manifest.items():
                 if isinstance(value, (dict, list)):
@@ -103,4 +116,8 @@ def write_manifest(
 
     return path
 
-__all__ = ["write_manifest", "MANIFEST_FILENAME", "MANIFEST_H5_FILENAME"]
+__all__ = [
+    "write_manifest",
+    "RUN_MANIFEST_FILENAME",
+    "RUN_MANIFEST_H5_FILENAME",
+]

--- a/src/dpf2/hpc/manager.py
+++ b/src/dpf2/hpc/manager.py
@@ -85,15 +85,19 @@ class JobManager:
         os.chmod(path, 0o755)
         return path
 
-    def submit(self, job_script: str, **kwargs: Any) -> Any:
+    def submit(self, job_script: str, *, manifest: str | None = None, **kwargs: Any) -> Any:
         """Submit ``job_script`` to the configured scheduler.
 
         Parameters
         ----------
         job_script:
             Path to a submission script or executable.
+        manifest:
+            Optional path to a ``run_manifest.json`` that should be staged with
+            other outputs.
         **kwargs:
-            Additional scheduler specific keyword arguments.
+            Additional scheduler specific keyword arguments. ``restart`` may
+            reference a manifest path to resume a previous run.
 
         Returns
         -------
@@ -103,6 +107,13 @@ class JobManager:
 
         stage_in: Mapping[str, str] | None = kwargs.pop("stage_in", None)
         stage_out: Mapping[str, str] | None = kwargs.pop("stage_out", None)
+        restart = kwargs.get("restart")
+        if manifest is not None:
+            stage_out = dict(stage_out or {})
+            stage_out[manifest] = manifest
+        if restart is not None and str(restart).endswith(".json"):
+            stage_in = dict(stage_in or {})
+            stage_in[str(restart)] = str(restart)
         job_script = self._wrap_staging(job_script, stage_in, stage_out)
 
         # Script level arguments and restart handling
@@ -147,7 +158,7 @@ class JobManager:
             if gpu_affinity is not None:
                 env["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_affinity)
             if restart is not None:
-                # Allow job scripts to locate the checkpoint for staging
+                # Allow job scripts to locate the checkpoint or manifest for staging
                 env["DPF_RESTART"] = str(restart)
             return subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
         if self.scheduler == "awsbatch":

--- a/tests/performance/test_hpc_manager.py
+++ b/tests/performance/test_hpc_manager.py
@@ -86,3 +86,39 @@ def test_mpi_node_topology_and_restart(tmp_path, monkeypatch):
     assert env["CUDA_VISIBLE_DEVICES"] == "0,1"
     assert env["DPF_RESTART"] == "chk.dat"
 
+
+def test_stage_manifest_and_restart(tmp_path, monkeypatch):
+    script = tmp_path / "job.sh"
+    script.write_text("#!/bin/bash\n")
+    jm = JobManager("slurm")
+
+    called: dict[str, object] = {}
+
+    def fake_wrap(self, job_script, stage_in, stage_out):  # type: ignore[override]
+        called["stage_in"] = stage_in
+        called["stage_out"] = stage_out
+        return job_script
+
+    def fake_run(cmd, capture_output, text, check, env):  # type: ignore[override]
+        called["cmd"] = cmd
+        called["env"] = env
+
+        class R:
+            pass
+
+        return R()
+
+    monkeypatch.setattr(JobManager, "_wrap_staging", fake_wrap)
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    manifest = "run/run_manifest.json"
+    jm.submit(str(script), manifest=manifest, restart=manifest)
+
+    assert called["stage_out"][manifest] == manifest
+    assert called["stage_in"][manifest] == manifest
+    cmd = called["cmd"]
+    idx = cmd.index(str(script))
+    assert cmd[idx + 1 : idx + 3] == ["--restart", manifest]
+    env = called["env"]
+    assert env["DPF_RESTART"] == manifest
+

--- a/tests/test_lab_mode_ensemble.py
+++ b/tests/test_lab_mode_ensemble.py
@@ -24,6 +24,6 @@ def test_lab_mode_runs_multiple_shots(tmp_path):
     assert result.exit_code == 0, result.output
     shot0 = tmp_path / "out" / "shot_000"
     shot1 = tmp_path / "out" / "shot_001"
-    assert (shot0 / "manifest.json").exists()
-    assert (shot1 / "manifest.json").exists()
+    assert (shot0 / "run_manifest.json").exists()
+    assert (shot1 / "run_manifest.json").exists()
     assert any(p.suffix == ".h5" for p in shot0.iterdir())

--- a/tests/test_manifest_metadata.py
+++ b/tests/test_manifest_metadata.py
@@ -11,3 +11,4 @@ def test_manifest_includes_config_and_seeds(tmp_path):
     assert data["code_hash"]
     assert data["config"] == cfg
     assert data["random_seeds"] == seeds
+    assert "environment" in data and "python" in data["environment"]


### PR DESCRIPTION
## Summary
- record git hash, configuration, RNG seeds, and environment info in `run_manifest.json`
- stage manifests and support manifest-based restart in JobManager
- document reproducibility workflow and update references to `run_manifest`

## Testing
- `pytest` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ca8111a4832a85a9a0bb66d067ab