### PR TITLE
Add GUI help text, scene I/O, and tutorials

### DIFF
--- a/examples/education/README.md
+++ b/examples/education/README.md
@@ -1,0 +1,6 @@
+# Educational Tutorials
+
+This directory hosts short, guided examples for new users.
+
+* `gui_tooltips.md` – explore context-sensitive help in the web interface.
+* `scene_export_import.md` – save and restore analysis scenes with `ProjectManager`.

--- a/examples/education/gui_tooltips.md
+++ b/examples/education/gui_tooltips.md
@@ -1,0 +1,12 @@
+# Exploring GUI Tooltips
+
+The interactive dashboard includes "What's this?" links next to most controls.
+The text is loaded from `help_text.json` and explains how each parameter affects a simulation.
+
+1. Launch the interface:
+
+```bash
+python -m dpf2.gui.interactive
+```
+
+2. Hover the pointer over a "What's this?" link to display the associated help text.

--- a/examples/education/scene_export_import.md
+++ b/examples/education/scene_export_import.md
@@ -1,0 +1,15 @@
+# Scene Export and Import
+
+`ProjectManager` can persist its state to a JSON file and restore it later.
+
+```python
+from dpf2.gui import ProjectManager
+pm = ProjectManager(project="demo")
+pm.metrics["run"] = {0.5: {"yield": 1.0}}
+pm.params["run"] = "initial_pressure"
+pm.export_scene("demo_scene.json")
+
+pm2 = ProjectManager()
+pm2.import_scene("demo_scene.json")
+print(pm2.metrics)
+```

--- a/src/dpf2/gui/help_text.json
+++ b/src/dpf2/gui/help_text.json
@@ -1,0 +1,10 @@
+{
+  "breakdown": "Breakdown: initial ionization of the gas producing plasma.",
+  "rundown": "Rundown: plasma accelerates and compresses toward the axis.",
+  "pinch": "Pinch: plasma compression leading to fusion-relevant conditions.",
+  "anode_radius": "Inner radius of the anode electrode in centimeters.",
+  "cathode_radius": "Inner radius of the cathode electrode in centimeters.",
+  "electrode_length": "Length of the electrodes in centimeters.",
+  "charging_voltage": "Capacitor bank voltage applied to the electrodes in volts.",
+  "initial_pressure": "Initial fill gas pressure in torr."
+}

--- a/src/dpf2/gui/interactive.py
+++ b/src/dpf2/gui/interactive.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List
+import json
 
 from .project_manager import ProjectManager
 from ..core.config import DPFConfig
@@ -26,6 +27,13 @@ try:  # pragma: no cover - optional dependency
     from plotly.subplots import make_subplots
 except Exception:  # pragma: no cover - allow import without dash
     Dash = None  # type: ignore[misc]
+
+
+HELP_TEXT_PATH = Path(__file__).with_name("help_text.json")
+try:  # pragma: no cover - helper file may not exist
+    HELP_TEXT = json.loads(HELP_TEXT_PATH.read_text())
+except Exception:  # pragma: no cover - fallback when file missing
+    HELP_TEXT = {}
 
 
 def _ensure_dash() -> None:
@@ -52,9 +60,10 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
     presets = DeviceProfiles.with_defaults().devices
     preset_options = [{"label": name, "value": name} for name in presets.keys()]
 
-    def _info_span(text: str) -> html.Span:
-        """Return a small "what's this?" tooltip span."""
+    def _info_span(key: str) -> html.Span:
+        """Return a small "what's this?" tooltip span from JSON help text."""
 
+        text = HELP_TEXT.get(key, "")
         return html.Span(
             "What's this?",
             title=text,
@@ -80,9 +89,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
                             html.P(
                                 [
                                     "Initiate plasma by ionizing the fill gas.",
-                                    _info_span(
-                                        "Breakdown: initial ionization of the gas producing plasma.",
-                                    ),
+                                    _info_span("breakdown"),
                                 ]
                             )
                         ],
@@ -94,9 +101,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
                             html.P(
                                 [
                                     "Current drives the plasma sheath toward the axis.",
-                                    _info_span(
-                                        "Rundown: plasma accelerates and compresses toward the axis.",
-                                    ),
+                                    _info_span("rundown"),
                                 ]
                             )
                         ],
