### PR TITLE
Add detector response processing with gating and dispersion

### DIFF
--- a/data/detectors/iv_probe.json
+++ b/data/detectors/iv_probe.json
@@ -1,0 +1,5 @@
+{
+  "gating": {"start": 0.0, "end": 10.0},
+  "dead_time": 0.0,
+  "dispersion": [0.5, 0.5]
+}

--- a/data/detectors/neutron_detector.json
+++ b/data/detectors/neutron_detector.json
@@ -1,0 +1,5 @@
+{
+  "gating": {"start": 1.0, "end": 3.0},
+  "dead_time": 0.0,
+  "dispersion": [1.0]
+}

--- a/data/detectors/xray_detector.json
+++ b/data/detectors/xray_detector.json
@@ -1,0 +1,5 @@
+{
+  "gating": {"start": 0.0, "end": 10.0},
+  "dead_time": 0.25,
+  "dispersion": [1.0]
+}

--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -142,6 +142,10 @@ class SXRModel(BaseModel):
 
     name: str
     position: Tuple[float, float, float]
+    response_file: Path | None = None
+    gate: Tuple[float, float] | None = Field(None, metadata={"units": "ns"})
+    dead_time_ns: float | None = Field(None, metadata={"units": "ns"})
+    dispersion: List[float] | None = None
 
 
 class TOFModel(BaseModel):
@@ -149,6 +153,10 @@ class TOFModel(BaseModel):
 
     name: str
     position: Tuple[float, float, float]
+    response_file: Path | None = None
+    gate: Tuple[float, float] | None = Field(None, metadata={"units": "ns"})
+    dead_time_ns: float | None = Field(None, metadata={"units": "ns"})
+    dispersion: List[float] | None = None
 
 
 class OutputField(str, Enum):

--- a/src/dpf2/diagnostics/iv_probes.py
+++ b/src/dpf2/diagnostics/iv_probes.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence, List, Dict, Any
+import json
+
+
+def load_response(path: str | Path) -> Dict[str, Any]:
+    """Load an I-V probe response description from *path*.
+
+    The file shares the same JSON structure as other detector responses.
+    """
+    with open(Path(path), "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def apply_response(
+    times: Sequence[float],
+    signal: Sequence[float],
+    response: Dict[str, Any],
+) -> List[float]:
+    """Apply the configured probe response effects to the input *signal*."""
+    if len(times) != len(signal):
+        raise ValueError("times and signal must be the same length")
+
+    vals = [float(v) for v in signal]
+    t = [float(x) for x in times]
+
+    gate = response.get("gating")
+    if gate:
+        start = float(gate.get("start", -float("inf")))
+        end = float(gate.get("end", float("inf")))
+        vals = [v if start <= ti <= end else 0.0 for ti, v in zip(t, vals)]
+
+    dead_time = response.get("dead_time")
+    if dead_time is not None:
+        dt = float(dead_time)
+        last = -float("inf")
+        processed: List[float] = []
+        for ti, v in zip(t, vals):
+            if v != 0.0 and ti - last < dt:
+                processed.append(0.0)
+            else:
+                processed.append(v)
+                if v != 0.0:
+                    last = ti
+        vals = processed
+
+    dispersion = response.get("dispersion")
+    if dispersion:
+        kernel = [float(k) for k in dispersion]
+        conv = [0.0 for _ in vals]
+        for i, v in enumerate(vals):
+            for j, k in enumerate(kernel):
+                idx = i + j
+                if idx < len(conv):
+                    conv[idx] += v * k
+        vals = conv
+
+    return vals
+
+__all__ = ["load_response", "apply_response"]

