### PR TITLE
Add phase overlay animations and student mode

### DIFF
--- a/examples/notebooks/sheath_animation.ipynb
+++ b/examples/notebooks/sheath_animation.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Sheath Evolution with Interactive Controls\n\n",
-    "This example demonstrates a simple sheath evolution visualization using Matplotlib and ipywidgets. Adjust the voltage and pressure sliders to explore how the sheath vector field responds. A basic Matplotlib animation shows the temporal evolution."
+    "This example demonstrates a simple sheath evolution visualization using Matplotlib and ipywidgets. Adjust the voltage and pressure sliders to explore how the sheath vector field responds. A basic animation now overlays a background field and annotates the canonical breakdown, axial rundown, pinch and disruption phases."
    ]
   },
   {
@@ -16,9 +16,9 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "from ipywidgets import interact, FloatSlider\n",
-    "from dpf2.visualization import animate_sheath\n\n",
+    "from dpf2.visualization import animate_discharge_phases\n\n",
     "def plot_sheath(voltage=1.0, pressure=0.1):\n",
-    "    anim = animate_sheath(voltage, pressure)\n",
+    "    anim = animate_discharge_phases(voltage, pressure)\n",
     "    return anim\n\n",
     "interact(plot_sheath,\n",
     "         voltage=FloatSlider(min=0.5, max=5.0, step=0.5, value=1.0, description='Voltage (kV)'),\n",
@@ -31,8 +31,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Matplotlib animation of sheath evolution\n",
-    "anim = animate_sheath(1.0, 0.1)\n",
+    "# Matplotlib animation of sheath evolution with phase annotations\n",
+    "anim = animate_discharge_phases(1.0, 0.1)\n",
     "anim\n"
    ]
   },
@@ -44,7 +44,7 @@
    "source": [
     "# Optional VTK visualization\n",
     "try:\n",
-    "    animate_sheath(1.0, 0.1, use_vtk=True)\n",
+    "    animate_discharge_phases(1.0, 0.1, use_vtk=True)\n",
     "except Exception as exc:\n",
     "    print('VTK not available:', exc)\n"
    ]

--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -43,6 +43,7 @@ from dpf2.optimization.param_sweep import (
     plot_metric_overlay,
 )
 from dpf2.gui.project_manager import ProjectManager
+from dpf2.gui import interactive
 
 from dpf2.device_profiles import DeviceProfiles
 
@@ -290,13 +291,22 @@ def build_config_wizard() -> DPFConfig:
     is_flag=True,
     help="Record a reproducibility manifest alongside outputs",
 )
+@click.option(
+    "--student",
+    is_flag=True,
+    help="Launch the simplified student GUI",
+)
 @click.pass_context
-def main(ctx: click.Context, notebook: bool, lab_mode: bool) -> None:
+def main(ctx: click.Context, notebook: bool, lab_mode: bool, student: bool) -> None:
     """Entry point for the DPF2 command line interface."""
     ctx.ensure_object(dict)
     ctx.obj["lab_mode"] = lab_mode
+    ctx.obj["student"] = student
     if notebook:
         _launch_notebook()
+        return
+    if student:
+        interactive.launch(simplified=True)
         return
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())

--- a/src/dpf2/gui/interactive.py
+++ b/src/dpf2/gui/interactive.py
@@ -35,7 +35,7 @@ def _ensure_dash() -> None:
         raise RuntimeError("dash is required for the interactive GUI")
 
 
-def launch(host: str = "127.0.0.1", port: int = 8050) -> None:
+def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = False) -> None:
     """Launch the Dash-based GUI.
 
     Parameters
@@ -208,10 +208,20 @@ def launch(host: str = "127.0.0.1", port: int = 8050) -> None:
             ),
             html.Button("Sweep Voltage", id="sweep_voltage"),
             html.Button("Sweep Pressure", id="sweep_pressure"),
-            html.Button("Overlay Runs", id="overlay_runs"),
-            html.Button("Pareto Search", id="pareto"),
-            html.Button("Export Metrics", id="export"),
-            html.Button("Export Overlay", id="export_overlay"),
+            html.Button(
+                "Overlay Runs", id="overlay_runs", style={} if not simplified else {"display": "none"}
+            ),
+            html.Button(
+                "Pareto Search", id="pareto", style={} if not simplified else {"display": "none"}
+            ),
+            html.Button(
+                "Export Metrics", id="export", style={} if not simplified else {"display": "none"}
+            ),
+            html.Button(
+                "Export Overlay",
+                id="export_overlay",
+                style={} if not simplified else {"display": "none"},
+            ),
             dcc.Graph(id="metrics_plot"),
         ]
     )

--- a/src/dpf2/visualization/__init__.py
+++ b/src/dpf2/visualization/__init__.py
@@ -6,8 +6,8 @@ weight so it can be used in examples and tests without requiring the
 full simulation stack.
 """
 
