### PR TITLE
Add neutron yield partitioning and diagnostics utilities

### DIFF
--- a/src/dpf2/diagnostics/neutron.py
+++ b/src/dpf2/diagnostics/neutron.py
@@ -1,0 +1,57 @@
+"""Neutron diagnostic utilities for angular spectra and time-of-flight."""
+
+from __future__ import annotations
+
+from typing import Sequence, Callable, Dict, List
+
+from ..neutron_yield_model import IonBeamEDF, compute_directional_spectrum
+from .neutron_yield import compute_beam_target_yield
+
+
+def angular_spectrum(
+    ion_edf: IonBeamEDF,
+    cross_section: Callable[[float], float],
+    angles: Sequence[float],
+    energy_bins: Sequence[float],
+) -> List[List[float]]:
+    """Return per-angle energy spectra using :func:`compute_directional_spectrum`."""
+
+    return compute_directional_spectrum(ion_edf, cross_section, angles, energy_bins)
+
+
+def synthesize_tof(
+    ion_edf: IonBeamEDF,
+    cross_section: Callable[[float], float],
+    angles: Sequence[float],
+    distance: float,
+    time_bins: Sequence[float],
+) -> Dict[str, List[float]]:
+    """Generate synthetic time-of-flight histograms for a detector layout."""
+
+    _yields, tofs = compute_beam_target_yield(
+        ion_edf, cross_section, angles, distance, time_bins
+    )
+    return {f"detector_{i}": hist for i, hist in enumerate(tofs)}
+
+
+def compute_anisotropy(
+    yields: Sequence[float], metric: str = "max_min_over_mean"
+) -> float:
+    """Compute anisotropy metric from per-angle yields."""
+
+    vals = [float(v) for v in yields]
+    if not vals:
+        return 0.0
+    if metric == "forward_backward_ratio":
+        half = len(vals) // 2
+        forward = sum(vals[:half])
+        backward = sum(vals[half:])
+        return forward / backward if backward > 0 else 0.0
+    mean = sum(vals) / len(vals)
+    if mean == 0:
+        return 0.0
+    return (max(vals) - min(vals)) / mean
+
+
+__all__ = ["angular_spectrum", "synthesize_tof", "compute_anisotropy"]
+

--- a/src/dpf2/fusion.py
+++ b/src/dpf2/fusion.py
@@ -13,6 +13,7 @@ __all__ = [
     "dd_channel_fractions",
     "dd_beam_target_angular_spectrum",
     "dd_directional_yields",
+    "dd_yield_components",
 ]
 
 
@@ -150,4 +151,45 @@ def dd_directional_yields(
         else:
             radial += v
     return {"forward": forward, "radial": radial, "backward": backward}
+
+
+def dd_yield_components(
+    T_keV: float,
+    n_thermal: float,
+    n_beam: float | None,
+    beam_energy_keV: float | None,
+    volume: float,
+    duration: float,
+) -> dict[str, tuple[float, float]]:
+    """Return D-D neutron yields with simple Poisson uncertainties.
+
+    The underlying reaction rates are provided by :func:`dd_fusion_rates`.  The
+    yields are obtained by multiplying the rates by ``volume`` and ``duration``.
+    Uncertainties are estimated assuming Poisson statistics, i.e. ``sqrt(N)``.
+
+    Parameters
+    ----------
+    T_keV, n_thermal, n_beam, beam_energy_keV
+        Inputs forwarded to :func:`dd_fusion_rates`.
+    volume, duration
+        Plasma volume (m^3) and integration time (s).
+
+    Returns
+    -------
+    dict
+        Mapping of ``"thermonuclear"``, ``"beam_target"`` and ``"total"`` to
+        ``(yield, uncertainty)`` tuples.
+    """
+
+    thermo_rate, beam_rate = dd_fusion_rates(
+        T_keV, n_thermal, n_beam, beam_energy_keV
+    )
+    th_yield = thermo_rate * volume * duration
+    bt_yield = beam_rate * volume * duration
+    total = th_yield + bt_yield
+    return {
+        "thermonuclear": (th_yield, math.sqrt(th_yield) if th_yield > 0 else 0.0),
+        "beam_target": (bt_yield, math.sqrt(bt_yield) if bt_yield > 0 else 0.0),
+        "total": (total, math.sqrt(total) if total > 0 else 0.0),
+    }
 

--- a/src/dpf2/neutron_yield_model.py
+++ b/src/dpf2/neutron_yield_model.py
@@ -4,7 +4,19 @@ import hashlib
 import json
 from pathlib import Path
 from bisect import bisect_right
-from typing import Any, ClassVar, Dict, List, Optional, Tuple, Literal, Callable, Sequence, Protocol
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Literal,
+    Callable,
+    Sequence,
+    Protocol,
+)
+import math
 
 from pydantic import BaseModel, ConfigDict, Field
 from .utils.pydantic_compat import model_validator as _model_validator
