### PR TITLE
Log GUI import failures with installation hints

### DIFF
--- a/src/dpf2/gui/__init__.py
+++ b/src/dpf2/gui/__init__.py
@@ -1,6 +1,10 @@
 """GUI utilities for DPF2."""
 
+import logging
+
 from .project_manager import ProjectManager
+
+logger = logging.getLogger(__name__)
 
 __all__ = ["ProjectManager"]
 
@@ -8,16 +12,25 @@ try:  # pragma: no cover - optional flask dependency
     from .dashboard import launch
     __all__.append("launch")
 except Exception:  # pragma: no cover - simplify when Flask missing
-    pass
+    logger.warning(
+        "Flask is required for the dashboard; install with `pip install flask`.",
+        exc_info=True,
+    )
 
 try:  # pragma: no cover - optional dash dependency
     from .interactive import launch as launch_dash
     __all__.append("launch_dash")
 except Exception:  # pragma: no cover - simplify when dash missing
-    pass
+    logger.warning(
+        "Dash is required for the interactive GUI; install with `pip install dash`.",
+        exc_info=True,
+    )
 
 try:  # pragma: no cover - optional PyQt dependency
     from .qt_sweep import launch as launch_qt
     __all__.append("launch_qt")
 except Exception:  # pragma: no cover - simplify when PyQt missing
-    pass
+    logger.warning(
+        "PyQt5 is required for the Qt sweep GUI; install with `pip install PyQt5`.",
+        exc_info=True,
+    )

--- a/tests/test_gui_import_warnings.py
+++ b/tests/test_gui_import_warnings.py
@@ -1,0 +1,57 @@
+import importlib
+import sys
+import logging
+
+import pytest
+
+
+def _import_gui(monkeypatch, missing):
+    """Reload ``dpf2.gui`` with ``missing`` module unavailable."""
+
+    class Blocker:
+        def find_spec(self, fullname, path, target=None):  # pragma: no cover - hook
+            if fullname == missing:
+                raise ModuleNotFoundError(fullname)
+            return None
+
+    blocker = Blocker()
+    sys.meta_path.insert(0, blocker)
+    sys.modules.pop("dpf2.gui", None)
+    sys.modules.pop(missing, None)
+    try:
+        return importlib.import_module("dpf2.gui")
+    finally:  # pragma: no cover - ensure cleanup
+        sys.meta_path.remove(blocker)
+
+
+def _assert_warning(monkeypatch, caplog, missing, expected):
+    with caplog.at_level(logging.WARNING):
+        _import_gui(monkeypatch, missing)
+    assert expected in caplog.text
+
+
+def test_dashboard_missing_logs_warning(monkeypatch, caplog):
+    _assert_warning(
+        monkeypatch,
+        caplog,
+        "dpf2.gui.dashboard",
+        "pip install flask",
+    )
+
+
+def test_interactive_missing_logs_warning(monkeypatch, caplog):
+    _assert_warning(
+        monkeypatch,
+        caplog,
+        "dpf2.gui.interactive",
+        "pip install dash",
+    )
+
+
+def test_qt_missing_logs_warning(monkeypatch, caplog):
+    _assert_warning(
+        monkeypatch,
+        caplog,
+        "dpf2.gui.qt_sweep",
+        "pip install PyQt5",
+    )


### PR DESCRIPTION
## Summary
- Warn when optional GUI dependencies (Flask, Dash, PyQt5) are missing and include pip install hints
- Test logging behavior by simulating missing GUI modules

## Testing
- `pytest tests/test_gui_import_warnings.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9dfc7c7d8832aac949903e8f5e0b7