### PR TITLE
Stage run manifest and document restart workflow

### DIFF
--- a/docs/hpc.md
+++ b/docs/hpc.md
@@ -4,10 +4,9 @@ DPF2 provides a minimal ``JobManager`` to help launch simulations on
 clusters.  When running on shared systems, enable the ``--lab-mode`` flag
 to capture metadata for reproducibility and auditing.
 
-The job manager can automatically stage run manifests by providing the
-``manifest`` argument to :meth:`~dpf2.hpc.JobManager.submit`. Passing the
-manifest path again via ``restart`` allows a job to resume from recorded
-metadata.
+The job manager automatically stages the ``run_manifest.json`` file with
+other outputs.  Passing the manifest path via ``restart`` allows a job to
+resume from recorded metadata.
 
 ## Example SLURM batch script
 
@@ -30,4 +29,26 @@ After the job completes the ``run`` directory will contain simulation outputs
 alongside ``run_manifest.json`` (and ``run_manifest.h5`` when ``h5py`` is installed).
 The manifest records the git commit, random seeds, environment details and
 particles-per-cell setting, allowing each run to be audited and reproduced.
+
+## Restarting from a manifest
+
+To resume a previous run provide the path to the existing manifest via
+``--restart``. The job manager will stage the manifest automatically.
+
+```bash
+#!/bin/bash
+#SBATCH -J dpf2_restart
+#SBATCH -N 1
+#SBATCH -c 8
+#SBATCH -t 00:05:00
+#SBATCH -o run2/%x-%j.log
+
+module load python
+
+# Restart from a recorded manifest and write outputs to a new directory
+python -m dpf2.cli --lab-mode simulate \
+    --config config.json \
+    --output run2 \
+    --restart run/run_manifest.json
+```
 

--- a/src/dpf2/hpc/manager.py
+++ b/src/dpf2/hpc/manager.py
@@ -74,7 +74,9 @@ class JobManager:
         if stage_in:
             for src, dst in stage_in.items():
                 lines.append(f"cp -r {src} {dst}")
-        lines.append(job_script)
+        # Forward any arguments passed to the wrapper script to the actual job
+        # script so features like ``--restart`` continue to function.
+        lines.append(f"{job_script} \"$@\"")
         if stage_out:
             for src, dst in stage_out.items():
                 lines.append(f"cp -r {src} {dst}")
@@ -94,7 +96,8 @@ class JobManager:
             Path to a submission script or executable.
         manifest:
             Optional path to a ``run_manifest.json`` that should be staged with
-            other outputs.
+            other outputs. If omitted, ``"run_manifest.json"`` is used and will
+            always be copied alongside job results.
         **kwargs:
             Additional scheduler specific keyword arguments. ``restart`` may
             reference a manifest path to resume a previous run.
@@ -108,12 +111,20 @@ class JobManager:
         stage_in: Mapping[str, str] | None = kwargs.pop("stage_in", None)
         stage_out: Mapping[str, str] | None = kwargs.pop("stage_out", None)
         restart = kwargs.get("restart")
-        if manifest is not None:
-            stage_out = dict(stage_out or {})
-            stage_out[manifest] = manifest
+
+        # Always copy the run manifest with other outputs so metadata is
+        # preserved. When ``manifest`` is not supplied we fall back to the
+        # conventional ``run_manifest.json`` name.
+        manifest_path = manifest or "run_manifest.json"
+        stage_out = dict(stage_out or {})
+        stage_out[manifest_path] = manifest_path
+
+        # ``--restart`` may reference a previously generated manifest. Stage it
+        # in so the job can resume using the recorded metadata.
         if restart is not None and str(restart).endswith(".json"):
             stage_in = dict(stage_in or {})
             stage_in[str(restart)] = str(restart)
+
         job_script = self._wrap_staging(job_script, stage_in, stage_out)
 
         # Script level arguments and restart handling

--- a/tests/performance/test_hpc_manager.py
+++ b/tests/performance/test_hpc_manager.py
@@ -41,8 +41,9 @@ def test_slurm_submit_options(tmp_path, monkeypatch):
     assert "--nodelist" in cmd and cmd[cmd.index("--nodelist") + 1] == "node1,node2"
     assert "--gpus" in cmd and cmd[cmd.index("--gpus") + 1] == "2"
     assert "--dependency" in cmd and cmd[cmd.index("--dependency") + 1] == "afterok:11:22"
-    idx = cmd.index(str(script))
-    assert cmd[idx + 1 : idx + 5] == ["--foo", "bar", "--restart", "chkpt.dat"]
+    # The job script is wrapped for staging so we only verify the tail
+    # contains the expected script arguments.
+    assert cmd[-4:] == ["--foo", "bar", "--restart", "chkpt.dat"]
     assert env["CUDA_VISIBLE_DEVICES"] == "0,1"
     assert env["DPF_RESTART"] == "chkpt.dat"
 
@@ -81,8 +82,8 @@ def test_mpi_node_topology_and_restart(tmp_path, monkeypatch):
     assert "1 hostA 1" in gpu_map
     assert "2 hostB 0" in gpu_map
 
-    idx = cmd.index(str(script))
-    assert cmd[idx + 1 : idx + 3] == ["--restart", "chk.dat"]
+    # Wrapper script obscures the actual job path; ensure args are forwarded.
+    assert cmd[-2:] == ["--restart", "chk.dat"]
     assert env["CUDA_VISIBLE_DEVICES"] == "0,1"
     assert env["DPF_RESTART"] == "chk.dat"
 
@@ -121,4 +122,27 @@ def test_stage_manifest_and_restart(tmp_path, monkeypatch):
     assert cmd[idx + 1 : idx + 3] == ["--restart", manifest]
     env = called["env"]
     assert env["DPF_RESTART"] == manifest
+
+
+def test_default_manifest_staged(tmp_path, monkeypatch):
+    """Ensure ``run_manifest.json`` is copied even without explicit argument."""
+
+    script = tmp_path / "job.sh"
+    script.write_text("#!/bin/bash\n")
+    jm = JobManager("slurm")
+
+    called: dict[str, object] = {}
+
+    def fake_wrap(self, job_script, stage_in, stage_out):  # type: ignore[override]
+        called["stage_out"] = stage_out
+        return job_script
+
+    def fake_run(cmd, capture_output, text, check, env):  # type: ignore[override]
+        return type("R", (), {})()
+
+    monkeypatch.setattr(JobManager, "_wrap_staging", fake_wrap)
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    jm.submit(str(script))
+    assert called["stage_out"]["run_manifest.json"] == "run_manifest.json"
 


### PR DESCRIPTION
## Summary
- always stage `run_manifest.json` when submitting jobs and allow `--restart` manifests
- forward wrapper arguments to preserve script options like `--restart`
- document SLURM workflow and restart example

## Testing
- `pytest tests/performance/test_hpc_manager.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9cecf5bb8832a8919fc90c4bd6b66