### PR TITLE
Log and export plasma inductance series

### DIFF
--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -68,6 +68,8 @@ class SimulationResults:
     dt: float | None = None
     cell_size: float | None = None
     particles_per_cell: float | None = None
+    Lp_field: np.ndarray | None = None
+    Lp_circuit: np.ndarray | None = None
 
     def to_dict(self) -> Dict[str, object]:
         data = {
@@ -88,6 +90,10 @@ class SimulationResults:
             data["cell_size"] = self.cell_size
         if self.particles_per_cell is not None:
             data["particles_per_cell"] = self.particles_per_cell
+        if self.Lp_field is not None:
+            data["Lp_field"] = self.Lp_field.tolist()
+        if self.Lp_circuit is not None:
+            data["Lp_circuit"] = self.Lp_circuit.tolist()
         return data
 
 
@@ -262,6 +268,7 @@ class SimulationEngine:
         neutron_cb: Callable[[float, float], None] | None = None,
         xray_cb: Callable[[float, float], None] | None = None,
         progress_cb: Callable[[int, float, float, float], None] | None = None,
+        hdf5_path: str | None = None,
     ) -> SimulationResults:
         """Run the simulation and return aggregated results.
 
@@ -274,6 +281,9 @@ class SimulationEngine:
         neutron_cb, xray_cb:
             Callbacks receiving ``(time, value)`` for streaming neutron
             yield and X-ray emission respectively.
+        hdf5_path:
+            Optional path to an HDF5 file storing ``Lp_field`` and
+            ``Lp_circuit`` time series along with run metadata.
         """
         sc = self.config.simulation_control
         dt = sc.min_dt or 1e-9
@@ -349,6 +359,9 @@ class SimulationEngine:
         if xray_cb is not None:
             diag_list.append(XRayEmissionStreamer(xray_cb))
 
+        field_lp: list[float] = [0.0]
+        circuit_lp: list[float] = [0.0]
+
         while circuit.time[-1] < t_end:
             state = CouplingState(current=current, voltage=voltage)
             if plasma_solver is not None:
@@ -383,6 +396,21 @@ class SimulationEngine:
             else:
                 updated = circuit.step(state, 0.0, dt, energy_tracker=tracker)
 
+            # Log plasma inductance from solver and inferred from circuit
+            field_lp.append(state.Lp)
+            dIdt = (updated.current - current) / dt if dt != 0 else 0.0
+            if dIdt != 0.0:
+                num = (
+                    circuit.circuit.V0
+                    - circuit.circuit.R * current
+                    - voltage
+                    - state.emf
+                )
+                inferred = num / dIdt - circuit.circuit.L
+            else:
+                inferred = circuit_lp[-1]
+            circuit_lp.append(float(inferred))
+
             if self.comm is not None and (self.comm.size > 1):  # pragma: no cover - MPI
                 updated = self.comm.bcast(updated, root=0)
 
@@ -409,6 +437,8 @@ class SimulationEngine:
         t = self._to_numpy(t_xp)
         current_arr = self._to_numpy(current_xp)
         voltage_arr = self._to_numpy(voltage_xp)
+        field_lp_arr = np.asarray(field_lp)
+        circuit_lp_arr = np.asarray(circuit_lp)
 
         if pinch_model == "analytic":
             plasma: PinchModelBase = AnalyticPinchModel()
@@ -453,6 +483,25 @@ class SimulationEngine:
                     f"Energy non-conservation {rel_err:.2%} exceeds tolerance {energy_tol:.2%}"
                 )
 
+        if hdf5_path is not None:
+            try:
+                import h5py  # type: ignore
+            except Exception as exc:  # pragma: no cover - optional dependency
+                raise RuntimeError("h5py is required for HDF5 output") from exc
+            import json
+            from .io.data_writer import DataWriter
+
+            meta = {
+                "config": self.config.model_dump(),
+                "config_hash": DataWriter._hash_config(self.config.model_dump()),
+                "git_commit": DataWriter._git_commit(),
+            }
+            with h5py.File(hdf5_path, "w") as h5:
+                h5.create_dataset("time", data=t)
+                h5.create_dataset("Lp_field", data=field_lp_arr)
+                h5.create_dataset("Lp_circuit", data=circuit_lp_arr)
+                h5.create_dataset("metadata", data=json.dumps(meta))
+
         return SimulationResults(
             time=pres.time,
             current=current_arr,
@@ -466,6 +515,7 @@ class SimulationEngine:
             dt=self.dt,
             cell_size=self.cell_size,
             particles_per_cell=self.particles_per_cell,
-
+            Lp_field=field_lp_arr,
+            Lp_circuit=circuit_lp_arr,
         )
 

--- a/src/dpf2/web/plots.py
+++ b/src/dpf2/web/plots.py
@@ -55,4 +55,30 @@ def plot_vector_field_overlay(
     return path
 
 
-__all__ = ["plot_current_voltage", "plot_vector_field_overlay"]
+def plot_plasma_inductance_comparison(
+    t: Sequence[float],
+    field_lp: Sequence[float],
+    circuit_lp: Sequence[float],
+    path: str | Path,
+) -> Path:
+    """Plot field-derived and circuit-derived plasma inductance."""
+
+    fig, ax = plt.subplots()
+    ax.plot(t, field_lp, label="field-derived")
+    ax.plot(t, circuit_lp, label="circuit-derived", linestyle="--")
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("Lp (H)")
+    ax.legend()
+    fig.tight_layout()
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(path)
+    plt.close(fig)
+    return path
+
+
+__all__ = [
+    "plot_current_voltage",
+    "plot_vector_field_overlay",
+    "plot_plasma_inductance_comparison",
+]


### PR DESCRIPTION
## Summary
- track field- and circuit-derived plasma inductance in `SimulationEngine.run`
- optionally export inductance time series to HDF5 with run metadata
- add plotting helper to compare plasma inductance methods

## Testing
- `pytest tests/test_plasma_inductance_coupling.py::test_engine_computes_plasma_inductance -q`
- `pytest tests/test_energy_tracker.py -q` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'parallel_settings')*
- `pytest tests/test_simulation_engine.py::test_engine_runs -q` *(terminated: exceeded time budget)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d73ac3a8832ab53bcf36a677bf52