### PR TITLE
feat: extend neutron spectra diagnostics

### DIFF
--- a/src/dpf2/diagnostics/neutron_spectra.py
+++ b/src/dpf2/diagnostics/neutron_spectra.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from bisect import bisect_right
-from typing import Sequence, List
+from pathlib import Path
+from typing import Dict, Sequence, List, Tuple
+import json
 import math
+import numpy as np
 
 # Neutron mass used for simple time-of-flight calculations (kg)
 M_N = 1.674e-27
@@ -23,18 +26,24 @@ class DetectorLayout:
     """Container describing a collection of detectors on a ring."""
 
     angles: Sequence[float]
-    distance_m: float
+    distance_m: float | Sequence[float]
     names: Sequence[str] | None = None
 
     def __post_init__(self) -> None:
-        if self.distance_m <= 0:
-            raise ValueError("distance_m must be positive")
+        if isinstance(self.distance_m, Sequence) and not isinstance(self.distance_m, str):
+            if len(self.distance_m) != len(self.angles):
+                raise ValueError("distance_m sequence must match number of angles")
+            distances = [float(d) for d in self.distance_m]
+        else:
+            if float(self.distance_m) <= 0:
+                raise ValueError("distance_m must be positive")
+            distances = [float(self.distance_m) for _ in self.angles]
         if self.names and len(self.names) != len(self.angles):
             raise ValueError("names must match number of angles")
         self.detectors: List[Detector] = []
         for i, ang in enumerate(self.angles):
             name = self.names[i] if self.names else f"detector_{i}"
-            self.detectors.append(Detector(float(ang), float(self.distance_m), name))
+            self.detectors.append(Detector(float(ang), distances[i], name))
 
     def angles_deg(self) -> List[float]:
         """Return detector viewing angles in degrees."""
@@ -116,10 +125,150 @@ def anisotropy_metric(values: Sequence[float]) -> float:
     return (max(values) - min(values)) / mean
 
 
+def load_detector_layout(path: str | Path) -> DetectorLayout:
+    """Load a :class:`DetectorLayout` from a JSON or STL file.
+
+    Parameters
+    ----------
+    path:
+        Path to the geometry description.  JSON expects ``{"distance_m":
+        float, "detectors": [{"angle_deg": float, "name": str}]}``.
+        STL parsing requires the :mod:`trimesh` package and uses the centroid
+        of each geometry component to determine detector angles and distances.
+    """
+
+    p = Path(path)
+    suffix = p.suffix.lower()
+    if suffix == ".json":
+        with p.open("r", encoding="utf8") as f:
+            data = json.load(f)
+        dets = data.get("detectors", [])
+        angles = [float(d["angle_deg"]) for d in dets]
+        distances = [float(d.get("distance_m", data.get("distance_m", 0.0))) for d in dets]
+        names = [d.get("name") for d in dets]
+        return DetectorLayout(angles=angles, distance_m=distances, names=names)
+    if suffix == ".stl":
+        try:
+            import trimesh  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise ImportError("trimesh is required for STL layouts") from exc
+        mesh = trimesh.load_mesh(str(p))
+        if isinstance(mesh, trimesh.Scene):  # pragma: no cover - unlikely
+            geoms = list(mesh.geometry.values())
+        else:
+            geoms = mesh.split(only_watertight=False)
+        angles: List[float] = []
+        distances: List[float] = []
+        names: List[str] = []
+        for i, g in enumerate(geoms):
+            centroid = g.centroid
+            ang = math.degrees(math.atan2(float(centroid[1]), float(centroid[0])))
+            dist = float(math.hypot(float(centroid[0]), float(centroid[1])))
+            angles.append(ang)
+            distances.append(dist)
+            names.append(f"detector_{i}")
+        return DetectorLayout(angles=angles, distance_m=distances, names=names)
+    raise ValueError("Unsupported detector layout format")
+
+
+def time_resolved_spectra(
+    layout: DetectorLayout,
+    energies: Sequence[float],
+    flux: Sequence[float],
+    time_bins: Sequence[float],
+    base_yield: float = 1.0,
+    anisotropy: float = 0.0,
+) -> Dict[str, List[float]]:
+    """Compute time-resolved spectra for each detector in ``layout``.
+
+    ``base_yield`` and ``anisotropy`` control a simple cosine angular yield
+    model applied to each detector before the time-of-flight histogram is
+    generated.
+    """
+
+    angle_weights = angular_spectrum(layout.angles_deg(), base_yield, anisotropy)
+    spectra: Dict[str, List[float]] = {}
+    for det, weight in zip(layout.detectors, angle_weights):
+        hist = synthetic_tof_spectrum(energies, flux, det.distance_m, time_bins)
+        hist = [h * weight for h in hist]
+        spectra[det.name] = hist
+    return spectra
+
+
+def forward_radial_backward_counts(
+    layout: DetectorLayout, spectra: Dict[str, Sequence[float]]
+) -> Dict[str, float]:
+    """Aggregate counts into forward, radial and backward groups."""
+
+    totals: Dict[str, float] = {"forward": 0.0, "radial": 0.0, "backward": 0.0}
+    for det in layout.detectors:
+        ang = det.angle_deg % 360.0
+        count = float(sum(spectra.get(det.name, [])))
+        if ang <= 45.0 or ang >= 315.0:
+            totals["forward"] += count
+        elif 135.0 <= ang <= 225.0:
+            totals["backward"] += count
+        else:
+            totals["radial"] += count
+    return totals
+
+
+def anisotropy_ratios(counts: Dict[str, float]) -> Dict[str, float]:
+    """Return simple forward/backward and radial/backward ratios."""
+
+    backward = counts.get("backward", 0.0)
+    ratios: Dict[str, float] = {}
+    if backward > 0.0:
+        ratios["forward_backward"] = counts.get("forward", 0.0) / backward
+        ratios["radial_backward"] = counts.get("radial", 0.0) / backward
+    return ratios
+
+
+def cross_correlate_tof_with_circuit(
+    time_bins: Sequence[float],
+    counts: Sequence[float],
+    circuit_time: Sequence[float],
+    circuit_signal: Sequence[float],
+) -> Tuple[List[float], List[float], float]:
+    """Cross-correlate a ToF spectrum with a circuit waveform.
+
+    Returns the correlation array, corresponding lags in seconds and the lag at
+    maximum correlation.  The circuit waveform is interpolated onto the midpoints
+    of the ToF bins before correlation.
+    """
+
+    if len(time_bins) < 2:
+        raise ValueError("time_bins must have at least two entries")
+    mid = 0.5 * (np.asarray(time_bins[:-1]) + np.asarray(time_bins[1:]))
+    interp = np.interp(mid, np.asarray(circuit_time), np.asarray(circuit_signal))
+    a = np.asarray(counts) - np.mean(counts)
+    b = interp - np.mean(interp)
+    if hasattr(np, "correlate"):
+        corr = np.correlate(a, b, mode="full")
+    else:  # pragma: no cover - exercised only with numpy stub lacking correlate
+        # simple Python correlation implementation
+        a_list = list(a)
+        b_list = list(b)
+        corr = [0.0] * (len(a_list) + len(b_list) - 1)
+        for i, av in enumerate(a_list):
+            for j, bv in enumerate(b_list):
+                corr[i + j] += av * bv
+        corr = np.asarray(corr)
+    dt = mid[1] - mid[0] if len(mid) > 1 else 0.0
+    lags = [(i - len(mid) + 1) * dt for i in range(len(corr))]
+    max_lag = float(lags[int(np.argmax(corr))])
+    return lags, list(corr), max_lag
+
+
 __all__ = [
     "Detector",
     "DetectorLayout",
     "synthetic_tof_spectrum",
     "angular_spectrum",
     "anisotropy_metric",
+    "load_detector_layout",
+    "time_resolved_spectra",
+    "forward_radial_backward_counts",
+    "anisotropy_ratios",
+    "cross_correlate_tof_with_circuit",
 ]

