### PR TITLE
Add RMS error reporting in benchmark command

### DIFF
--- a/docs/run_benchmark.md
+++ b/docs/run_benchmark.md
@@ -22,4 +22,5 @@ $ dpf2 run-benchmark unu_pff
 The generated plot includes grey tolerance bands around the reference
 traces with the actual simulation output overlaid.  A table lists whether
 current, voltage and neutron yield fall within their respective bands, and
-the metrics file records the maximum deviation for each signal.
+the metrics file records both the maximum and RMS deviation for each
+signal.

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -1279,15 +1279,18 @@ def run_benchmark(case: str, benchmark_dir: str, output: str) -> None:
     fig.savefig(out_root / "overlay.png")
     plt.close(fig)
 
-    # Write metrics alongside the plot
-    metrics = {
-        name: {
+    # Write metrics alongside the plot.  In addition to the maximum absolute
+    # error, record an RMS error for a slightly more informative scorecard.
+    metrics = {}
+    for name, _, act, ref, band, passed in results:
+        err = np.abs(act - ref)
+        metrics[name] = {
             "passed": passed,
             "tolerance": band,
-            "max_error": float(np.max(np.abs(act - ref))),
+            "max_error": float(np.max(err)),
+            "rms_error": float(np.sqrt(np.mean(err ** 2))),
         }
-        for name, _, act, ref, band, passed in results
-    }
+
     metrics["overall_passed"] = all(m["passed"] for m in metrics.values())
     (out_root / "metrics.json").write_text(json.dumps(metrics, indent=2))
 


### PR DESCRIPTION
## Summary
- extend `run-benchmark` metrics with RMS error calculation
- document that metrics now include maximum and RMS deviation for each signal

## Testing
- `pytest tests/test_cli_run_benchmark.py::test_run_benchmark_cmd -q`
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package and other missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cec80a3c832a9a7308d045cc84bf