### PR TITLE
Add device profile presets and selection

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 exclude h5py_stub.py
 exclude pydantic_stub.py
 recursive-include examples *.py *.json *.ipynb
+recursive-include device_profiles *.json

--- a/device_profiles/EDU1K.json
+++ b/device_profiles/EDU1K.json
@@ -1,0 +1,14 @@
+{
+  "deviceLabel": "EDU1K",
+  "deviceDescription": "1 kJ class educational Mather-type DPF",
+  "energyKJ": 1.0,
+  "workingGas": "D",
+  "capacitorBank": {"C": 30e-6, "L": 25e-9, "R": 0.02},
+  "anodeRadiusCm": 0.5,
+  "cathodeRadiusCm": 1.5,
+  "anodeLengthCm": 7.0,
+  "insulatorLengthCm": 2.0,
+  "insulatorMaterial": {"materialId": "alumina"},
+  "breakdownVoltageKV": 10.0,
+  "regimeCategory": "low_energy"
+}

--- a/device_profiles/IND20K.json
+++ b/device_profiles/IND20K.json
@@ -1,0 +1,14 @@
+{
+  "deviceLabel": "IND20K",
+  "deviceDescription": "20 kJ industrial-scale DPF",
+  "energyKJ": 20.0,
+  "workingGas": "D",
+  "capacitorBank": {"C": 200e-6, "L": 20e-9, "R": 0.012},
+  "anodeRadiusCm": 1.5,
+  "cathodeRadiusCm": 4.5,
+  "anodeLengthCm": 20.0,
+  "insulatorLengthCm": 6.0,
+  "insulatorMaterial": {"materialId": "alumina"},
+  "breakdownVoltageKV": 20.0,
+  "regimeCategory": "medium_energy"
+}

--- a/device_profiles/PF1000.json
+++ b/device_profiles/PF1000.json
@@ -1,0 +1,27 @@
+{
+  "deviceLabel": "PF1000",
+  "deviceDescription": "High-energy MJ-scale DPF at IFJ Krakow",
+  "energyKJ": 500.0,
+  "workingGas": "D",
+  "capacitorBank": {"C": 30e-6, "L": 15e-9, "R": 0.015},
+  "anodeRadiusCm": 2.5,
+  "cathodeRadiusCm": 6.0,
+  "anodeLengthCm": 16.0,
+  "insulatorLengthCm": 5.0,
+  "insulatorMaterial": {"materialId": "alumina"},
+  "insulatorSleeve": {
+    "innerRadiusCm": 2.5,
+    "thicknessCm": 0.5,
+    "lengthCm": 5.0,
+    "material": {"materialId": "alumina"}
+  },
+  "breakdownVoltageKV": 25.0,
+  "fuelMixture": {"D": 0.9, "Ar": 0.1},
+  "regimeCategory": "MJ_scale",
+  "referenceShotIds": ["2053", "2071", "2089"],
+  "primaryObservables": ["I(t)", "Yn", "SXR"],
+  "diagnosticCapabilities": {
+    "TOF": {"channels": 4, "resolutionNs": 1.0},
+    "SXR": {"filters": ["Al", "Ti"]}
+  }
+}

--- a/docs/device_presets.md
+++ b/docs/device_presets.md
@@ -1,0 +1,53 @@
+# Device Presets
+
+DPF2 includes a small library of Dense Plasma Focus (DPF) geometries located
+in the `device_profiles/` directory.  These presets provide starting points for
+common educational and industrial machines and may be selected from the CLI or
+GUI.  All dimensions below are given in centimetres unless noted otherwise.
+
+## EDU1K – 1 kJ Educational DPF
+
+| Parameter | Value |
+|-----------|-------|
+| Energy | 1 kJ |
+| Anode radius | 0.5 cm |
+| Cathode radius | 1.5 cm |
+| Anode length | 7.0 cm |
+
+Scaling laws:
+
+- Voltage follows \(V = \sqrt{2E/C}\) for capacitor energy \(E\).
+- To maintain similarity, electrode radii scale with \(\sqrt{E}\); lengths
+  should scale roughly three times the anode radius.
+
+## IND20K – 20 kJ Industrial DPF
+
+| Parameter | Value |
+|-----------|-------|
+| Energy | 20 kJ |
+| Anode radius | 1.5 cm |
+| Cathode radius | 4.5 cm |
+| Anode length | 20.0 cm |
+
+Scaling laws:
+
+- Pinch current obeys \(I \propto \sqrt{C}\,V\).
+- Geometric dimensions scale approximately with \(\sqrt{E}\) to preserve
+  current density.
+
+## PF1000 – MJ-scale Reference
+
+| Parameter | Value |
+|-----------|-------|
+| Energy | 500 kJ |
+| Anode radius | 2.5 cm |
+| Cathode radius | 6.0 cm |
+| Anode length | 16.0 cm |
+
+Scaling laws:
+
+- Maintaining aspect ratio \(L \approx 6.4 r_a\) preserves rundown dynamics.
+- Neutron yield scales roughly with \(I^4\) in this regime.
+
+These profiles can be extended or customised by editing the JSON files under
+`device_profiles/`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ nav:
       - PIC Collision: ../examples/pic_collision_example.py
   - GUI Features:  # persona: student
       - Sandbox Walk-Through: student_intro.md