@@ -25,6 +37,7 @@ def from_camel_case(string: str) -> str:
         else:
             out.append(ch)
     return "".join(out)
+
 from .units_settings import UnitsSettings
 
 
@@ -88,6 +101,10 @@ class NeutronYieldModel(ConfigSectionBase):
     apply_detector_response_function: bool = False
     detector_response_file: Optional[Path] = None
     detector_response_normalization: Optional[Literal["none", "area", "peak", "custom"]] = "none"
+    detector_layout: Optional[Dict[str, float]] = None
+    anisotropy_metric: Literal[
+        "max_min_over_mean", "forward_backward_ratio"
+    ] = "max_min_over_mean"
 
     # ------------------------------------------------------------------
     @classmethod
@@ -308,8 +325,30 @@ def compute_directional_spectrum(
     return spectra
 
 
+def partition_yield(
+    thermonuclear_rate: Sequence[float],
+    beam_target_rate: Sequence[float],
+    dt: float,
+) -> Dict[str, Tuple[float, float]]:
+    """Integrate rate histories and return yields with Poisson uncertainties."""
+
+    if dt <= 0:
+        raise ValueError("dt must be positive")
+    if len(thermonuclear_rate) != len(beam_target_rate):
+        raise ValueError("rate histories must have the same length")
+    th = sum(float(v) for v in thermonuclear_rate) * dt
+    bt = sum(float(v) for v in beam_target_rate) * dt
+    total = th + bt
+    return {
+        "thermonuclear": (th, math.sqrt(th) if th > 0 else 0.0),
+        "beam_target": (bt, math.sqrt(bt) if bt > 0 else 0.0),
+        "total": (total, math.sqrt(total) if total > 0 else 0.0),
+    }
+
+
 __all__ = [
     "NeutronYieldModel",
     "TabulatedIonEDF",
     "compute_directional_spectrum",
+    "partition_yield",
 ]

--- a/tests/diagnostics/test_neutron_yield.py
+++ b/tests/diagnostics/test_neutron_yield.py
@@ -1,0 +1,30 @@
+import math
+
+from dpf2.neutron_yield_model import partition_yield
+from dpf2.fusion import dd_yield_components
+
+
+def test_partition_yield_components():
+    thermo = [2.0, 2.0, 2.0]
+    beam = [1.0, 1.0, 1.0]
+    res = partition_yield(thermo, beam, dt=0.5)
+    th, th_u = res["thermonuclear"]
+    bt, bt_u = res["beam_target"]
+    tot, tot_u = res["total"]
+    assert math.isclose(th + bt, tot)
+    assert math.isclose(th_u, math.sqrt(th))
+    assert math.isclose(bt_u, math.sqrt(bt))
+    assert math.isclose(tot_u, math.sqrt(tot))
+
+
+def test_dd_yield_components_zero_beam():
+    res = dd_yield_components(
+        T_keV=10.0,
+        n_thermal=1e20,
+        n_beam=0.0,
+        beam_energy_keV=50.0,
+        volume=1.0,
+        duration=1.0,
+    )
+    assert res["beam_target"][0] == 0.0
+    assert math.isclose(res["total"][0], res["thermonuclear"][0])


### PR DESCRIPTION
## Summary
- compute D-D yield components with uncertainties
- add detector layout configuration and yield partitioning helper
- provide neutron angular spectrum, TOF synthesis, and anisotropy utilities
- test thermonuclear vs beam-target channel partitioning

## Testing
- `pytest tests/diagnostics/test_neutron_yield.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e452c070832a81328b2a9223b1d6