### PR TITLE
Add CLI and range controls for param sweeps

### DIFF
--- a/src/dpf2/gui/qt_sweep.py
+++ b/src/dpf2/gui/qt_sweep.py
@@ -6,21 +6,32 @@ The interface exposes controls for charging voltage and initial gas pressure
 and allows quick parametric sweeps over either quantity.  After each sweep a
 plot of yield versus the swept parameter is displayed using :mod:`matplotlib`.
 
+In addition to the GUI, a small CLI is provided for headless parametric sweeps
+that reuses the same helpers.  Both interfaces allow specifying explicit
+parameter ranges rather than the fixed factors previously used.
+
 A simple multi-objective (yield vs. spot size) optimization is also provided via
 :func:`dpf2.gui.project_manager.ProjectManager.pareto_search`.
 
-This module only depends on :mod:`PyQt5` at runtime; if that optional
-dependency is missing an informative :class:`RuntimeError` is raised when
-attempting to launch the GUI.
+This module only depends on :mod:`PyQt5` at runtime for the GUI portion; if that
+optional dependency is missing an informative :class:`RuntimeError` is raised
+when attempting to launch the GUI.
 """
 
 from pathlib import Path
-from typing import List
+from typing import Dict, Iterable, List
 
+import argparse
+import numpy as np
 import matplotlib.pyplot as plt
 
 from .project_manager import ProjectManager
 from ..core.config import DPFConfig
+from ..optimization.param_sweep import (
+    compute_sweep_metrics,
+    plot_metric_overlay,
+    run_parametric_sweep,
+)
 
 try:  # pragma: no cover - optional GUI dependency
     from PyQt5.QtWidgets import (
@@ -30,6 +41,7 @@ try:  # pragma: no cover - optional GUI dependency
         QHBoxLayout,
         QLabel,
         QDoubleSpinBox,
+        QSpinBox,
         QPushButton,
     )
 except Exception:  # pragma: no cover - allow import when PyQt missing
@@ -41,6 +53,30 @@ def _ensure_qt() -> None:
 
     if QApplication is None:  # pragma: no cover - executed only when missing
         raise RuntimeError("PyQt5 is required for the Qt GUI")
+
+
+def plot_yield_vs_S_gv(
+    metrics: Dict[float, Dict[str, float]], path: Path, gv_S: float = 2.0
+) -> Path:
+    """Plot yield versus shock parameter ``S`` and mark GV prediction.
+
+    Points whose ``S`` deviates from the ``gv_S`` prediction are coloured red.
+    The resulting image is written to ``path``.
+    """
+
+    s_vals = [m.get("S", 0.0) for m in metrics.values()]
+    y_vals = [m.get("yield", 0.0) for m in metrics.values()]
+    colors = ["red" if abs(s - gv_S) > 0.5 else "blue" for s in s_vals]
+    plt.figure()
+    plt.scatter(s_vals, y_vals, c=colors)
+    plt.axvline(gv_S, color="k", linestyle="--", label="GV prediction")
+    plt.xlabel("S")
+    plt.ylabel("Yield")
+    plt.legend()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    plt.savefig(path)
+    plt.close()
+    return path
 
 
 class _SweepWindow(QWidget):
@@ -72,6 +108,50 @@ class _SweepWindow(QWidget):
         p_row.addWidget(self.pressure)
         layout.addLayout(p_row)
 
+        # Voltage sweep range controls
+        self.v_min = QDoubleSpinBox()
+        self.v_min.setRange(5_000, 30_000)
+        self.v_min.setValue(8_000)
+        self.v_min.setSuffix(" V")
+        self.v_max = QDoubleSpinBox()
+        self.v_max.setRange(5_000, 30_000)
+        self.v_max.setValue(12_000)
+        self.v_max.setSuffix(" V")
+        self.v_steps = QSpinBox()
+        self.v_steps.setRange(2, 20)
+        self.v_steps.setValue(3)
+        v_range = QHBoxLayout()
+        v_range.addWidget(QLabel("V min"))
+        v_range.addWidget(self.v_min)
+        v_range.addWidget(QLabel("V max"))
+        v_range.addWidget(self.v_max)
+        v_range.addWidget(QLabel("steps"))
+        v_range.addWidget(self.v_steps)
+        layout.addLayout(v_range)
+
+        # Pressure sweep range controls
+        self.p_min = QDoubleSpinBox()
+        self.p_min.setRange(0.1, 5.0)
+        self.p_min.setSingleStep(0.1)
+        self.p_min.setValue(0.5)
+        self.p_min.setSuffix(" Torr")
+        self.p_max = QDoubleSpinBox()
+        self.p_max.setRange(0.1, 5.0)
+        self.p_max.setSingleStep(0.1)
+        self.p_max.setValue(1.5)
+        self.p_max.setSuffix(" Torr")
+        self.p_steps = QSpinBox()
+        self.p_steps.setRange(2, 20)
+        self.p_steps.setValue(3)
+        p_range = QHBoxLayout()
+        p_range.addWidget(QLabel("P min"))
+        p_range.addWidget(self.p_min)
+        p_range.addWidget(QLabel("P max"))
+        p_range.addWidget(self.p_max)
+        p_range.addWidget(QLabel("steps"))
+        p_range.addWidget(self.p_steps)
+        layout.addLayout(p_range)
+
         btn_row = QHBoxLayout()
         self.btn_sweep_v = QPushButton("Sweep Voltage")
         self.btn_sweep_p = QPushButton("Sweep Pressure")
@@ -91,12 +171,8 @@ class _SweepWindow(QWidget):
         self.pm = ProjectManager(project="qt")
 
         # Connect callbacks
-        self.btn_sweep_v.clicked.connect(
-            lambda: self._run_sweep("charging_voltage", [0.8, 1.0, 1.2])
-        )
-        self.btn_sweep_p.clicked.connect(
-            lambda: self._run_sweep("initial_pressure", [0.5, 1.0, 1.5])
-        )
+        self.btn_sweep_v.clicked.connect(self._sweep_voltage)
+        self.btn_sweep_p.clicked.connect(self._sweep_pressure)
         self.btn_overlay.clicked.connect(self._overlay_runs)
         self.btn_export.clicked.connect(self._export_metrics)
         self.btn_pareto.clicked.connect(self._pareto_search)
@@ -108,12 +184,26 @@ class _SweepWindow(QWidget):
         cfg.initial_pressure = float(self.pressure.value())
         return cfg
 
-    def _run_sweep(self, param: str, factors: List[float]) -> None:
+    def _sweep_voltage(self) -> None:
+        vals = np.linspace(
+            float(self.v_min.value()),
+            float(self.v_max.value()),
+            int(self.v_steps.value()),
+        )
+        self._run_sweep("charging_voltage", vals)
+
+    def _sweep_pressure(self) -> None:
+        vals = np.linspace(
+            float(self.p_min.value()),
+            float(self.p_max.value()),
+            int(self.p_steps.value()),
+        )
+        self._run_sweep("initial_pressure", vals)
+
+    def _run_sweep(self, param: str, values: Iterable[float]) -> None:
         cfg = self._config()
-        base = getattr(cfg, param)
-        values = [base * f for f in factors]
         label = f"{param}_{len(self.pm.metrics)}"
-        self.pm.run_sweep(label, cfg, param, values)
+        metrics = self.pm.run_sweep(label, cfg, param, list(values))
         if self.pm.last_kpi_plot:
             img = plt.imread(self.pm.last_kpi_plot)
             plt.figure()
@@ -121,6 +211,28 @@ class _SweepWindow(QWidget):
             plt.axis("off")
             plt.tight_layout()
             plt.show()
+        if param == "initial_pressure":
+            s_path = plot_yield_vs_S_gv(
+                metrics,
+                Path("results")
+                / self.pm.project
+                / "yield_vs_S"
+                / f"{label}.png",
+            )
+            img = plt.imread(s_path)
+            plt.figure()
+            plt.imshow(img)
+            plt.axis("off")
+            plt.tight_layout()
+            plt.show()
+            best_val, best_metrics = max(
+                metrics.items(), key=lambda kv: kv[1].get("yield", 0.0)
+            )
+            opt_S = best_metrics.get("S", 0.0)
+            gv = 2.0
+            print(f"Optimal S = {opt_S:.2f} at P={best_val}")
+            if abs(opt_S - gv) > 1e-6:
+                print(f"Deviation from GV ({gv}) = {opt_S - gv:+.2f}")
 
     def _overlay_runs(self) -> None:
         path = self.pm.overlay_metrics()
@@ -170,4 +282,55 @@ def launch() -> None:
     app.exec_()
 
 
-__all__ = ["launch"]
+def main(argv: List[str] | None = None) -> None:
+    """Entry point for simple CLI-driven sweeps."""
+
+    parser = argparse.ArgumentParser(description="Run a parametric sweep")
+    parser.add_argument("--gui", action="store_true", help="launch the Qt GUI")
+    parser.add_argument(
+        "--param",
+        choices=["charging_voltage", "initial_pressure"],
+        help="Configuration parameter to sweep",
+    )
+    parser.add_argument("--min", type=float, help="Minimum value for the sweep")
+    parser.add_argument("--max", type=float, help="Maximum value for the sweep")
+    parser.add_argument("--steps", type=int, default=3, help="Number of sweep points")
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="cli_sweep",
+        help="Directory for sweep outputs",
+    )
+    args = parser.parse_args(argv)
+
+    if args.gui or not args.param or args.min is None or args.max is None:
+        launch()
+        return
+
+    cfg = DPFConfig()
+    values = np.linspace(args.min, args.max, args.steps)
+    results = run_parametric_sweep(cfg, args.param, values, output_dir=args.output)
+    metrics = compute_sweep_metrics(cfg, results, args.param)
+    plot_metric_overlay(
+        args.param, metrics, Path(args.output) / f"{args.param}_metrics.png"
+    )
+    if args.param == "initial_pressure":
+        plot_yield_vs_S_gv(metrics, Path(args.output) / "yield_vs_S.png")
+        best_val, best_metrics = max(
+            metrics.items(), key=lambda kv: kv[1].get("yield", 0.0)
+        )
+        opt_S = best_metrics.get("S", 0.0)
+        gv = 2.0
+        print(f"Optimal S = {opt_S:.2f} at P={best_val}")
+        if abs(opt_S - gv) > 1e-6:
+            print(f"Deviation from GV ({gv}) = {opt_S - gv:+.2f}")
+    else:
+        best_val = max(metrics, key=lambda v: metrics[v].get("yield", 0.0))
+        print(f"Optimal {args.param} = {best_val}")
+
+
+__all__ = ["launch", "main"]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()


### PR DESCRIPTION
## Summary
- extend Qt sweep GUI with explicit voltage/pressure range inputs and shock parameter visualization
- add command line interface for running param sweeps and plotting results

## Testing
- `pytest -q` *(fails: ImportError attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d72e7c0c832a9393130409bea5bd