### PR TITLE
Add dynesty calibration utilities and examples

### DIFF
--- a/examples/notebooks/tof_calibration.ipynb
+++ b/examples/notebooks/tof_calibration.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Time-of-Flight Calibration\n",
+    "Estimate mass and current scaling factors from ToF and current data using `dynesty_calibrate_mass_current`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from dpf2.uq.calibration import dynesty_calibrate_mass_current\n",
+    "\n",
+    "rng = np.random.default_rng(0)\n",
+    "current_sim = np.linspace(0.0, 1.0, 5)\n",
+    "tof_sim = np.array([1.0])\n",
+    "\n",
+    "true_mass = 1.2\n",
+    "true_current = 0.8\n",
+    "current_data = true_current * current_sim + rng.normal(0, 0.01, size=current_sim.shape)\n",
+    "tof_data = true_mass * tof_sim + rng.normal(0, 0.01, size=tof_sim.shape)\n",
+    "\n",
+    "samples = dynesty_calibrate_mass_current(\n",
+    "    current_sim,\n",
+    "    current_data,\n",
+    "    tof_sim,\n",
+    "    tof_data,\n",
+    "    bounds={\"mass_factor\": (0.5, 1.5), \"current_factor\": (0.5, 1.5)},\n",
+    "    n_iter=200,\n",
+    "    seed=123,\n",
+    ")\n",
+    "print({k: (float(np.mean(v)), float(np.std(v))) for k, v in samples.items()})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/waveform_calibration.ipynb
+++ b/examples/notebooks/waveform_calibration.ipynb
@@ -1,0 +1,57 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Waveform Calibration\n",
+    "Demonstrate calibration of mass and current scaling factors from a noisy current waveform using `emcee_calibrate_waveform`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from dpf2.uq.calibration import emcee_calibrate_waveform\n",
+    "\n",
+    "rng = np.random.default_rng(0)\n",
+    "time_sim = np.linspace(0, 1e-6, 50)\n",
+    "current_sim = 1e5 * np.sin(2 * np.pi * time_sim / time_sim[-1])\n",
+    "\n",
+    "true_mass = 1.1\n",
+    "true_current = 0.9\n",
+    "time_data = time_sim\n",
+    "scaled_time = true_mass * time_sim\n",
+    "current_data = true_current * np.interp(time_data, scaled_time, current_sim, left=0.0, right=0.0)\n",
+    "current_data += rng.normal(0, 1e4, size=current_data.shape)\n",
+    "\n",
+    "samples = emcee_calibrate_waveform(\n",
+    "    time_sim,\n",
+    "    current_sim,\n",
+    "    time_data,\n",
+    "    current_data,\n",
+    "    bounds={\"mass_factor\": (0.5, 1.5), \"current_factor\": (0.5, 1.5)},\n",
+    "    n_steps=500,\n",
+    "    seed=123,\n",
+    ")\n",
+    "print({k: (float(np.mean(v)), float(np.std(v))) for k, v in samples.items()})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dpf2/uq/calibration.py
+++ b/src/dpf2/uq/calibration.py
@@ -228,6 +228,66 @@ def emcee_calibrate_mass_current(
 
 
 # ---------------------------------------------------------------------------
+def dynesty_calibrate_mass_current(
+    current_sim: np.ndarray,
+    current_data: np.ndarray,
+    tof_sim: np.ndarray,
+    tof_data: np.ndarray,
+    bounds: Bounds | None = None,
+    n_live: int = 50,
+    n_iter: int = 500,
+    sigma_current: float = 1.0,
+    sigma_tof: float = 1.0,
+    seed: int | None = None,
+) -> Dict[str, np.ndarray]:
+    """Estimate mass and current factors using :mod:`dynesty` nested sampling.
+
+    Parameters mirror :func:`emcee_calibrate_mass_current` but employ a
+    nested sampler that can better explore multi-modal posteriors.
+    """
+
+    try:  # pragma: no cover - dependency may be optional
+        import dynesty  # type: ignore
+    except Exception as exc:  # pragma: no cover - import error path
+        raise RuntimeError(
+            "dynesty is required for dynesty_calibrate_mass_current"
+        ) from exc
+
+    if bounds is None:
+        bounds = {"mass_factor": (0.5, 1.5), "current_factor": (0.5, 1.5)}
+
+    names = ["mass_factor", "current_factor"]
+    lower = np.array([bounds[n][0] for n in names])
+    upper = np.array([bounds[n][1] for n in names])
+
+    current_sim = np.asarray(current_sim, dtype=float)
+    current_data = np.asarray(current_data, dtype=float)
+    tof_sim = np.asarray(tof_sim, dtype=float)
+    tof_data = np.asarray(tof_data, dtype=float)
+
+    def prior_transform(u: np.ndarray) -> np.ndarray:
+        return lower + u * (upper - lower)
+
+    def log_like(theta: np.ndarray) -> float:
+        mass_factor, current_factor = theta
+        curr_pred = current_factor * current_sim
+        tof_pred = mass_factor * tof_sim
+        resid_current = (current_data - curr_pred) / sigma_current
+        resid_tof = (tof_data - tof_pred) / sigma_tof
+        return -0.5 * (
+            np.dot(resid_current, resid_current)
+            + np.dot(resid_tof, resid_tof)
+        )
+
+    sampler = dynesty.NestedSampler(
+        log_like, prior_transform, len(names), nlive=n_live, seed=seed
+    )
+    sampler.run_nested(maxiter=n_iter, print_progress=False)
+    res = sampler.results
+    return {name: res.samples[:, idx] for idx, name in enumerate(names)}
+
+
+# ---------------------------------------------------------------------------
 def emcee_calibrate_waveform(
     time_sim: np.ndarray,
     current_sim: np.ndarray,
@@ -285,10 +345,67 @@ def emcee_calibrate_waveform(
     return {name: chain[:, idx] for idx, name in enumerate(names)}
 
 
+# ---------------------------------------------------------------------------
+def dynesty_calibrate_waveform(
+    time_sim: np.ndarray,
+    current_sim: np.ndarray,
+    time_data: np.ndarray,
+    current_data: np.ndarray,
+    bounds: Bounds | None = None,
+    n_live: int = 50,
+    n_iter: int = 500,
+    sigma: float = 1.0,
+    seed: int | None = None,
+) -> Dict[str, np.ndarray]:
+    """Calibrate waveform scaling factors using :mod:`dynesty`.
+
+    This mirrors :func:`emcee_calibrate_waveform` but with nested sampling.
+    """
+
+    try:  # pragma: no cover - dependency may be optional
+        import dynesty  # type: ignore
+    except Exception as exc:  # pragma: no cover - import error path
+        raise RuntimeError(
+            "dynesty is required for dynesty_calibrate_waveform"
+        ) from exc
+
+    if bounds is None:
+        bounds = {"mass_factor": (0.5, 1.5), "current_factor": (0.5, 1.5)}
+
+    names = ["mass_factor", "current_factor"]
+    lower = np.array([bounds[n][0] for n in names])
+    upper = np.array([bounds[n][1] for n in names])
+
+    time_sim = np.asarray(time_sim, dtype=float)
+    current_sim = np.asarray(current_sim, dtype=float)
+    time_data = np.asarray(time_data, dtype=float)
+    current_data = np.asarray(current_data, dtype=float)
+
+    def prior_transform(u: np.ndarray) -> np.ndarray:
+        return lower + u * (upper - lower)
+
+    def log_like(theta: np.ndarray) -> float:
+        mass_factor, current_factor = theta
+        scaled_time = mass_factor * time_sim
+        sim_interp = np.interp(time_data, scaled_time, current_sim, left=0.0, right=0.0)
+        pred = current_factor * sim_interp
+        resid = (current_data - pred) / sigma
+        return -0.5 * np.dot(resid, resid)
+
+    sampler = dynesty.NestedSampler(
+        log_like, prior_transform, len(names), nlive=n_live, seed=seed
+    )
+    sampler.run_nested(maxiter=n_iter, print_progress=False)
+    res = sampler.results
+    return {name: res.samples[:, idx] for idx, name in enumerate(names)}
+
+
 __all__ = [
     "bayesian_calibration",
     "nested_calibration",
     "emcee_calibrate_mass_current",
+    "dynesty_calibrate_mass_current",
     "emcee_calibrate_waveform",
+    "dynesty_calibrate_waveform",
 ]
 

--- a/tests/test_dynesty_calibration.py
+++ b/tests/test_dynesty_calibration.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from dpf2.uq.calibration import dynesty_calibrate_mass_current
+
+
+def test_dynesty_calibrate_mass_current():
+    pytest.importorskip("dynesty")
+    rng = np.random.default_rng(0)
+
+    current_sim = np.linspace(0.0, 1.0, 5)
+    tof_sim = np.array([1.0])
+
+    true_mass = 1.2
+    true_current = 0.8
+
+    current_data = true_current * current_sim + rng.normal(0, 0.01, size=current_sim.shape)
+    tof_data = true_mass * tof_sim + rng.normal(0, 0.01, size=tof_sim.shape)
+
+    samples = dynesty_calibrate_mass_current(
+        current_sim,
+        current_data,
+        tof_sim,
+        tof_data,
+        bounds={"mass_factor": (0.5, 2.0), "current_factor": (0.5, 2.0)},
+        n_live=10,
+        n_iter=100,
+        sigma_current=0.01,
+        sigma_tof=0.01,
+        seed=0,
+    )
+
+    mean_mass = float(np.mean(samples["mass_factor"]))
+    mean_current = float(np.mean(samples["current_factor"]))
+
+    assert abs(mean_mass - true_mass) < 0.2
+    assert abs(mean_current - true_current) < 0.2

--- a/tests/test_dynesty_waveform_calibration.py
+++ b/tests/test_dynesty_waveform_calibration.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+from dpf2.uq.calibration import dynesty_calibrate_waveform
+
+
+def test_dynesty_calibrate_waveform():
+    pytest.importorskip("dynesty")
+    rng = np.random.default_rng(0)
+    t_sim = np.linspace(0.0, 1.0, 50)
+    current_sim = np.sin(2 * np.pi * t_sim)
+    true_mass = 1.1
+    true_current = 0.9
+    t_data = t_sim
+    current_true = true_current * np.interp(t_data, true_mass * t_sim, current_sim, left=0.0, right=0.0)
+    current_data = current_true + rng.normal(0, 0.01, size=t_data.shape)
+
+    samples = dynesty_calibrate_waveform(
+        t_sim,
+        current_sim,
+        t_data,
+        current_data,
+        bounds={"mass_factor": (0.5, 2.0), "current_factor": (0.5, 2.0)},
+        n_live=20,
+        n_iter=200,
+        sigma=0.01,
+        seed=0,
+    )
+    mean_mass = float(np.mean(samples["mass_factor"]))
+    mean_current = float(np.mean(samples["current_factor"]))
+    assert abs(mean_mass - true_mass) < 0.2
+    assert abs(mean_current - true_current) < 0.2


### PR DESCRIPTION
## Summary
- extend `uq.calibration` with dynesty-based samplers for mass/current and waveform calibration
- add demonstration notebooks for waveform and time-of-flight calibration
- cover new dynesty routines with basic tests

## Testing
- `pytest tests/test_bayesian_calibration.py -q`
- `pytest tests/test_emcee_calibration.py -q` *(skipped: emcee missing)*
- `pytest tests/test_emcee_waveform_calibration.py -q` *(skipped: emcee missing)*
- `pytest tests/test_dynesty_calibration.py -q` *(skipped: dynesty missing)*
- `pytest tests/test_dynesty_waveform_calibration.py -q` *(skipped: dynesty missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ceceddd4832a989e5bee495f4750