### PR TITLE
Warn on missing material tables

### DIFF
--- a/src/dpf2/circuit/distributed.py
+++ b/src/dpf2/circuit/distributed.py
@@ -27,6 +27,7 @@ from typing import Iterable, Sequence, List, Any
 import numpy as np
 import math
 import cmath
+import warnings
 
 from dpf2.core.bases import PlasmaSolverBase
 
@@ -114,15 +115,29 @@ class TransmissionLineSegment:
                     try:
                         self.R_per_m = get_resistivity(self.material)
                     except KeyError:
-                        pass
+                        warnings.warn(
+                            f"No resistivity data for material '{self.material}', using default {self.R_per_m}",
+                            stacklevel=2,
+                        )
                 if self.skin_effect_coeff == 0.0:
                     try:
                         self.skin_effect_coeff = get_skin_effect_coeff(self.material)
                     except KeyError:
-                        pass
+                        warnings.warn(
+                            f"No skin-effect data for material '{self.material}', using default {self.skin_effect_coeff}",
+                            stacklevel=2,
+                        )
             except Exception:
-                # Material tables are optional; fail silently if unavailable
-                pass
+                if self.R_per_m == 0.0:
+                    warnings.warn(
+                        f"Material tables unavailable; using default resistivity {self.R_per_m} for '{self.material}'",
+                        stacklevel=2,
+                    )
+                if self.skin_effect_coeff == 0.0:
+                    warnings.warn(
+                        f"Material tables unavailable; using default skin-effect coefficient {self.skin_effect_coeff} for '{self.material}'",
+                        stacklevel=2,
+                    )
 
     def delay(self) -> float:
         """Return propagation delay for this segment in seconds."""

--- a/tests/test_transmission_line_material_warnings.py
+++ b/tests/test_transmission_line_material_warnings.py
@@ -1,0 +1,57 @@
+import sys
+import types
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_distributed():
+    """Load the distributed circuit module with minimal stubs."""
+
+    pkg = types.ModuleType("dpf2")
+    pkg.__path__ = []
+
+    core_pkg = types.ModuleType("dpf2.core")
+    bases_pkg = types.ModuleType("dpf2.core.bases")
+
+    class PlasmaSolverBase:
+        pass
+
+    bases_pkg.PlasmaSolverBase = PlasmaSolverBase
+    core_pkg.bases = bases_pkg
+
+    sys.modules["dpf2"] = pkg
+    sys.modules["dpf2.core"] = core_pkg
+    sys.modules["dpf2.core.bases"] = bases_pkg
+
+    module_path = Path(__file__).resolve().parent.parent / "src/dpf2/circuit/distributed.py"
+    spec = importlib.util.spec_from_file_location("dpf2.circuit.distributed", module_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["dpf2.circuit.distributed"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_warns_when_material_tables_missing():
+    mod = _load_distributed()
+    TransmissionLineSegment = mod.TransmissionLineSegment
+
+    with pytest.warns(UserWarning) as record:
+        TransmissionLineSegment(0, 1, 1.0, 0.0, 0.0, 0.0, material="copper")
+
+    # Ensure warnings include the material name and default values
+    assert record
+    for w in record:
+        msg = str(w.message)
+        assert "copper" in msg
+        assert "0.0" in msg
+
+    for name in [
+        "dpf2.circuit.distributed",
+        "dpf2.core.bases",
+        "dpf2.core",
+        "dpf2",
+    ]:
+        sys.modules.pop(name, None)
+


### PR DESCRIPTION
## Summary
- warn when material table data is missing for transmission line segments
- add tests ensuring default material values emit warnings

## Testing
- `pytest tests/test_transmission_line_material_warnings.py`
- `pytest tests/test_distributed_circuit.py::test_switch_triggering_edge_cases -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9dfc07304832a949543c2b8cae31d