### PR TITLE
Add sputtering model and impurity-aware radiation

### DIFF
--- a/src/dpf2/device_profiles.py
+++ b/src/dpf2/device_profiles.py
@@ -47,6 +47,8 @@ class DeviceEntry(BaseModel):
     cathode_radius_cm: float = Field(..., alias="cathodeRadiusCm", ge=0.0)
     anode_length_cm: float = Field(..., alias="anodeLengthCm", ge=0.0)
     insulator_length_cm: float = Field(..., alias="insulatorLengthCm", ge=0.0)
+    anode_material: Optional[MaterialRef] = Field(None, alias="anodeMaterial")
+    cathode_material: Optional[MaterialRef] = Field(None, alias="cathodeMaterial")
     insulator_material: Optional[MaterialRef] = Field(None, alias="insulatorMaterial")
     insulator_sleeve: Optional[InsulatorSleeve] = Field(
         None, alias="insulatorSleeve"

--- a/src/dpf2/materials/__init__.py
+++ b/src/dpf2/materials/__init__.py
@@ -7,6 +7,12 @@ from .library import MaterialLibrary
 
 from .state import ComponentMaterialState
 from .mdm import MaterialDamageModel
+from .sputtering import (
+    Species,
+    sigmund_yield,
+    yamamura_yield,
+    impurity_source_terms,
+)
 from .tables import (
     RESISTIVITY_TABLE,
     SKIN_EFFECT_TABLE,
@@ -20,6 +26,10 @@ __all__ = [
     "MaterialLibrary",
     "ComponentMaterialState",
     "MaterialDamageModel",
+    "Species",
+    "sigmund_yield",
+    "yamamura_yield",
+    "impurity_source_terms",
     "RESISTIVITY_TABLE",
     "SKIN_EFFECT_TABLE",
     "get_resistivity",

--- a/src/dpf2/materials/sputtering.py
+++ b/src/dpf2/materials/sputtering.py
@@ -1,0 +1,149 @@
+"""Sputtering models and impurity source terms.
+
+This module provides minimal implementations of the Sigmund and
+Yamamura sputtering yield formulas.  The expressions are simplified so
+that the unit tests can exercise basic scaling behaviour without
+requiring extensive atomic data tables.  The routines operate on
+fundamental atomic properties (charge ``Z`` and mass in amu) and return
+species yields and impurity source terms suitable for coupling with the
+light–weight material damage model used in the test suite.
+
+The Sigmund model describes the sputtering yield for normally incident
+ions while the Yamamura model adds an empirical angular dependence.
+Both models expose a similar interface and can be used to construct
+impurity source terms from an incident ion flux.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import cos, exp, radians
+from typing import Dict
+
+__all__ = [
+    "Species",
+    "sigmund_yield",
+    "yamamura_yield",
+    "impurity_source_terms",
+]
+
+
+@dataclass(frozen=True)
+class Species:
+    """Basic atomic description used by the sputtering helpers."""
+
+    name: str
+    Z: int  # atomic number
+    mass_u: float  # atomic mass in atomic mass units
+
+
+# ----------------------------------------------------------------------------
+# Yield models
+# ----------------------------------------------------------------------------
+
+def sigmund_yield(
+    projectile: Species,
+    target: Species,
+    energy_eV: float,
+    *,
+    U0_eV: float = 4.0,
+) -> float:
+    """Return the Sigmund sputtering yield for normal incidence.
+
+    Parameters
+    ----------
+    projectile, target:
+        :class:`Species` instances describing the incoming ion and the
+        target material.
+    energy_eV:
+        Incident ion energy in electron volts.
+    U0_eV:
+        Effective surface binding energy of the target in eV.  The
+        default ``4.0`` eV roughly corresponds to typical metallic
+        surfaces and keeps the test values simple.
+
+    Notes
+    -----
+    The implementation follows the structure of Sigmund's theory but
+    collapses the stopping cross section to a simple charge dependent
+    factor.  The numerical coefficients are chosen so that the results
+    are within the expected order of magnitude for common materials
+    while remaining computationally lightweight.
+    """
+
+    if energy_eV <= 0 or U0_eV <= 0:
+        return 0.0
+
+    mu = projectile.mass_u / target.mass_u
+    alpha = 0.08 + 0.164 * mu + 0.014 * mu * mu
+    Sn = (projectile.Z * target.Z) / (
+        projectile.Z ** (2.0 / 3.0) + target.Z ** (2.0 / 3.0)
+    )
+
+    # Threshold energy for sputtering [eV]
+    Eth = U0_eV * (1.0 + mu) ** 2 / (4.0 * mu)
+    if energy_eV < Eth:
+        return 0.0
+
+    return 0.042 * alpha * Sn * (1.0 - Eth / energy_eV)
+
+
+def yamamura_yield(
+    projectile: Species,
+    target: Species,
+    energy_eV: float,
+    angle_deg: float,
+    *,
+    U0_eV: float = 4.0,
+    f: float = 2.5,
+) -> float:
+    """Return the Yamamura sputtering yield for an arbitrary angle.
+
+    The function first evaluates :func:`sigmund_yield` and then applies
+    the Yamamura angular correction.  ``angle_deg`` is the angle between
+    the incident direction and the surface normal.
+    """
+
+    Y0 = sigmund_yield(projectile, target, energy_eV, U0_eV=U0_eV)
+    if Y0 <= 0:
+        return 0.0
+
+    theta = radians(angle_deg)
+    c = cos(theta)
+    if c <= 0.0:
+        return 0.0
+
+    return Y0 * (c ** -f) * exp(-f * (1.0 - c))
+
+
+# ----------------------------------------------------------------------------
+# Impurity source terms
+# ----------------------------------------------------------------------------
+
+def impurity_source_terms(
+    ion_flux: float,
+    yield_per_ion: float,
+    species: Species,
+) -> Dict[str, float]:
+    """Return impurity source terms for a given incident flux.
+
+    Parameters
+    ----------
+    ion_flux:
+        Incoming ion flux [m^-2 s^-1].
+    yield_per_ion:
+        Sputtering yield for the incident species.
+    species:
+        Target material species being sputtered.
+
+    Returns
+    -------
+    Dict[str, float]
+        Mapping of species name to sputtered particle flux.  The flux is
+        ``ion_flux * yield_per_ion`` with no additional scaling so that
+        the values can be directly fed into simple impurity models.
+    """
+
+    if ion_flux <= 0 or yield_per_ion <= 0:
+        return {species.name: 0.0}
+    return {species.name: ion_flux * yield_per_ion}

--- a/src/dpf2/radiation/power.py
+++ b/src/dpf2/radiation/power.py
@@ -13,7 +13,13 @@ import numpy as np
 __all__ = ["bremsstrahlung_power", "line_radiation_power"]
 
 
-def bremsstrahlung_power(ne: np.ndarray, ni: np.ndarray, Te: np.ndarray) -> np.ndarray:
+def bremsstrahlung_power(
+    ne: np.ndarray,
+    ni: np.ndarray,
+    Te: np.ndarray,
+    *,
+    Z_eff: float = 1.0,
+) -> np.ndarray:
     """Return volumetric bremsstrahlung power.
 
     Parameters
@@ -24,20 +30,32 @@ def bremsstrahlung_power(ne: np.ndarray, ni: np.ndarray, Te: np.ndarray) -> np.n
         Electron temperature [eV or K].  Only relative scaling is used in the
         tests so the unit choice is immaterial.
 
+    Z_eff:
+        Effective charge state of the plasma.  A value greater than one
+        mimics the enhancement of bremsstrahlung due to high-Z
+        impurities.  The default of ``1.0`` preserves the previous
+        behaviour used in the unit tests.
+
     Returns
     -------
     numpy.ndarray
-        Power density [W/m^3] scaling as ``ne * ni * sqrt(Te)``.
+        Power density [W/m^3] scaling as ``ne * ni * Z_eff * sqrt(Te)``.
     """
 
     ne = np.asarray(ne)
     ni = np.asarray(ni)
     Te = np.asarray(Te)
     coeff = 1.0
-    return coeff * ne * ni * np.sqrt(Te)
+    return coeff * ne * ni * Z_eff * np.sqrt(Te)
 
 
-def line_radiation_power(ne: np.ndarray, Te: np.ndarray, *, coeff: float = 0.0) -> np.ndarray:
+def line_radiation_power(
+    ne: np.ndarray,
+    Te: np.ndarray,
+    *,
+    coeff: float = 0.0,
+    impurity_fraction: float = 1.0,
+) -> np.ndarray:
     """Placeholder line-radiation loss model.
 
     The helper mirrors :func:`bremsstrahlung_power` but uses a configurable
@@ -48,4 +66,4 @@ def line_radiation_power(ne: np.ndarray, Te: np.ndarray, *, coeff: float = 0.0) 
 
     ne = np.asarray(ne)
     Te = np.asarray(Te)
-    return coeff * ne * ne * np.sqrt(Te)
+    return coeff * impurity_fraction * ne * ne * np.sqrt(Te)

--- a/src/dpf2/radiation/xray_emission_model.py
+++ b/src/dpf2/radiation/xray_emission_model.py
@@ -50,6 +50,8 @@ def cr_line_emission(
     T_e_eV: float,
     n_e_cm3: float,
     species: Literal["Ne", "Ar"],
+    *,
+    impurity_fraction: float = 1.0,
 ) -> Dict[str, float]:
     """Return line emissivity for the requested species.
 
@@ -61,6 +63,11 @@ def cr_line_emission(
         Electron density in cm^-3.
     species:
         Ion species identifier (``"Ne"`` or ``"Ar"``).
+
+    impurity_fraction:
+        Multiplier representing the fractional abundance of the emitting
+        species.  ``1.0`` corresponds to a pure plasma of the given
+        species while smaller values scale the emissivity accordingly.
 
     Returns
     -------
@@ -81,7 +88,7 @@ def cr_line_emission(
         raise ValueError(f"Unsupported species '{species}'")
 
     emissivity: Dict[str, float] = {}
-    n2 = n_e_cm3 ** 2
+    n2 = (n_e_cm3 ** 2) * impurity_fraction
     for name, line in lines.items():
         emissivity[name] = line.coeff * n2 * exp(-line.energy_eV / T_e_eV)
     return emissivity

--- a/tests/materials/test_sputtering.py
+++ b/tests/materials/test_sputtering.py
@@ -1,0 +1,31 @@
+import pytest
+
+from dpf2.materials import (
+    Species,
+    sigmund_yield,
+    yamamura_yield,
+    impurity_source_terms,
+)
+
+
+def test_sigmund_yield_threshold():
+    d = Species("D", Z=1, mass_u=2.0)
+    cu = Species("Cu", Z=29, mass_u=63.5)
+    y_low = sigmund_yield(d, cu, 10.0)
+    assert y_low == 0.0
+    y_high = sigmund_yield(d, cu, 100.0)
+    assert y_high > 0.0
+    assert pytest.approx(y_high, rel=1e-6) == 0.0065810636
+
+
+def test_yamamura_angle_scaling():
+    d = Species("D", Z=1, mass_u=2.0)
+    cu = Species("Cu", Z=29, mass_u=63.5)
+    y = yamamura_yield(d, cu, 100.0, 45.0)
+    assert pytest.approx(y, rel=1e-6) == 0.0075262530
+
+
+def test_impurity_source_terms():
+    cu = Species("Cu", Z=29, mass_u=63.5)
+    flux = impurity_source_terms(1e20, 0.01, cu)
+    assert flux["Cu"] == pytest.approx(1e18)

--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -80,5 +80,21 @@ def test_insulator_material_is_materialref():
     assert sleeve.material.material_id == "alumina"
 
 
+def test_electrode_material_fields_present():
+    cfg = DeviceProfiles.with_defaults()
+    d = cfg.devices["PF1000"]
+    # ``d`` may be a plain ``dict`` when the lightweight pydantic stub is
+    # used in environments without the real dependency.  In that case we
+    # simply verify that the new keys exist.  With the real pydantic model
+    # the attributes are available directly on the ``DeviceEntry`` object.
+    if isinstance(d, dict):  # pragma: no cover - exercised in stub mode
+        assert "anodeMaterial" not in d or d["anodeMaterial"] is None
+        assert "cathodeMaterial" not in d or d["cathodeMaterial"] is None
+    else:  # pragma: no cover - real pydantic path
+        assert hasattr(d, "anode_material")
+        assert hasattr(d, "cathode_material")
+        assert d.anode_material is None and d.cathode_material is None
+
+
 def test_cli_has_device_option():
     assert any("--device" in opt.opts for opt in simulate.params)


### PR DESCRIPTION
## Summary
- implement Sigmund/Yamamura sputtering yields and impurity source terms
- adjust bremsstrahlung and CR line emission for impurity evolution
- expose electrode material references in device profiles

## Testing
- `pytest tests/materials/test_sputtering.py tests/test_cr_line_emission.py tests/physics/test_radiation_scaling.py tests/test_device_profiles.py::test_electrode_material_fields_present`

------
https://chatgpt.com/codex/tasks/task_e_68b9e4610b28832a801c4efb7d77c0d7