--- a/src/dpf2/diagnostics/neutron.py
+++ b/src/dpf2/diagnostics/neutron.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence, List, Dict, Any
+import json
+
+
+def load_response(path: str | Path) -> Dict[str, Any]:
+    """Load a neutron detector response description from *path*.
+
+    The file is expected to contain JSON with optional keys ``gating``,
+    ``dead_time`` and ``dispersion``. ``gating`` should be a mapping with
+    ``start`` and ``end`` times.  ``dispersion`` is interpreted as a kernel for
+    a simple discrete convolution applied after gating and dead time.
+    """
+    with open(Path(path), "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def apply_response(
+    times: Sequence[float],
+    signal: Sequence[float],
+    response: Dict[str, Any],
+) -> List[float]:
+    """Apply detector response effects to *signal* sampled at *times*.
+
+    Gating removes samples outside the time window.  Dead time suppresses
+    subsequent non-zero samples that occur within the specified interval after
+    a non-zero sample.  Dispersion convolves the signal with the provided
+    kernel.
+    """
+    if len(times) != len(signal):
+        raise ValueError("times and signal must be the same length")
+
+    vals = [float(v) for v in signal]
+    t = [float(x) for x in times]
+
+    gate = response.get("gating")
+    if gate:
+        start = float(gate.get("start", -float("inf")))
+        end = float(gate.get("end", float("inf")))
+        vals = [v if start <= ti <= end else 0.0 for ti, v in zip(t, vals)]
+
+    dead_time = response.get("dead_time")
+    if dead_time is not None:
+        dt = float(dead_time)
+        last = -float("inf")
+        processed: List[float] = []
+        for ti, v in zip(t, vals):
+            if v != 0.0 and ti - last < dt:
+                processed.append(0.0)
+            else:
+                processed.append(v)
+                if v != 0.0:
+                    last = ti
+        vals = processed
+
+    dispersion = response.get("dispersion")
+    if dispersion:
+        kernel = [float(k) for k in dispersion]
+        klen = len(kernel)
+        conv = [0.0 for _ in vals]
+        for i, v in enumerate(vals):
+            for j, k in enumerate(kernel):
+                idx = i + j
+                if idx < len(conv):
+                    conv[idx] += v * k
+        vals = conv
+
+    return vals
+
+__all__ = ["load_response", "apply_response"]

--- a/src/dpf2/diagnostics/xray.py
+++ b/src/dpf2/diagnostics/xray.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence, List, Dict, Any
+import json
+
+
+def load_response(path: str | Path) -> Dict[str, Any]:
+    """Load an X-ray detector response description from *path*.
+
+    The JSON format mirrors that used for neutron detectors.
+    """
+    with open(Path(path), "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def apply_response(
+    times: Sequence[float],
+    signal: Sequence[float],
+    response: Dict[str, Any],
+) -> List[float]:
+    """Apply detector response effects to *signal* sampled at *times*.
+
+    This delegates to the same implementation as the neutron module.
+    """
+    if len(times) != len(signal):
+        raise ValueError("times and signal must be the same length")
+
+    vals = [float(v) for v in signal]
+    t = [float(x) for x in times]
+
+    gate = response.get("gating")
+    if gate:
+        start = float(gate.get("start", -float("inf")))
+        end = float(gate.get("end", float("inf")))
+        vals = [v if start <= ti <= end else 0.0 for ti, v in zip(t, vals)]
+
+    dead_time = response.get("dead_time")
+    if dead_time is not None:
+        dt = float(dead_time)
+        last = -float("inf")
+        processed: List[float] = []
+        for ti, v in zip(t, vals):
+            if v != 0.0 and ti - last < dt:
+                processed.append(0.0)
+            else:
+                processed.append(v)
+                if v != 0.0:
+                    last = ti
+        vals = processed
+
+    dispersion = response.get("dispersion")
+    if dispersion:
+        kernel = [float(k) for k in dispersion]
+        conv = [0.0 for _ in vals]
+        for i, v in enumerate(vals):
+            for j, k in enumerate(kernel):
+                idx = i + j
+                if idx < len(conv):
+                    conv[idx] += v * k
+        vals = conv
+
+    return vals
+
+__all__ = ["load_response", "apply_response"]

--- a/tests/diagnostics/test_detector_responses.py
+++ b/tests/diagnostics/test_detector_responses.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from dpf2.diagnostics import neutron, xray, iv_probes
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "data" / "detectors"
+
+
+def test_neutron_gating_only():
+    resp = neutron.load_response(DATA_DIR / "neutron_detector.json")
+    times = [0, 1, 2, 3, 4]
+    signal = [1, 1, 1, 1, 1]
+    processed = neutron.apply_response(times, signal, resp)
+    assert processed == [0.0, 1.0, 1.0, 1.0, 0.0]
+
+
+def test_xray_dead_time():
+    resp = xray.load_response(DATA_DIR / "xray_detector.json")
+    times = [0.0, 0.1, 0.2, 0.5]
+    signal = [1, 1, 1, 1]
+    processed = xray.apply_response(times, signal, resp)
+    assert processed == [1.0, 0.0, 0.0, 1.0]
+
+
+def test_iv_probe_dispersion():
+    resp = iv_probes.load_response(DATA_DIR / "iv_probe.json")
+    times = [0.0, 1.0, 2.0, 3.0]
+    signal = [1.0, 0.0, 0.0, 1.0]
+    processed = iv_probes.apply_response(times, signal, resp)
+    assert processed == [0.5, 0.5, 0.0, 0.5]


### PR DESCRIPTION
## Summary
- add neutron/xray/I-V probe modules capable of loading response files and applying gating, dead-time and dispersion
- update diagnostics configuration models to accept response parameters
- include example detector response files and tests

## Testing
- `PYTHONPATH=src pytest tests/diagnostics/test_detector_responses.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e471aafc832a8b141e503d17fff3