### PR TITLE
Add dataset provenance and hashing utilities

### DIFF
--- a/src/dpf2/chemistry/__init__.py
+++ b/src/dpf2/chemistry/__init__.py
@@ -15,6 +15,7 @@ import numpy as np
 
 from ..core_schema import IonizationModel
 from .kinetics import RateTable, RateEquations
+from .metadata import DatasetMetadata, load_adas_metadata, load_lxcat_metadata
 
 __all__ = [
     "ChemistryModel",
@@ -23,6 +24,9 @@ __all__ = [
     "create_chemistry",
     "RateTable",
     "RateEquations",
+    "DatasetMetadata",
+    "load_adas_metadata",
+    "load_lxcat_metadata",
 ]
 
 

--- a/src/dpf2/chemistry/metadata.py
+++ b/src/dpf2/chemistry/metadata.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Metadata loaders for chemistry datasets.
+
+These helpers validate that required provenance information is present in
+sidecar JSON metadata files distributed with ADAS or LXCat tables.
+"""
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Mapping
+
+
+@dataclass
+class DatasetMetadata:
+    """Minimal provenance for a tabulated data set."""
+
+    doi: str
+    version: str
+
+
+def _load(path: Path | str) -> DatasetMetadata:
+    data = json.loads(Path(path).read_text())
+    doi = data.get("doi")
+    version = data.get("version")
+    if not doi or not version:
+        raise ValueError("metadata requires 'doi' and 'version'")
+    return DatasetMetadata(doi=str(doi), version=str(version))
+
+
+def load_adas_metadata(meta_path: Path | str) -> DatasetMetadata:
+    """Load metadata for an ADAS table."""
+
+    return _load(meta_path)
+
+
+def load_lxcat_metadata(meta_path: Path | str) -> DatasetMetadata:
+    """Load metadata for an LXCat cross-section table."""
+
+    return _load(meta_path)
+
+
+__all__ = ["DatasetMetadata", "load_adas_metadata", "load_lxcat_metadata"]

--- a/src/dpf2/cli/lab.py
+++ b/src/dpf2/cli/lab.py
@@ -50,6 +50,7 @@ def write_manifest(
     ppc: int | None = None,
     seeds: Mapping[str, int] | None = None,
     warnings: Sequence[str] | None = None,
+    datasets: Mapping[str, Mapping[str, object]] | None = None,
 ) -> Path:
     """Write a JSON manifest capturing reproducibility metadata.
 
@@ -67,6 +68,10 @@ def write_manifest(
     seeds:
         Mapping of RNG seeds (e.g. {"python": int, "numpy": int}). If not
         provided, the current RNG states are sampled.
+    datasets:
+        Optional mapping of dataset names to metadata dictionaries containing
+        ``path``, ``doi`` and ``version``. Hashes of these datasets are stored
+        in the manifest.
     """
     out = Path(output_dir)
     out.mkdir(parents=True, exist_ok=True)
@@ -99,6 +104,9 @@ def write_manifest(
             manifest["config"] = {k: str(v) for k, v in config.items()}
     if warnings:
         manifest["warnings"] = list(warnings)
+    if datasets:
+        from ..io.manifest import capture_dataset_metadata
+        manifest["datasets"] = capture_dataset_metadata(datasets)
 
     path = out / RUN_MANIFEST_FILENAME
     path.write_text(json.dumps(manifest, indent=2))

--- a/src/dpf2/cli/validate_datasets.py
+++ b/src/dpf2/cli/validate_datasets.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Utility CLI to compare alternative datasets and show impact bands."""
+
+import argparse
+from pathlib import Path
+
+from ..io.manifest import capture_dataset_metadata
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compare two datasets")
+    parser.add_argument("dataset", type=Path, help="Primary dataset")
+    parser.add_argument(
+        "--swap",
+        type=Path,
+        required=True,
+        help="Alternate dataset to compare against",
+    )
+    args = parser.parse_args(argv)
+
+    info = capture_dataset_metadata(
+        {
+            "base": {"path": args.dataset, "doi": "n/a", "version": "n/a"},
+            "swap": {"path": args.swap, "doi": "n/a", "version": "n/a"},
+        }
+    )
+    base_hash = info["base"]["hash"]
+    swap_hash = info["swap"]["hash"]
+    print(f"Base hash: {base_hash}")
+    print(f"Swap hash: {swap_hash}")
+    if base_hash != swap_hash:
+        print("Datasets differ - impact band may be significant.")
+    else:
+        print("Datasets identical.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/src/dpf2/io/__init__.py
+++ b/src/dpf2/io/__init__.py
@@ -3,6 +3,7 @@ from .structured import StructuredOutputWriter
 from .restart import RestartManager
 from .datasets import load_dataset_manifest
 from .json_io import export_config, import_config
+from .manifest import capture_dataset_metadata
 
 __all__ = [
     "DataWriter",
@@ -11,4 +12,5 @@ __all__ = [
     "load_dataset_manifest",
     "export_config",
     "import_config",
+    "capture_dataset_metadata",
 ]

--- a/src/dpf2/io/manifest.py
+++ b/src/dpf2/io/manifest.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+"""Helpers for recording dataset provenance in run manifests."""
+
+from pathlib import Path
+import hashlib
+from typing import Mapping
+
+
+def _hash_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with Path(path).open("rb") as fh:
+        for chunk in iter(lambda: fh.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def capture_dataset_metadata(
+    datasets: Mapping[str, Mapping[str, object]]
+) -> dict[str, dict[str, str]]:
+    """Compute hashes and attach DOI/version for referenced datasets.
+
+    Parameters
+    ----------
+    datasets:
+        Mapping of dataset name to a mapping containing ``path``, ``doi`` and
+        ``version`` entries.
+    """
+
+    result: dict[str, dict[str, str]] = {}
+    for name, info in datasets.items():
+        path = info.get("path")
+        doi = info.get("doi")
+        version = info.get("version")
+        if path is None or doi is None or version is None:
+            raise ValueError("dataset metadata requires 'path', 'doi' and 'version'")
+        h = _hash_file(Path(path))
+        result[name] = {"hash": h, "doi": str(doi), "version": str(version)}
+    return result
+
+
+__all__ = ["capture_dataset_metadata"]

--- a/src/dpf2/radiation/__init__.py
+++ b/src/dpf2/radiation/__init__.py
@@ -11,6 +11,7 @@ from ..core_schema import RadiationModel, RadiationTransportModel
 from .multigroup import MultiGroupDiffusion
 from .power import bremsstrahlung_power, line_radiation_power
 from .xray_emission_model import cr_line_emission
+from .metadata import DatasetMetadata, load_chianti_metadata
 
 __all__ = [
     "RadiationBase",
@@ -21,6 +22,8 @@ __all__ = [
     "bremsstrahlung_power",
     "line_radiation_power",
     "cr_line_emission",
+    "DatasetMetadata",
+    "load_chianti_metadata",
 ]
 
 

--- a/src/dpf2/radiation/metadata.py
+++ b/src/dpf2/radiation/metadata.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Metadata loaders for radiation data sets."""
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+
+
+@dataclass
+class DatasetMetadata:
+    """Minimal provenance for a radiation table."""
+
+    doi: str
+    version: str
+
+
+def load_chianti_metadata(meta_path: Path | str) -> DatasetMetadata:
+    """Load metadata for a CHIANTI table."""
+
+    data = json.loads(Path(meta_path).read_text())
+    doi = data.get("doi")
+    version = data.get("version")
+    if not doi or not version:
+        raise ValueError("metadata requires 'doi' and 'version'")
+    return DatasetMetadata(doi=str(doi), version=str(version))
+
+
+__all__ = ["DatasetMetadata", "load_chianti_metadata"]

--- a/tests/io/test_manifest.py
+++ b/tests/io/test_manifest.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dpf2.cli.lab import write_manifest
+
+
+def test_manifest_records_dataset_doi(tmp_path):
+    data_file = tmp_path / "table.dat"
+    data_file.write_text("example")
+    manifest_path = write_manifest(
+        tmp_path,
+        datasets={
+            "ADAS": {
+                "path": data_file,
+                "doi": "10.1234/example",
+                "version": "1.0",
+            }
+        },
+    )
+    manifest = json.loads(manifest_path.read_text())
+    assert "datasets" in manifest
+    meta = manifest["datasets"]["ADAS"]
+    assert meta["doi"] == "10.1234/example"
+    assert meta["version"] == "1.0"
+    assert len(meta["hash"]) == 64
+
+
+def test_manifest_dataset_requires_doi_and_version(tmp_path):
+    data_file = tmp_path / "table.dat"
+    data_file.write_text("x")
+    with pytest.raises(ValueError):
+        write_manifest(tmp_path, datasets={"ADAS": {"path": data_file, "doi": "10"}})


### PR DESCRIPTION
## Summary
- add ADAS, LXCat, and CHIANTI metadata loaders requiring DOI and version fields
- record dataset hashes and metadata in run manifests and expose a dataset comparison CLI
- test manifest DOI capture and missing metadata handling

## Testing
- `pytest tests/io/test_manifest.py tests/test_manifest_metadata.py tests/test_manifest_warnings.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e45d0150832a946d946cf925977e