### PR TITLE
Add abort option to QualityDashboard

### DIFF
--- a/src/dpf2/diagnostics/quality_dashboard.py
+++ b/src/dpf2/diagnostics/quality_dashboard.py
@@ -16,6 +16,7 @@ class QualityDashboard:
     min_cfl: float | None = None
     min_lambda_D: float | None = None
     min_ppc: float | None = None
+    abort_on_violation: bool = False
     history: list[dict[str, float]] = field(default_factory=list)
 
     def log(
@@ -41,13 +42,18 @@ class QualityDashboard:
         with open(self.output_dir / "dashboard.json", "w", encoding="utf-8") as fh:
             json.dump(self.history, fh, indent=2)
 
+        def _warn_or_abort(msg: str) -> None:
+            logger.warning(msg)
+            if self.abort_on_violation:
+                raise RuntimeError(msg)
+
         if self.min_cfl is not None and cfl < self.min_cfl:
-            logger.warning("CFL below threshold: %g < %g", cfl, self.min_cfl)
+            _warn_or_abort(f"CFL below threshold: {cfl:g} < {self.min_cfl:g}")
         if self.min_lambda_D is not None and lambda_D < self.min_lambda_D:
-            logger.warning(
-                "Debye length below threshold: %g < %g", lambda_D, self.min_lambda_D
+            _warn_or_abort(
+                f"Debye length below threshold: {lambda_D:g} < {self.min_lambda_D:g}"
             )
         if self.min_ppc is not None and ppc < self.min_ppc:
-            logger.warning(
-                "Particles per cell below threshold: %g < %g", ppc, self.min_ppc
+            _warn_or_abort(
+                f"Particles per cell below threshold: {ppc:g} < {self.min_ppc:g}"
             )

--- a/tests/test_quality_dashboard.py
+++ b/tests/test_quality_dashboard.py
@@ -1,0 +1,17 @@
+import json
+import pytest
+from dpf2.diagnostics.quality_dashboard import QualityDashboard
+
+
+def test_quality_dashboard_logs_and_warns(tmp_path, caplog):
+    q = QualityDashboard(output_dir=tmp_path, min_cfl=0.5)
+    q.log(step=1, dt=0.1, cell_size=1.0, ppc=10, cfl=0.1, lambda_D=1.0)
+    data = json.load(open(tmp_path / "dashboard.json"))
+    assert data[0]["step"] == 1
+    assert "CFL below threshold" in caplog.text
+
+
+def test_quality_dashboard_abort(tmp_path):
+    q = QualityDashboard(output_dir=tmp_path, min_cfl=0.5, abort_on_violation=True)
+    with pytest.raises(RuntimeError):
+        q.log(step=1, dt=0.1, cell_size=1.0, ppc=10, cfl=0.1, lambda_D=1.0)


### PR DESCRIPTION
## Summary
- allow QualityDashboard to optionally abort when quality thresholds are violated
- add tests ensuring warnings and abort behaviour

## Testing
- `pre-commit run --files src/dpf2/diagnostics/quality_dashboard.py tests/test_quality_dashboard.py` *(fails: command not found)*
- `pytest tests/test_quality_dashboard.py tests/test_hall_mhd_solver.py tests/test_physics_pic_solver.py -q` *(fails: TypeError/AttributeError: numpy stub limitations)*
- `pytest tests/test_quality_dashboard.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9cebe5890832a8220f588b5375b31