### PR TITLE
feat: add material-aware CAD parsing and geometry wizard options

### DIFF
--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -192,6 +192,26 @@ def build_config_wizard() -> DPFConfig:
         show_default=True,
     )
 
+    geometry_params: dict[str, Any] = {"type": preset, "length": electrode_length}
+    if preset == "tapered":
+        r_top = click.prompt(
+            "Top radius [m]",
+            type=click.FloatRange(1e-3, 1.0),
+            default=anode_radius,
+            show_default=True,
+        )
+        geometry_params.update({"r_base": cathode_radius, "r_top": r_top})
+    elif preset == "hollow":
+        r_inner = click.prompt(
+            "Inner bore radius [m]",
+            type=click.FloatRange(0.0, cathode_radius),
+            default=cathode_radius / 2,
+            show_default=True,
+        )
+        geometry_params.update({"r_outer": cathode_radius, "r_inner": r_inner})
+    else:
+        geometry_params.update({"r_outer": anode_radius, "r_inner": cathode_radius})
+
     # --- Fill gas ----------------------------------------------------
     click.echo("\nPlasma fill parameters:")
     gas_type = click.prompt(
@@ -276,6 +296,7 @@ def build_config_wizard() -> DPFConfig:
         }
     )
     cfg_dict.update(advanced_cfg)
+    cfg_dict["geometry"] = geometry_params
     return DPFConfig(**cfg_dict)
 
 

--- a/src/dpf2/core/config.py
+++ b/src/dpf2/core/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 from dataclasses import asdict
 from pathlib import Path
+from typing import Any, Dict
 
 from pydantic import ValidationError
 from pydantic.dataclasses import dataclass as pydantic_dataclass
@@ -28,6 +29,7 @@ class DPFConfig:
     nz_cells: int = 200
     cfl_number: float = 0.5
     end_time: float = 10e-6
+    geometry: Dict[str, Any] | None = None
 
     @classmethod
     def from_file(cls, path: str | Path) -> "DPFConfig":

--- a/src/dpf2/geometry/loaders.py
+++ b/src/dpf2/geometry/loaders.py
@@ -12,35 +12,49 @@ except Exception:  # pragma: no cover - meshio may not be installed
 
 
 def _parse_step_like(lines: List[str]) -> Dict[str, Any]:
-    """Parse a tiny subset of STEP/IGES style geometry.
+    """Parse a small subset of STEP/IGES style geometry.
 
-    The parser understands lines beginning with ``NODE`` to define points and
-    ``TRI`` to define triangular faces.  ``TRI`` statements may include an
-    optional fourth field specifying a material tag for the element.  Indices in
-    ``TRI`` statements are one-based to mimic common CAD conventions.
+    In addition to ``NODE`` and ``TRI`` statements, ``MAT``/``MATERIAL`` lines
+    may define a mapping from numeric identifiers to material names and
+    ``FEATURE`` lines can associate element indices with named groups.  ``TRI``
+    statements may include an optional fourth field specifying a material tag for
+    the element.  Indices in ``TRI`` and ``FEATURE`` statements are one-based to
+    mimic common CAD conventions.
     """
 
     nodes: List[List[float]] = []
     elements: List[List[int]] = []
     materials: List[Any] = []
+    features: Dict[str, List[int]] = {}
+    mat_map: Dict[str, Any] = {}
     for ln in lines:
         parts = ln.split()
         if not parts:
             continue
         tag, *rest = parts
-        if tag.upper() == "NODE" and len(rest) == 3:
+        up = tag.upper()
+        if up == "NODE" and len(rest) == 3:
             nodes.append([float(v) for v in rest])
-        elif tag.upper() == "TRI" and len(rest) in {3, 4}:
+        elif up == "TRI" and len(rest) in {3, 4}:
             elements.append([int(v) for v in rest[:3]])
             if len(rest) == 4:
                 mat = rest[3]
+                mat = mat_map.get(mat, mat)
                 try:
                     materials.append(int(mat))
                 except ValueError:
                     materials.append(mat)
+        elif up in {"MAT", "MATERIAL"} and len(rest) >= 2:
+            key = rest[0]
+            mat_map[key] = rest[1] if len(rest) == 2 else " ".join(rest[1:])
+        elif up == "FEATURE" and len(rest) >= 2:
+            name, idxs = rest[0], rest[1:]
+            features[name] = [int(v) for v in idxs]
     out: Dict[str, Any] = {"nodes": nodes, "elements": elements}
     if materials:
         out["materials"] = materials
+    if features:
+        out["features"] = features
     return out
 
 
@@ -87,6 +101,16 @@ def load_cad_geometry(path: Path) -> Dict[str, Any]:
                 result: Dict[str, Any] = {"nodes": m.points.tolist(), "elements": elements}
                 if materials:
                     result["materials"] = materials
+                if getattr(m, "cell_sets", None):
+                    feats: Dict[str, List[int]] = {}
+                    for name, sets in m.cell_sets.items():
+                        idxs: List[int] = []
+                        for block in sets:
+                            idxs.extend(block.tolist())
+                        if idxs:
+                            feats[name] = idxs
+                    if feats:
+                        result["features"] = feats
                 return result
             except Exception:
                 pass

--- a/tests/geometry/hollow.step
+++ b/tests/geometry/hollow.step
@@ -1,0 +1,11 @@
+MAT 1 steel
+MAT 2 air
+NODE 0 0 0
+NODE 1 0 0
+NODE 0 1 0
+NODE 1 1 0
+TRI 1 2 3 1
+TRI 2 3 4 2
+FEATURE outer 1 2
+FEATURE inner 2
+

--- a/tests/geometry/tapered.step
+++ b/tests/geometry/tapered.step
@@ -1,0 +1,11 @@
+MAT 1 copper
+MAT 2 vacuum
+NODE 0 0 0
+NODE 1 0 0
+NODE 0 1 0
+NODE 0 0 1
+TRI 1 2 3 1
+TRI 1 3 4 2
+FEATURE metal 1
+FEATURE gap 2
+

--- a/tests/geometry/test_geometry_loading.py
+++ b/tests/geometry/test_geometry_loading.py
@@ -45,3 +45,19 @@ def test_axisymmetric_profile_from_file():
     prof = AxisymmetricProfile.from_file(path)
     assert prof.r[-1] == 1.0
     assert prof.z[-1] == 2.0
+
+
+def test_load_tapered_cad():
+    path = Path(__file__).with_name("tapered.step")
+    data = load_cad_geometry(path)
+    assert data["materials"] == ["copper", "vacuum"]
+    assert data["features"]["metal"] == [1]
+    assert data["features"]["gap"] == [2]
+
+
+def test_load_hollow_cad():
+    path = Path(__file__).with_name("hollow.step")
+    data = load_cad_geometry(path)
+    assert data["materials"] == ["steel", "air"]
+    assert data["features"]["outer"] == [1, 2]
+    assert data["features"]["inner"] == [2]


### PR DESCRIPTION
## Summary
- parse material maps and feature groups from STEP/IGES files
- expose tapered/hollow geometry parameters in CLI wizard and config
- cover tapered and hollow CAD samples with tests

## Testing
- `pytest tests/geometry/test_geometry_loading.py tests/geometry/test_parameterized.py`
- `pytest tests/test_cli_simulate.py` *(fails: DummySim.run() got an unexpected keyword argument 'seeds')*


------
https://chatgpt.com/codex/tasks/task_e_68b9d7336854832ab9dbb07181e553c4