### PR TITLE
Add sweep utilities and stability diagnostics

### DIFF
--- a/src/dpf2/diagnostics/quality_dashboard.py
+++ b/src/dpf2/diagnostics/quality_dashboard.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 import json
 import logging
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +17,7 @@ class QualityDashboard:
     min_cfl: float | None = None
     min_lambda_D: float | None = None
     min_ppc: float | None = None
+    max_dt: float | None = None
     abort_on_violation: bool = False
     history: list[dict[str, float]] = field(default_factory=list)
 
@@ -37,6 +39,12 @@ class QualityDashboard:
             "cfl": cfl,
             "lambda_D": lambda_D,
         }
+
+        dt_violation = self.max_dt is not None and dt > self.max_dt
+        lambda_violation = lambda_D < cell_size
+        entry["dt_violation"] = dt_violation
+        entry["lambda_D_violation"] = lambda_violation
+
         self.history.append(entry)
         self.output_dir.mkdir(parents=True, exist_ok=True)
         with open(self.output_dir / "dashboard.json", "w", encoding="utf-8") as fh:
@@ -57,3 +65,68 @@ class QualityDashboard:
             _warn_or_abort(
                 f"Particles per cell below threshold: {ppc:g} < {self.min_ppc:g}"
             )
+        if dt_violation:
+            _warn_or_abort(
+                f"Time step above stability limit: {dt:g} > {self.max_dt:g}"
+            )
+        if lambda_violation:
+            _warn_or_abort(
+                f"Debye length under-resolved: {lambda_D:g} < {cell_size:g}"
+            )
+
+        self._update_plot()
+
+    # ------------------------------------------------------------------
+    def _update_plot(self) -> None:
+        """Render a simple plot of stability metrics."""
+        try:
+            import matplotlib
+            matplotlib.use("Agg")
+            import matplotlib.pyplot as plt
+        except Exception:  # pragma: no cover - matplotlib optional
+            return
+
+        if not self.history:
+            return
+
+        steps = [h["step"] for h in self.history]
+        dts = [h["dt"] for h in self.history]
+        lambdas = [h["lambda_D"] for h in self.history]
+        cells = [h["cell_size"] for h in self.history]
+
+        fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
+        ax1.plot(steps, dts, label="Δt")
+        if self.max_dt is not None:
+            ax1.axhspan(0, self.max_dt, color="lightgreen", alpha=0.3)
+            ax1.axhline(self.max_dt, color="red", linestyle="--", label="Δt limit")
+        ax1.set_ylabel("Δt")
+        ax1.legend()
+
+        ax2.plot(steps, lambdas, label="λ_D")
+        ax2.plot(steps, cells, label="cell size", linestyle="--")
+        arr_steps = np.array(steps)
+        arr_cells = np.array(cells)
+        arr_lambda = np.array(lambdas)
+        ax2.fill_between(
+            arr_steps,
+            arr_cells,
+            arr_lambda,
+            where=arr_lambda >= arr_cells,
+            color="lightgreen",
+            alpha=0.3,
+        )
+        ax2.fill_between(
+            arr_steps,
+            arr_lambda,
+            arr_cells,
+            where=arr_lambda < arr_cells,
+            color="red",
+            alpha=0.3,
+        )
+        ax2.set_ylabel("λ_D")
+        ax2.set_xlabel("step")
+        ax2.legend()
+
+        fig.tight_layout()
+        fig.savefig(self.output_dir / "stability.png")
+        plt.close(fig)

--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+import logging
 
 from pathlib import Path
 from typing import Dict, Sequence, Callable
@@ -43,6 +44,9 @@ from .pinch_models import (
 )
 
 from .physics.energy import EnergyTracker
+
+
+logger = logging.getLogger(__name__)
 
 
 __all__ = ["SimulationEngine", "SimulationResults", "EnsembleResults"]
@@ -468,4 +472,71 @@ class SimulationEngine:
             particles_per_cell=self.particles_per_cell,
 
         )