+  - Device Presets: device_presets.md
   - API Reference: api_reference.md
   - Benchmarks: benchmarks.md
   - Run & Compare: run_compare.md

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -43,6 +43,8 @@ from dpf2.optimization.param_sweep import (
     plot_metric_overlay,
 )
 
+from dpf2.device_profiles import DeviceProfiles
+
 from dpf2.scaling_laws import sweep_yield_scaling
 from dpf2.uq.sampling import latin_hypercube, sobol_sample
 from dpf2.uq.analysis import sobol_indices, uncertainty_band
@@ -332,6 +334,11 @@ def main(ctx: click.Context, notebook: bool, lab_mode: bool) -> None:
     is_flag=True,
     help="Save key waveforms and diagnostics at completion",
 )
+@click.option(
+    "--device",
+    type=click.Choice(sorted(DeviceProfiles.with_defaults().devices.keys())),
+    help="Preset device geometry",
+)
 @click.option("--wizard", is_flag=True, help="Interactive mode to build configuration")
 @click.option(
     "--shots",
@@ -351,6 +358,7 @@ def simulate(
     live_plot: bool,
     synthetic: str | None,
     diagnostics: bool,
+    device: str | None,
     wizard: bool,
     shots: int,
 ) -> None:
@@ -364,9 +372,29 @@ def simulate(
         else:
             cfg = DPFConfig.from_file(config) if config else DPFConfig()
 
-            default_voltage = getattr(cfg, "charging_voltage", 15000.0)
-            default_length = getattr(cfg, "electrode_length", 0.10)
+        if device:
+            presets = DeviceProfiles.with_defaults().devices
+            if device not in presets:
+                raise click.ClickException(f"Unknown device preset: {device}")
+            dev = presets[device]
+            cfg.anode_radius = dev.anode_radius_cm * 0.01
+            cfg.cathode_radius = dev.cathode_radius_cm * 0.01
+            cfg.electrode_length = dev.anode_length_cm * 0.01
+            bank = dev.capacitor_bank
+            cfg.capacitance = bank.get("C", cfg.capacitance)
+            cfg.inductance = bank.get("L", cfg.inductance)
+            cfg.resistance = bank.get("R", cfg.resistance)
+            cfg.gas_type = dev.working_gas
+            C = bank.get("C")
+            if C:
+                cfg.charging_voltage = (2.0 * dev.energy_kJ * 1000.0 / C) ** 0.5
+            elif dev.breakdown_voltage_kV:
+                cfg.charging_voltage = dev.breakdown_voltage_kV * 1000.0
 
+        default_voltage = getattr(cfg, "charging_voltage", 15000.0)
+        default_length = getattr(cfg, "electrode_length", 0.10)
+
+        if not wizard:
             # Prompt and validate voltage
             if voltage is None:
                 if click.get_text_stream("stdin").isatty():
@@ -381,7 +409,7 @@ def simulate(
                     voltage = default_voltage
             else:
                 voltage = _validate_range(
-                    "voltage", voltage, 1000.0, 100000.0, "Check the units (volts)."
+                    "voltage", voltage, 1000.0, 100000.0, "Check the units (volts).",
                 )
 
             # Prompt and validate segment length

--- a/src/dpf2/device_profiles.py
+++ b/src/dpf2/device_profiles.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import warnings
+from pathlib import Path
 from typing import Any, ClassVar, Dict, List, Optional, Union, Literal
 
 
@@ -120,38 +121,22 @@ class DeviceProfiles(ConfigSectionBase):
     # ------------------------------------------------------------------
     @classmethod
     def with_defaults(cls) -> "DeviceProfiles":
-        data = {
-            "defaultDeviceId": "PF1000",
-            "devices": {
-                "PF1000": {
-                    "deviceLabel": "PF1000",
-                    "deviceDescription": "High-energy MJ-scale DPF at IFJ Krakow",
-                    "energyKJ": 500.0,
-                    "workingGas": "D",
-                    "capacitorBank": {"C": 30e-6, "L": 15e-9, "R": 0.015},
-                    "anodeRadiusCm": 2.5,
-                    "cathodeRadiusCm": 6.0,
-                    "anodeLengthCm": 16.0,
-                    "insulatorLengthCm": 5.0,
-                    "insulatorMaterial": {"materialId": "alumina"},
-                    "insulatorSleeve": {
-                        "innerRadiusCm": 2.5,
-                        "thicknessCm": 0.5,
-                        "lengthCm": 5.0,
-                        "material": {"materialId": "alumina"},
-                    },
-                    "breakdownVoltageKV": 25.0,
-                    "fuelMixture": {"D": 0.9, "Ar": 0.1},
-                    "regimeCategory": "MJ_scale",
-                    "referenceShotIds": ["2053", "2071", "2089"],
-                    "primaryObservables": ["I(t)", "Yn", "SXR"],
-                    "diagnosticCapabilities": {
-                        "TOF": {"channels": 4, "resolutionNs": 1.0},
-                        "SXR": {"filters": ["Al", "Ti"]},
-                    },
-                }
-            },
-        }
+        base = Path(__file__).resolve().parents[2] / "device_profiles"
+        devices: Dict[str, Dict[str, Any]] = {}
+        if base.exists():
+            for path in base.glob("*.json"):
+                try:
+                    info = json.loads(path.read_text())
+                except Exception:
+                    continue
+                label = info.get("deviceLabel")
+                if label:
+                    devices[label] = info
+        data: Dict[str, Any] = {"devices": devices}
+        if "PF1000" in devices:
+            data["defaultDeviceId"] = "PF1000"
+        elif devices:
+            data["defaultDeviceId"] = next(iter(devices))
         return cls.model_validate(data)
 
     def resolve_defaults(self) -> "DeviceProfiles":

--- a/src/dpf2/gui/interactive.py
+++ b/src/dpf2/gui/interactive.py
@@ -60,7 +60,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050) -> None:
             dcc.Dropdown(
                 id="preset",
                 options=preset_options,
-                placeholder="Geometry preset",
+                placeholder="Device preset",
             ),
             html.Div(
                 [

--- a/src/dpf2/web/app.py
+++ b/src/dpf2/web/app.py
@@ -38,7 +38,7 @@ INDEX_HTML = """
   Anode radius (m): <input name=anode_radius value="{{ cfg.anode_radius }}"><br>
   Cathode radius (m): <input name=cathode_radius value="{{ cfg.cathode_radius }}"><br>
   Electrode length (m): <input name=electrode_length value="{{ cfg.electrode_length }}"><br>
-  Geometry preset:
+  Device preset:
   <select name=preset>
     <option value=""></option>
     {% for name in presets %}<option value="{{ name }}">{{ name }}</option>{% endfor %}

--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -2,6 +2,8 @@ import warnings
 import pytest
 from dpf2.device_profiles import DeviceProfiles
 
+from dpf2.cli.main import simulate
+
 try:
     import yaml  # type: ignore
     YAML_AVAILABLE = True
@@ -12,6 +14,12 @@ except Exception:
 def test_default_device_key_exists():
     cfg = DeviceProfiles.with_defaults()
     assert cfg.default_device_id in cfg.devices
+
+
+def test_additional_presets_available():
+    cfg = DeviceProfiles.with_defaults()
+    assert "EDU1K" in cfg.devices
+    assert "IND20K" in cfg.devices
 
 
 def test_fuel_fractions_sum_to_one():
@@ -70,3 +78,7 @@ def test_insulator_material_is_materialref():
     )
     assert sleeve is not None and sleeve.material is not None
     assert sleeve.material.material_id == "alumina"
+
+
+def test_cli_has_device_option():
+    assert any("--device" in opt.opts for opt in simulate.params)


### PR DESCRIPTION
## Summary
- load device profiles from `device_profiles/` JSON files
- allow choosing a preset via new `--device` CLI option and GUI dropdowns
- document EDU1K, IND20K, and PF1000 presets with scaling guidance

## Testing
- `pytest tests/test_device_profiles.py::test_additional_presets_available tests/test_device_profiles.py::test_cli_has_device_option -q`
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ca8751e4832a86435912166338cd