### PR TITLE
Refactor ProjectManager tooltips to use help.json

### DIFF
--- a/web/frontend/src/ProjectManager.jsx
+++ b/web/frontend/src/ProjectManager.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import YieldPressureOverlay from './YieldPressureOverlay.jsx';
 import EfficiencyCurveOverlay from './EfficiencyCurveOverlay.jsx';
 import GeometryPresets from './GeometryPresets.jsx';
+import help from './help.json';
 
 export default function ProjectManager({ projects = [] }) {
   const [configSets, setConfigSets] = useState(projects);
@@ -152,7 +153,7 @@ export default function ProjectManager({ projects = [] }) {
               <button
                 type="button"
                 onClick={() => exportConfig(p)}
-                title="Download this configuration for sharing"
+                title={help.project.export}
               >
                 Export
               </button>
@@ -169,9 +170,9 @@ export default function ProjectManager({ projects = [] }) {
         <input
           type="file"
           onChange={handleFile}
-          title="Optional CAD file for custom geometry"
+          title={help.project.geometryFile}
         />
-        <button type="submit" title="Upload the configuration set">Add</button>
+        <button type="submit" title={help.project.newSet}>Add</button>
         <details>
           <summary>What is this?</summary>
           Drag a geometry preset into the drop zone or upload a CAD file to
@@ -187,7 +188,7 @@ export default function ProjectManager({ projects = [] }) {
           type="file"
           accept="application/json"
           onChange={importConfig}
-          title="Load a configuration set from JSON"
+          title={help.project.import}
         />
         <details>
           <summary>What is this?</summary>

--- a/web/frontend/src/help.json
+++ b/web/frontend/src/help.json
@@ -1,0 +1,8 @@
+{
+  "project": {
+    "export": "Download this configuration for sharing",
+    "newSet": "Upload the configuration set",
+    "geometryFile": "Optional CAD file for custom geometry",
+    "import": "Load a configuration set from JSON"
+  }
+}


### PR DESCRIPTION
## Summary
- centralize ProjectManager tooltips in `help.json`
- replace hard-coded titles with `help.project.*` strings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `pytest` *(fails: ImportError: attempted relative import with no known parent package and other ImportErrors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9da90bd20832aafa7356e90239235