+
+    # ------------------------------------------------------------------
+    def sweep_ppc_grid(
+        self,
+        ppc_values: Sequence[int],
+        grid_sizes: Sequence[int],
+        *,
+        method: str = "analytical",
+        pinch_model: str = "analytic",
+    ) -> Dict[str, object]:
+        """Sweep particles-per-cell and grid resolution computing yield variance.
+
+        Parameters
+        ----------
+        ppc_values:
+            Iterable of particles per cell counts.
+        grid_sizes:
+            Iterable of grid resolutions (``nx = ny = nz``).
+        method, pinch_model:
+            Forwarded to :meth:`run` for each simulation.
+
+        Returns
+        -------
+        dict
+            Dictionary with ``yields`` and overall ``variance``.
+        """
+
+        yields: list[float] = []
+        for ppc in ppc_values:
+            for n in grid_sizes:
+                cfg = self.config.model_copy(deep=True)
+                if hasattr(cfg, "physics") and hasattr(cfg.physics, "particles_per_cell"):
+                    cfg.physics.particles_per_cell = ppc
+                if hasattr(cfg, "grid_resolution"):
+                    cfg.grid_resolution.nx = n
+                    cfg.grid_resolution.ny = n
+                    cfg.grid_resolution.nz = n
+
+                engine = SimulationEngine(
+                    cfg,
+                    comm=self.comm,
+                    num_threads=1,
+                    use_gpu=self.use_gpu,
+                )
+                res = engine.run(method=method, pinch_model=pinch_model)
+                yields.append(res.neutron_yield)
+                logger.info(
+                    "ppc=%s grid=%s yield=%g", ppc, n, res.neutron_yield
+                )
+
+        variance = float(np.var(yields)) if yields else 0.0
+        out_dir = Path("synthetic_diagnostics/quality")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        with open(out_dir / "ppc_grid_sweep.json", "w", encoding="utf-8") as fh:
+            json.dump(
+                {
+                    "ppc": list(ppc_values),
+                    "grid": list(grid_sizes),
+                    "yields": yields,
+                    "variance": variance,
+                },
+                fh,
+                indent=2,
+            )
+
+        logger.info("Yield variance across sweep: %g", variance)
+        return {"yields": yields, "variance": variance}
 

--- a/tests/test_quality_dashboard.py
+++ b/tests/test_quality_dashboard.py
@@ -15,3 +15,15 @@ def test_quality_dashboard_abort(tmp_path):
     q = QualityDashboard(output_dir=tmp_path, min_cfl=0.5, abort_on_violation=True)
     with pytest.raises(RuntimeError):
         q.log(step=1, dt=0.1, cell_size=1.0, ppc=10, cfl=0.1, lambda_D=1.0)
+
+
+def test_quality_dashboard_resolution_alerts(tmp_path, caplog):
+    q = QualityDashboard(output_dir=tmp_path, max_dt=0.05)
+    q.log(step=1, dt=0.1, cell_size=0.2, ppc=10, cfl=0.6, lambda_D=0.1)
+    assert "Time step above stability limit" in caplog.text
+    assert "Debye length under-resolved" in caplog.text
+    try:
+        import matplotlib  # noqa: F401
+    except Exception:  # pragma: no cover - optional dependency
+        pytest.skip("matplotlib not available")
+    assert (tmp_path / "stability.png").exists()


### PR DESCRIPTION
## Summary
- sweep particles-per-cell and grid resolution to compute yield variance
- add stability-band plotting and resolution alerts to quality dashboard
- log sweep results and quality alerts for CLI and GUI consumption

## Testing
- `pytest tests/test_quality_dashboard.py::test_quality_dashboard_logs_and_warns -q`
- `pytest tests/test_quality_dashboard.py::test_quality_dashboard_abort -q`
- `pytest tests/test_quality_dashboard.py::test_quality_dashboard_resolution_alerts -q` *(fails: Missing optional dependency `matplotlib`, test skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68b9d73611d4832aabcd28dcf205b097