-from .sheath import animate_sheath
+from .sheath import animate_sheath, animate_discharge_phases
 from .widgets import sheath_widget
 
-__all__ = ["animate_sheath", "sheath_widget"]
+__all__ = ["animate_sheath", "animate_discharge_phases", "sheath_widget"]
 

--- a/src/dpf2/visualization/sheath.py
+++ b/src/dpf2/visualization/sheath.py
@@ -10,7 +10,7 @@ simulation dependencies.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import Callable, Optional, Sequence
 
 import numpy as np
 
@@ -78,6 +78,7 @@ def animate_sheath(
     *,
     use_vtk: bool = False,
     captions: Optional[Sequence[str]] = None,
+    overlay: Optional[Callable[[float], SheathField]] = None,
 ):
     """Animate a simple sheath evolution.
 
@@ -140,6 +141,12 @@ def animate_sheath(
     fig, ax = plt.subplots()
     field0 = _sheath_field(voltage, pressure, 0.0)
     quiver = ax.quiver(field0.x, field0.y, field0.u, field0.v)
+    overlay_quiver = None
+    if overlay is not None:
+        o0 = overlay(0.0)
+        overlay_quiver = ax.quiver(
+            o0.x, o0.y, o0.u, o0.v, color="C1", alpha=0.5
+        )
     ax.set_title("Sheath evolution")
     ax.set_xlabel("x")
     ax.set_ylabel("y")
@@ -148,15 +155,47 @@ def animate_sheath(
     def _frame(i: int):
         fld = _sheath_field(voltage, pressure, i * 0.1)
         quiver.set_UVC(fld.u, fld.v)
+        if overlay is not None and overlay_quiver is not None:
+            ov = overlay(i * 0.1)
+            overlay_quiver.set_UVC(ov.u, ov.v)
         if i < len(captions):
             caption_text.set_text(f"Step {i + 1}: {captions[i]}")
         else:
             caption_text.set_text(f"Step {i + 1}")
-        return quiver, caption_text
+        artists = [quiver, caption_text]
+        if overlay_quiver is not None:
+            artists.append(overlay_quiver)
+        return artists
 
     anim = FuncAnimation(fig, _frame, frames=40, interval=50, blit=True)
     return anim
 
 
-__all__ = ["animate_sheath"]
+def animate_discharge_phases(
+    voltage: float,
+    pressure: float,
+    *,
+    use_vtk: bool = False,
+) -> object:
+    """Animate the canonical DPF discharge phases.
+
+    This convenience wrapper overlays a uniform background field and
+    annotates the four typical phases of a dense plasma focus discharge:
+    breakdown, axial rundown, pinch and disruption.
+    """
+
+    def _overlay(_: float) -> SheathField:
+        grid = np.linspace(-1.0, 1.0, 20)
+        x, y = np.meshgrid(grid, grid)
+        u = 0.2 * np.ones_like(x)
+        v = np.zeros_like(y)
+        return SheathField(x, y, u, v)
+
+    phases = ["Breakdown", "Axial rundown", "Pinch", "Disruption"]
+    return animate_sheath(
+        voltage, pressure, use_vtk=use_vtk, captions=phases, overlay=_overlay
+    )
+
+
+__all__ = ["animate_sheath", "animate_discharge_phases"]
 

--- a/tests/test_cli_extra_commands.py
+++ b/tests/test_cli_extra_commands.py
@@ -87,3 +87,16 @@ def test_plot_run_cmd(tmp_path):
     ])
     assert result.exit_code == 0
     assert out_png.exists()
+
+
+def test_student_flag_invokes_gui(monkeypatch):
+    called: dict[str, bool] = {}
+
+    def fake_launch(*, simplified: bool = False):
+        called["simplified"] = simplified
+
+    monkeypatch.setattr(cli_main, "interactive", types.SimpleNamespace(launch=fake_launch))
+    runner = CliRunner()
+    result = runner.invoke(main, ["--student"])
+    assert result.exit_code == 0
+    assert called.get("simplified") is True

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -13,6 +13,13 @@ def test_animate_sheath_returns_animation():
     assert anim is not None
 
 
+def test_discharge_phases_returns_animation():
+    from dpf2.visualization import animate_discharge_phases
+
+    anim = animate_discharge_phases(1.0, 0.1)
+    assert anim is not None
+
+
 def test_sheath_widget_returns_widget():
     ipywidgets = pytest.importorskip("ipywidgets")
     from dpf2.visualization import sheath_widget


### PR DESCRIPTION
## Summary
- support vector-field overlays and discharge phase annotations in visualization helpers
- update notebook to display breakdown, rundown, pinch and disruption animations
- add student-friendly mode accessible via `--student` CLI flag and GUI toggle

## Testing
- `pytest tests/test_visualization.py tests/test_cli_extra_commands.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9d73054a0832ab69eeeabdfca2d2a