### PR TITLE
feat: add directional spectra and ToF correlation

### DIFF
--- a/src/dpf2/diagnostics/neutron_spectra.py
+++ b/src/dpf2/diagnostics/neutron_spectra.py
@@ -195,6 +195,44 @@ def time_resolved_spectra(
     return spectra
 
 
+def directional_time_resolved_spectra(
+    layout: DetectorLayout,
+    energies: Sequence[float],
+    flux: Sequence[float],
+    time_bins: Sequence[float],
+    base_yield: float = 1.0,
+    anisotropy: float = 0.0,
+) -> Dict[str, List[float]]:
+    """Return forward, radial and backward time-resolved spectra.
+
+    This convenience wrapper combines :func:`time_resolved_spectra` with
+    directional aggregation so that the resulting histograms are grouped by
+    detector orientation.  The returned dictionary contains keys
+    ``"forward"``, ``"radial"`` and ``"backward"`` with values describing the
+    counts in each time bin for detectors in that group.
+    """
+
+    per_det = time_resolved_spectra(
+        layout, energies, flux, time_bins, base_yield=base_yield, anisotropy=anisotropy
+    )
+    grouped: Dict[str, List[float]] = {
+        "forward": [0.0] * (len(time_bins) - 1),
+        "radial": [0.0] * (len(time_bins) - 1),
+        "backward": [0.0] * (len(time_bins) - 1),
+    }
+    for det in layout.detectors:
+        ang = det.angle_deg % 360.0
+        if ang <= 45.0 or ang >= 315.0:
+            group = "forward"
+        elif 135.0 <= ang <= 225.0:
+            group = "backward"
+        else:
+            group = "radial"
+        hist = per_det.get(det.name, [0.0] * (len(time_bins) - 1))
+        grouped[group] = [g + h for g, h in zip(grouped[group], hist)]
+    return grouped
+
+
 def forward_radial_backward_counts(
     layout: DetectorLayout, spectra: Dict[str, Sequence[float]]
 ) -> Dict[str, float]:
@@ -211,6 +249,23 @@ def forward_radial_backward_counts(
         else:
             totals["radial"] += count
     return totals
+
+
+def directional_counts_from_geometry(
+    geometry: str | Path,
+    energies: Sequence[float],
+    flux: Sequence[float],
+    time_bins: Sequence[float],
+    base_yield: float = 1.0,
+    anisotropy: float = 0.0,
+) -> Dict[str, float]:
+    """Load a geometry file and return forward/radial/backward totals."""
+
+    layout = load_detector_layout(geometry)
+    spectra = time_resolved_spectra(
+        layout, energies, flux, time_bins, base_yield=base_yield, anisotropy=anisotropy
+    )
+    return forward_radial_backward_counts(layout, spectra)
 
 
 def anisotropy_ratios(counts: Dict[str, float]) -> Dict[str, float]:
@@ -260,6 +315,41 @@ def cross_correlate_tof_with_circuit(
     return lags, list(corr), max_lag
 
 
+def correlate_tof_peaks_with_circuit_iv(
+    time_bins: Sequence[float],
+    counts: Sequence[float],
+    circuit_time: Sequence[float],
+    current: Sequence[float],
+    voltage: Sequence[float],
+) -> Tuple[List[Tuple[float, float]], List[float], List[float], float]:
+    """Correlate ToF peaks with circuit power derived from ``I`` and ``V``.
+
+    The instantaneous power trace (``I * V``) is interpolated onto the
+    midpoints of the ToF histogram and cross-correlated with the counts.  In
+    addition, local maxima in the ToF spectrum are paired with the
+    corresponding circuit power to provide a direct comparison of peak
+    features.
+    """
+
+    power = np.asarray(current) * np.asarray(voltage)
+    lags, corr, max_lag = cross_correlate_tof_with_circuit(
+        time_bins, counts, circuit_time, power
+    )
+    if len(time_bins) < 2:
+        raise ValueError("time_bins must have at least two entries")
+    mid = 0.5 * (np.asarray(time_bins[:-1]) + np.asarray(time_bins[1:]))
+    counts_arr = np.asarray(counts)
+    peak_idx = [
+        i
+        for i in range(1, len(counts_arr) - 1)
+        if counts_arr[i] > counts_arr[i - 1] and counts_arr[i] > counts_arr[i + 1]
+    ]
+    peak_times = [float(mid[i]) for i in peak_idx]
+    peak_power = np.interp(peak_times, np.asarray(circuit_time), power)
+    peaks = [(t, float(p)) for t, p in zip(peak_times, peak_power)]
+    return peaks, lags, corr, max_lag
+
+
 __all__ = [
     "Detector",
     "DetectorLayout",
@@ -268,7 +358,10 @@ __all__ = [
     "anisotropy_metric",
     "load_detector_layout",
     "time_resolved_spectra",
+    "directional_time_resolved_spectra",
     "forward_radial_backward_counts",
+    "directional_counts_from_geometry",
     "anisotropy_ratios",
     "cross_correlate_tof_with_circuit",
+    "correlate_tof_peaks_with_circuit_iv",
 ]

--- a/tests/test_neutron_spectra.py
+++ b/tests/test_neutron_spectra.py
@@ -6,8 +6,11 @@ from dpf2.diagnostics.neutron_spectra import (
     load_detector_layout,
     time_resolved_spectra,
     forward_radial_backward_counts,
+    directional_time_resolved_spectra,
+    directional_counts_from_geometry,
     anisotropy_ratios,
     cross_correlate_tof_with_circuit,
+    correlate_tof_peaks_with_circuit_iv,
 )
 
 
@@ -56,6 +59,34 @@ def test_time_resolved_geometry_and_anisotropy(tmp_path):
     assert ratios["forward_backward"] == 1.0
 
 
+def test_directional_helpers(tmp_path):
+    import json
+
+    layout_data = {
+        "distance_m": 1.0,
+        "detectors": [
+            {"angle_deg": 0.0, "name": "f"},
+            {"angle_deg": 90.0, "name": "r"},
+            {"angle_deg": 180.0, "name": "b"},
+        ],
+    }
+    layout_path = tmp_path / "layout.json"
+    layout_path.write_text(json.dumps(layout_data))
+    layout = load_detector_layout(layout_path)
+    energies = [1.0, 2.0]
+    flux = [1.0, 1.0]
+    time_bins = [0.0, 1.0, 2.0]
+    grouped = directional_time_resolved_spectra(layout, energies, flux, time_bins)
+    assert set(grouped.keys()) == {"forward", "radial", "backward"}
+    assert grouped["forward"] == grouped["radial"] == grouped["backward"]
+    counts = directional_counts_from_geometry(
+        layout_path, energies, flux, time_bins
+    )
+    assert counts["forward"] == sum(grouped["forward"])
+    assert counts["radial"] == sum(grouped["radial"])
+    assert counts["backward"] == sum(grouped["backward"])
+
+
 def test_cross_correlation():
     time_bins = [0.0, 1.0, 2.0, 3.0]
     counts = [0.0, 1.0, 0.0]
@@ -65,4 +96,17 @@ def test_cross_correlation():
         time_bins, counts, circuit_time, circuit_signal
     )
     assert len(lags) == len(corr) == 2 * len(counts) - 1
+    assert max_lag == 0.0
+
+
+def test_correlate_tof_peaks_with_circuit_iv():
+    time_bins = [0.0, 1.0, 2.0, 3.0]
+    counts = [0.0, 1.0, 0.0]
+    circuit_time = [0.0, 1.0, 2.0, 3.0]
+    current = [0.0, 1.0, 0.0, 0.0]
+    voltage = [0.0, 2.0, 0.0, 0.0]
+    peaks, lags, corr, max_lag = correlate_tof_peaks_with_circuit_iv(
+        time_bins, counts, circuit_time, current, voltage
+    )
+    assert peaks == [(1.5, 1.0)]
     assert max_lag == 0.0


### PR DESCRIPTION
## Summary
- add directional time-resolved neutron spectra and geometry helpers
- correlate ToF peaks with circuit I-V features

## Testing
- `pytest tests/test_neutron_spectra.py -q`
- ⚠️ `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b9dfbd46dc832aa99184c9c79b2473