--- a/tests/test_neutron_spectra.py
+++ b/tests/test_neutron_spectra.py
@@ -3,6 +3,11 @@ from dpf2.diagnostics.neutron_spectra import (
     angular_spectrum,
     anisotropy_metric,
     DetectorLayout,
+    load_detector_layout,
+    time_resolved_spectra,
+    forward_radial_backward_counts,
+    anisotropy_ratios,
+    cross_correlate_tof_with_circuit,
 )
 
 
@@ -24,3 +29,40 @@ def test_angular_spectrum_and_anisotropy():
     assert metric == 2.0
     layout = DetectorLayout(angles=angles, distance_m=1.0)
     assert layout.detectors[1].angle_deg == 90.0
+
+
+def test_time_resolved_geometry_and_anisotropy(tmp_path):
+    import json
+
+    layout_data = {
+        "distance_m": 1.0,
+        "detectors": [
+            {"angle_deg": 0.0, "name": "f"},
+            {"angle_deg": 90.0, "name": "r"},
+            {"angle_deg": 180.0, "name": "b"},
+        ],
+    }
+    layout_path = tmp_path / "layout.json"
+    layout_path.write_text(json.dumps(layout_data))
+    layout = load_detector_layout(layout_path)
+    energies = [1.0, 2.0]
+    flux = [1.0, 1.0]
+    time_bins = [0.0, 1.0]
+    spectra = time_resolved_spectra(layout, energies, flux, time_bins)
+    assert set(spectra.keys()) == {"f", "r", "b"}
+    counts = forward_radial_backward_counts(layout, spectra)
+    assert counts["forward"] == counts["radial"] == counts["backward"]
+    ratios = anisotropy_ratios(counts)
+    assert ratios["forward_backward"] == 1.0
+
+
+def test_cross_correlation():
+    time_bins = [0.0, 1.0, 2.0, 3.0]
+    counts = [0.0, 1.0, 0.0]
+    circuit_time = [0.5, 1.5, 2.5]
+    circuit_signal = [0.0, 1.0, 0.0]
+    lags, corr, max_lag = cross_correlate_tof_with_circuit(
+        time_bins, counts, circuit_time, circuit_signal
+    )
+    assert len(lags) == len(corr) == 2 * len(counts) - 1
+    assert max_lag == 0.0


### PR DESCRIPTION
## Summary
- support loading detector layouts from JSON or STL
- compute per-angle time-resolved spectra and directional counts
- add anisotropy ratios and ToF/circuit cross-correlation utilities

## Testing
- `pytest tests/test_neutron_spectra.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9d72d5d8c832a9c04a1ebd1fdb5d2