### PR TITLE
feat: add threshold dashboard

### DIFF
--- a/src/dpf2/diagnostics/thresholds.py
+++ b/src/dpf2/diagnostics/thresholds.py
@@ -1,4 +1,8 @@
+import json
+import logging
 import math
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import List
 import warnings
 
@@ -69,4 +73,88 @@ __all__ = [
     "compute_debye_length",
     "plasma_inductance_circuit",
     "check_thresholds",
+    "ThresholdDashboard",
 ]
+
+
+@dataclass
+class ThresholdDashboard:
+    """Record threshold metrics and feed them to a JSON dashboard.
+
+    The dashboard stores per-step metrics and their colour-coded status for
+    easy consumption by a GUI or CLI monitor.  Thresholds are user-configurable
+    and violations can optionally abort the run.
+    """
+
+    output_dir: Path = Path("synthetic_diagnostics/thresholds")
+    max_cfl: float | None = None
+    min_lambda_D_dx: float | None = None
+    max_divB: float | None = None
+    abort_on_violation: bool = False
+    history: list[dict[str, float | str]] = field(default_factory=list)
+    logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
+
+    def _status(self, value: float, threshold: float | None, *, higher_is_better: bool) -> str:
+        if threshold is None:
+            return "grey"
+        if higher_is_better:
+            if value < threshold:
+                return "red"
+            if value < 1.2 * threshold:
+                return "yellow"
+            return "green"
+        if value > threshold:
+            return "red"
+        if value > 0.8 * threshold:
+            return "yellow"
+        return "green"
+
+    def log(
+        self,
+        *,
+        step: int,
+        cfl: float,
+        lambda_D: float,
+        cell_size: float,
+        divB: float,
+    ) -> dict[str, str]:
+        """Record metrics and warn/abort on threshold violations."""
+
+        lambda_ratio = lambda_D / cell_size
+        statuses = {
+            "cfl": self._status(cfl, self.max_cfl, higher_is_better=False),
+            "lambda_D_dx": self._status(
+                lambda_ratio, self.min_lambda_D_dx, higher_is_better=True
+            ),
+            "divB": self._status(divB, self.max_divB, higher_is_better=False),
+        }
+
+        entry = {
+            "step": step,
+            "cfl": cfl,
+            "cfl_status": statuses["cfl"],
+            "lambda_D_dx": lambda_ratio,
+            "lambda_D_dx_status": statuses["lambda_D_dx"],
+            "divB": divB,
+            "divB_status": statuses["divB"],
+        }
+        self.history.append(entry)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        with open(self.output_dir / "dashboard.json", "w", encoding="utf-8") as fh:
+            json.dump(self.history, fh, indent=2)
+
+        if statuses["cfl"] == "red" and self.max_cfl is not None:
+            self.logger.warning(
+                f"CFL above threshold: {cfl:g} > {self.max_cfl:g}"
+            )
+        if statuses["lambda_D_dx"] == "red" and self.min_lambda_D_dx is not None:
+            self.logger.warning(
+                f"lambda_D/dx below threshold: {lambda_ratio:g} < {self.min_lambda_D_dx:g}"
+            )
+        if statuses["divB"] == "red" and self.max_divB is not None:
+            self.logger.warning(
+                f"divB above threshold: {divB:g} > {self.max_divB:g}"
+            )
+        if self.abort_on_violation and any(s == "red" for s in statuses.values()):
+            raise RuntimeError("Threshold violation")
+        return statuses

--- a/tests/test_threshold_dashboard.py
+++ b/tests/test_threshold_dashboard.py
@@ -1,0 +1,33 @@
+import json
+import pytest
+from dpf2.diagnostics.thresholds import ThresholdDashboard
+
+
+def test_threshold_dashboard_logs_and_warns(tmp_path, caplog):
+    dash = ThresholdDashboard(
+        output_dir=tmp_path,
+        max_cfl=0.5,
+        min_lambda_D_dx=2.0,
+        max_divB=0.1,
+    )
+    statuses = dash.log(
+        step=1,
+        cfl=1.0,
+        lambda_D=0.5,
+        cell_size=1.0,
+        divB=0.2,
+    )
+    data = json.load(open(tmp_path / "dashboard.json"))
+    assert data[0]["step"] == 1
+    assert statuses["cfl"] == "red"
+    assert statuses["lambda_D_dx"] == "red"
+    assert statuses["divB"] == "red"
+    assert "CFL above threshold" in caplog.text
+    assert "lambda_D/dx below threshold" in caplog.text
+    assert "divB above threshold" in caplog.text
+
+
+def test_threshold_dashboard_abort(tmp_path):
+    dash = ThresholdDashboard(output_dir=tmp_path, max_cfl=0.5, abort_on_violation=True)
+    with pytest.raises(RuntimeError):
+        dash.log(step=1, cfl=1.0, lambda_D=1.0, cell_size=1.0, divB=0.0)


### PR DESCRIPTION
## Summary
- feed timestep quality metrics to a dashboard JSON with ThresholdDashboard
- log CFL, Debye length ratio and divB against user thresholds with color status and optional abort
- add tests for new dashboard features

## Testing
- `pytest tests/test_threshold_dashboard.py tests/test_thresholds.py tests/test_quality_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_68b9d73d7440832a901c415215cfbc40