@@ -108,9 +113,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
                             html.P(
                                 [
                                     "Final compression yields peak conditions and neutrons.",
-                                    _info_span(
-                                        "Pinch: plasma compression leading to fusion-relevant conditions.",
-                                    ),
+                                    _info_span("pinch"),
                                 ]
                             )
                         ],
@@ -129,9 +132,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
                             html.Label(
                                 [
                                     "Anode radius (cm)",
-                                    _info_span(
-                                        "Inner radius of the anode electrode in centimeters.",
-                                    ),
+                                    _info_span("anode_radius"),
                                 ]
                             ),
                             dcc.Input(id="anode_radius", type="number"),
@@ -142,9 +143,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
                             html.Label(
                                 [
                                     "Cathode radius (cm)",
-                                    _info_span(
-                                        "Inner radius of the cathode electrode in centimeters.",
-                                    ),
+                                    _info_span("cathode_radius"),
                                 ]
                             ),
                             dcc.Input(id="cathode_radius", type="number"),
@@ -155,9 +154,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
                             html.Label(
                                 [
                                     "Electrode length (cm)",
-                                    _info_span(
-                                        "Length of the electrodes in centimeters.",
-                                    ),
+                                    _info_span("electrode_length"),
                                 ]
                             ),
                             dcc.Input(id="electrode_length", type="number"),
@@ -171,9 +168,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
                     html.Label(
                         [
                             "Charging Voltage",
-                            _info_span(
-                                "Capacitor bank voltage applied to the electrodes in volts.",
-                            ),
+                            _info_span("charging_voltage"),
                         ]
                     ),
                     dcc.Slider(
@@ -191,9 +186,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
                     html.Label(
                         [
                             "Fill Pressure",
-                            _info_span(
-                                "Initial fill gas pressure in torr.",
-                            ),
+                            _info_span("initial_pressure"),
                         ]
                     ),
                     dcc.Slider(

--- a/src/dpf2/gui/project_manager.py
+++ b/src/dpf2/gui/project_manager.py
@@ -10,6 +10,7 @@ metrics from multiple sweeps which can then be overlaid or written to disk.
 
 from pathlib import Path
 import csv
+import json
 from typing import Callable, Dict, Iterable, List, Tuple
 
 import numpy as np
@@ -349,6 +350,30 @@ class ProjectManager:
                         ]
                     )
         return path
+
+    def export_scene(self, path: str | Path) -> Path:
+        """Export current metrics and parameters to ``path`` in JSON format."""
+
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "project": self.project,
+            "metrics": self.metrics,
+            "params": self.params,
+        }
+        path.write_text(json.dumps(data, indent=2))
+        return path
+
+    def import_scene(self, path: str | Path) -> None:
+        """Populate the manager from a JSON file produced by ``export_scene``."""
+
+        data = json.loads(Path(path).read_text())
+        self.project = data.get("project", self.project)
+        metrics: Dict[str, Dict[float, Dict[str, float]]] = {}
+        for label, vals in data.get("metrics", {}).items():
+            metrics[label] = {float(k): v for k, v in vals.items()}
+        self.metrics = metrics
+        self.params = data.get("params", {})
 
 
 __all__ = ["ProjectManager"]

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -18,3 +18,17 @@ def test_export_and_overlay(tmp_path):
     pytest.importorskip("matplotlib")
     out_plot = pm.overlay_yield_pressure(tmp_path / "yield_pressure.png")
     assert out_plot.exists()
+
+
+def test_scene_roundtrip(tmp_path):
+    pm = ProjectManager(project="demo")
+    pm.metrics["run"] = {0.5: {"yield": 1.0}}
+    pm.params["run"] = "initial_pressure"
+    scene = pm.export_scene(tmp_path / "scene.json")
+    assert scene.exists()
+
+    new_pm = ProjectManager()
+    new_pm.import_scene(scene)
+    assert new_pm.project == "demo"
+    assert new_pm.metrics == {"run": {0.5: {"yield": 1.0}}}
+    assert new_pm.params == {"run": "initial_pressure"}


### PR DESCRIPTION
## Summary
- Load GUI tooltips from `help_text.json` and use keys for context help
- Provide ProjectManager scene export/import to JSON
- Add educational tutorials under `examples/education`

## Testing
- `pytest tests/test_project_manager.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9dfc9961c832a80d82c3d7e5fd44c