### PR TITLE
Add tooltip help text for frontend components

### DIFF
--- a/web/frontend/src/help.json
+++ b/web/frontend/src/help.json
@@ -1,0 +1,22 @@
+{
+  "login": {
+    "username": "Name used to sign into the control panel.",
+    "token": "Authentication token supplied by the DPF server."
+  },
+  "config": {
+    "hardware": "Select which hardware profile to load for the simulation.",
+    "export": "Download the current configuration as a JSON file."
+  },
+  "sliders": {
+    "gain": "Change the amplifier gain to tune the device response.",
+    "threshold": "Minimum signal level before a count is registered."
+  },
+  "quickstart": {
+    "intro": "Launch a demo project with sample data and defaults.",
+    "docs": "Open the online documentation for deeper guidance."
+  },
+  "project": {
+    "save": "Persist the project to your browser storage for later editing.",
+    "share": "Generate a shareable URL with the current project state."
+  }
+}


### PR DESCRIPTION
## Summary
- add `help.json` with tooltip text for login, config, sliders, quickstart, and project sections so components can import contextual help

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9da8dc0dc832a8d4721c71388c3aa