### PR TITLE
Add benchmark comparison CLI and reports

### DIFF
--- a/src/dpf2/cli/benchmark.py
+++ b/src/dpf2/cli/benchmark.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Tuple
+
+import click
+import numpy as np
+
+try:  # pragma: no cover - matplotlib optional
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib may be absent
+    plt = None  # type: ignore[assignment]
+
+from ..benchmark_matching import BenchmarkMatching
+
+
+def _load_config(path: Path) -> BenchmarkMatching:
+    """Load a BenchmarkMatching configuration from ``path``."""
+    text = path.read_text()
+    try:  # pragma: no cover - prefer pydantic API when available
+        return BenchmarkMatching.model_validate_json(text)  # type: ignore[attr-defined]
+    except Exception:  # pragma: no cover - fallback for stubbed pydantic
+        data = json.loads(text)
+        return BenchmarkMatching(**data)
+
+
+def _load_waveform(path: Path) -> Tuple[np.ndarray, np.ndarray]:
+    """Return time and value arrays from a CSV file."""
+    with path.open() as fh:
+        reader = csv.DictReader(fh)
+        names = reader.fieldnames or ["time", "value"]
+        t_vals, v_vals = [], []
+        for row in reader:
+            t_vals.append(float(row[names[0]]))
+            v_vals.append(float(row[names[1]]))
+    return np.array(t_vals), np.array(v_vals)
+
+
+@click.command("match-benchmark")
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="Path to BenchmarkMatching configuration file",
+)
+@click.option(
+    "--simulation",
+    "sim_path",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="Simulation waveform CSV to compare against the benchmark",
+)
+@click.option(
+    "--output",
+    "outdir",
+    type=click.Path(file_okay=False),
+    default="benchmark_reports",
+    show_default=True,
+    help="Directory where reports will be written",
+)
+def match_benchmark(config_path: str, sim_path: str, outdir: str) -> None:
+    """Compare simulation outputs against benchmark traces."""
+    cfg = _load_config(Path(config_path))
+
+    bench_path = cfg.benchmark_trace_path
+    if bench_path is None:
+        raise click.ClickException("benchmark_trace_path must be provided in config")
+    bench_path = Path(bench_path)
+    if not bench_path.is_absolute():
+        bench_path = Path(config_path).parent / bench_path
+
+    bench_t, bench_v = _load_waveform(bench_path)
+    sim_t, sim_v = _load_waveform(Path(sim_path))
+
+    sim_interp = np.interp(bench_t, sim_t, sim_v)
+    err = sim_interp - bench_v
+    rmse = float(np.sqrt(np.mean(err ** 2)))
+    max_ref = float(np.max(np.abs(bench_v))) or 1.0
+    rmse_pct = rmse / max_ref * 100.0
+    passed = (
+        rmse_pct <= cfg.waveform_tolerance
+        if cfg.waveform_tolerance is not None
+        else False
+    )
+
+    out = Path(outdir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    metrics = {
+        "dataset": cfg.dataset_id,
+        "rmse": rmse,
+        "rmse_percent": rmse_pct,
+        "tolerance_percent": cfg.waveform_tolerance,
+        "passed": passed,
+    }
+    (out / "metrics.json").write_text(json.dumps(metrics, indent=2))
+
+    if plt is not None:  # pragma: no cover - plotting optional
+        fig, ax = plt.subplots()
+        ax.plot(bench_t, bench_v, label="benchmark")
+        ax.plot(bench_t, sim_interp, label="simulation")
+        ax.set_xlabel(f"time ({cfg.benchmark_time_unit or 's'})")
+        label = cfg.benchmark_fields[0] if cfg.benchmark_fields else "value"
+        ax.set_ylabel(label)
+        ax.legend()
+        fig.tight_layout()
+        fig.savefig(out / "comparison.pdf")
+        plt.close(fig)
+
+        fig, ax = plt.subplots(figsize=(6, 3))
+        ax.axis("off")
+        text = (
+            f"Dataset: {cfg.dataset_id}\n"
+            f"RMSE: {rmse:.3g}\n"
+            f"RMSE (%): {rmse_pct:.2f}\n"
+            f"Passed: {passed}"
+        )
+        ax.text(0.0, 1.0, text, va="top")
+        fig.savefig(out / "report.pdf")
+        plt.close(fig)
+
+    html = (
+        "<html><body>"
+        f"<h1>Benchmark {cfg.dataset_id}</h1>"
+        f"<p>RMSE: {rmse:.3g}</p>"
+        f"<p>RMSE (%): {rmse_pct:.2f}</p>"
+        f"<p>Passed: {passed}</p>"
+        "</body></html>"
+    )
+    (out / "report.html").write_text(html)
+
+
+__all__ = ["match_benchmark"]

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -1414,5 +1414,7 @@ def run_compare(benchmark_dir: str, output: str) -> None:
         click.echo(row)
 
 
+from .benchmark import match_benchmark
+main.add_command(match_benchmark)
 if __name__ == "__main__":
     main()

--- a/tests/test_cli_benchmark_match.py
+++ b/tests/test_cli_benchmark_match.py
@@ -1,0 +1,91 @@
+from click.testing import CliRunner
+
+import pydantic_stub
+import h5py_stub
+import sys
+import types
+import json
+from pathlib import Path
+
+# Stub optional dependencies
+sys.modules["pydantic"] = pydantic_stub
+sys.modules["pydantic.dataclasses"] = pydantic_stub.dataclasses
+sys.modules["h5py"] = h5py_stub
+
+
+class _DummyAxes:
+    def plot(self, *args, **kwargs):
+        return None
+
+    def set_xlabel(self, *args, **kwargs):
+        return None
+
+    def set_ylabel(self, *args, **kwargs):
+        return None
+
+    def legend(self, *args, **kwargs):
+        return None
+
+    def axis(self, *args, **kwargs):
+        return None
+
+    def text(self, *args, **kwargs):
+        return None
+
+
+class _DummyFig:
+    def tight_layout(self):
+        return None
+
+    def savefig(self, path):
+        Path(path).touch()
+
+
+class _DummyPyplot:
+    def subplots(self, *args, **kwargs):
+        return _DummyFig(), _DummyAxes()
+
+    def close(self, *args, **kwargs):
+        return None
+
+
+dummy_pyplot = _DummyPyplot()
+sys.modules["matplotlib"] = types.SimpleNamespace(pyplot=dummy_pyplot)
+sys.modules["matplotlib.pyplot"] = dummy_pyplot
+
+import importlib
+benchmark_cli = importlib.import_module("dpf2.cli.benchmark")
+match_benchmark = benchmark_cli.match_benchmark
+
+
+def test_match_benchmark(tmp_path):
+    bench = tmp_path / "bench.csv"
+    bench.write_text("time,value\n0,0\n1,1\n")
+    sim = tmp_path / "sim.csv"
+    sim.write_text("time,value\n0,0\n1,1\n")
+
+    cfg = {
+        "dataset_id": "PF1000",
+        "benchmark_trace_path": str(bench),
+        "benchmark_format": "csv",
+        "benchmark_fields": ["I(t)"],
+        "waveform_tolerance": 5.0,
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(cfg))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        match_benchmark,
+        [
+            "--config",
+            str(cfg_path),
+            "--simulation",
+            str(sim),
+            "--output",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert (tmp_path / "report.html").exists()
+    assert (tmp_path / "report.pdf").exists()


### PR DESCRIPTION
## Summary
- add `match-benchmark` CLI command to compare simulation outputs with benchmark traces
- produce JSON metrics plus PDF/HTML reports for waveform errors
- register new command and cover with tests

## Testing
- `pytest tests/test_cli_benchmark_match.py tests/test_cli_run_benchmark.py -q`
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package and other missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cec1d6e8832a95b2123dc4569882