### PR TITLE
feat: integrate plasma inductance feedback and jittered switches

### DIFF
--- a/src/dpf2/circuit/distributed.py
+++ b/src/dpf2/circuit/distributed.py
@@ -22,13 +22,22 @@ which is perfectly adequate for the unit tests that exercise this module.
 """
 
 from dataclasses import dataclass, field
-from typing import Iterable, Sequence, List
+from typing import Iterable, Sequence, List, Any
 
 import numpy as np
 import math
 import cmath
 
-__all__ = ["TransmissionLineSegment", "TriggeredSwitch", "assemble_matrices"]
+from dpf2.core.bases import PlasmaSolverBase
+
+__all__ = [
+    "TransmissionLineSegment",
+    "TriggeredSwitch",
+    "CrowbarStage",
+    "BlumleinSection",
+    "PlasmaInductance",
+    "assemble_matrices",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +207,7 @@ class TriggeredSwitch:
     R_off: float = 1e6
     trigger_times: Sequence[float] | None = None
     trigger_time: float | None = None  # backward compatible single trigger
+    jitter_std: float = 0.0
     L_parasitic: float = 0.0
     R_parasitic: float = 0.0
     C_parasitic: float = 0.0
@@ -214,6 +224,10 @@ class TriggeredSwitch:
             self.trigger_times = list(self.trigger_times)
             if self.trigger_time is not None:
                 self.trigger_times.append(self.trigger_time)
+        # Optional Gaussian jitter applied to trigger times
+        if self.jitter_std > 0.0 and self.trigger_times:
+            jitter = np.random.normal(0.0, self.jitter_std, len(self.trigger_times))
+            self.trigger_times = [t + j for t, j in zip(self.trigger_times, jitter)]
         # Ensure times are in ascending order for efficient processing
         self.trigger_times = sorted(self.trigger_times)
 
@@ -238,6 +252,85 @@ class TriggeredSwitch:
             self.update(t)
         base = self.R_on if self.closed else self.R_off
         return base + self.R_parasitic
+
+
+@dataclass
+class CrowbarStage(TriggeredSwitch):
+    """Resistive crowbar stage engaging at ``trigger_time`` with optional jitter."""
+
+    def __init__(
+        self,
+        from_node: int,
+        to_node: int,
+        resistance: float,
+        trigger_time: float,
+        jitter_std: float = 0.0,
+    ) -> None:
+        super().__init__(
+            from_node=from_node,
+            to_node=to_node,
+            closed=False,
+            R_on=resistance,
+            R_off=1e12,
+            trigger_times=[trigger_time],
+            jitter_std=jitter_std,
+        )
+
+
+@dataclass
+class BlumleinSection:
+    """Transmission line segment with a triggerable switch representing a Blumlein block."""
+
+    segment: TransmissionLineSegment
+    trigger: TriggeredSwitch
+
+    def __init__(
+        self,
+        segment: TransmissionLineSegment,
+        trigger_time: float,
+        jitter_std: float = 0.0,
+        R_on: float = 1e-3,
+        R_off: float = 1e6,
+    ) -> None:
+        self.segment = segment
+        self.trigger = TriggeredSwitch(
+            from_node=segment.to_node,
+            to_node=segment.from_node,
+            closed=False,
+            R_on=R_on,
+            R_off=R_off,
+            trigger_times=[trigger_time],
+            jitter_std=jitter_std,
+        )
+
+    def components(self) -> tuple[TransmissionLineSegment, TriggeredSwitch]:
+        """Return the underlying segment and trigger switch."""
+
+        return self.segment, self.trigger
+
+
+@dataclass
+class PlasmaInductance:
+    """Dynamic inductive branch sourced from an external plasma solver."""
+
+    from_node: int
+    to_node: int
+    solver: PlasmaSolverBase
+
+    def delay(self) -> float:
+        return 0.0
+
+    def totals(
+        self, t: float = 0.0, frequency: float | None = None
+    ) -> tuple[float, float, float]:
+        """Return instantaneous plasma inductance ``Lp``."""
+
+        try:
+            fb = self.solver.coupling_interface()
+            Lp = float(getattr(fb, "Lp", 0.0))
+        except Exception:
+            Lp = 0.0
+        return Lp, 0.0, 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -343,6 +343,7 @@ class SimulationEngine:
         voltage = circuit.voltages[-1]
         step = 0
         plasma_state = None
+        coupling = CouplingState(current=current, voltage=voltage)
         diag_list = list(diagnostics or [])
         if neutron_cb is not None:
             diag_list.append(NeutronYieldStreamer(neutron_cb))
@@ -350,41 +351,50 @@ class SimulationEngine:
             diag_list.append(XRayEmissionStreamer(xray_cb))
 
         while circuit.time[-1] < t_end:
-            state = CouplingState(current=current, voltage=voltage)
             if plasma_solver is not None:
-                plasma_state = plasma_solver.step(plasma_state, dt, current, voltage)
-                Lp = 0.0
-                if hasattr(plasma_solver, "compute_plasma_inductance"):
-                    try:
-                        Lp = float(plasma_solver.compute_plasma_inductance(plasma_state, current))
-                    except Exception:
-                        Lp = 0.0
-                elif hasattr(plasma_solver, "plasma_inductance"):
-                    try:
-                        Lp = float(plasma_solver.plasma_inductance(plasma_state))
-                    except Exception:
-                        Lp = 0.0
+                plasma_state = plasma_solver.step(
+                    plasma_state, dt, coupling.current, coupling.voltage
+                )
                 iface = plasma_solver.coupling_interface()
-                iface.Lp = Lp
-                br = iface.back_reaction
+                Lp = getattr(iface, "Lp", 0.0)
+                if Lp == 0.0:
+                    if hasattr(plasma_solver, "compute_plasma_inductance"):
+                        try:
+                            Lp = float(
+                                plasma_solver.compute_plasma_inductance(
+                                    plasma_state, coupling.current
+                                )
+                            )
+                        except Exception:
+                            Lp = 0.0
+                    elif hasattr(plasma_solver, "plasma_inductance"):
+                        try:
+                            Lp = float(plasma_solver.plasma_inductance(plasma_state))
+                        except Exception:
+                            Lp = 0.0
+                coupling.Lp = Lp
+                coupling.emf = getattr(iface, "emf", 0.0)
+                coupling.mutual_inductance = getattr(iface, "mutual_inductance", 0.0)
+                br = getattr(iface, "back_reaction", 0.0)
                 if self.comm is not None and self.comm.size > 1:  # pragma: no cover - MPI
                     br = self.comm.allreduce(br, op=MPI.SUM)
-                state.Lp = Lp
-                state.emf = iface.emf
-                state.mutual_inductance = iface.mutual_inductance
-                state.back_reaction = br
+                coupling.back_reaction = br
 
             # Optional multithreading for circuit stepping
             if self._executor is not None:
                 future = self._executor.submit(
-                    circuit.step, state, 0.0, dt, energy_tracker=tracker
+                    circuit.step, coupling, 0.0, dt, energy_tracker=tracker
                 )
                 updated = future.result()
             else:
-                updated = circuit.step(state, 0.0, dt, energy_tracker=tracker)
+                updated = circuit.step(coupling, 0.0, dt, energy_tracker=tracker)
 
             if self.comm is not None and (self.comm.size > 1):  # pragma: no cover - MPI
                 updated = self.comm.bcast(updated, root=0)
+
+            coupling.current = updated.current
+            coupling.voltage = updated.voltage
+            current, voltage = updated.current, updated.voltage
 
             # Radiation transport coupling (placeholder)
             rad_in = tracker.thermal[-1] if tracker.thermal else 0.0


### PR DESCRIPTION
## Summary
- support jittered switching and new crowbar/blumlein helpers
- add PlasmaInductance segment pulling Lp(t) from plasma solver
- couple SimulationEngine and plasma solver via shared CouplingState for I-V-Lp

## Testing
- `python -m pytest` *(fails: 55 errors during collection)*
- `python -m pytest tests/test_plasma_inductance_coupling.py tests/test_distributed_circuit.py tests/test_triggered_switch.py` *(fails: 3 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d72a11e0832ab0218ed3c9623eca