### PR TITLE
Implement AMR triggers and solver callbacks

### DIFF
--- a/src/dpf2/diagnostics/quality_dashboard.py
+++ b/src/dpf2/diagnostics/quality_dashboard.py
@@ -29,6 +29,7 @@ class QualityDashboard:
         ppc: float,
         cfl: float,
         lambda_D: float,
+        amr_level: int | None = None,
     ) -> None:
         """Record a step's metrics and emit warnings if thresholds violated."""
         entry = {
@@ -39,6 +40,8 @@ class QualityDashboard:
             "cfl": cfl,
             "lambda_D": lambda_D,
         }
+        if amr_level is not None:
+            entry["amr_level"] = amr_level
 
         dt_violation = self.max_dt is not None and dt > self.max_dt
         lambda_violation = lambda_D < cell_size
@@ -93,8 +96,13 @@ class QualityDashboard:
         dts = [h["dt"] for h in self.history]
         lambdas = [h["lambda_D"] for h in self.history]
         cells = [h["cell_size"] for h in self.history]
+        levels = [h.get("amr_level") for h in self.history]
 
-        fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
+        has_levels = any(l is not None for l in levels)
+        if has_levels:
+            fig, (ax1, ax2, ax3) = plt.subplots(3, 1, sharex=True)
+        else:
+            fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
         ax1.plot(steps, dts, label="Δt")
         if self.max_dt is not None:
             ax1.axhspan(0, self.max_dt, color="lightgreen", alpha=0.3)
@@ -124,8 +132,15 @@ class QualityDashboard:
             alpha=0.3,
         )
         ax2.set_ylabel("λ_D")
-        ax2.set_xlabel("step")
-        ax2.legend()
+        if has_levels:
+            ax2.legend()
+            ax3.step(steps, [l if l is not None else 0 for l in levels], where="post", label="AMR level")
+            ax3.set_ylabel("level")
+            ax3.set_xlabel("step")
+            ax3.legend()
+        else:
+            ax2.set_xlabel("step")
+            ax2.legend()
 
         fig.tight_layout()
         fig.savefig(self.output_dir / "stability.png")

--- a/src/dpf2/mesh/amr.py
+++ b/src/dpf2/mesh/amr.py
@@ -43,6 +43,46 @@ def plasma_gradient_refinement(field: np.ndarray, threshold: float) -> np.ndarra
     return np.array(mask)
 
 
+def debye_length_refinement(lambda_D: np.ndarray, threshold: float) -> np.ndarray:
+    """Return mask where the Debye length ``lambda_D`` falls below ``threshold``."""
+    arr = lambda_D.data if hasattr(lambda_D, "data") else lambda_D
+    def _walk(a):
+        if isinstance(a, list):
+            return [_walk(x) for x in a]
+        return bool(a < threshold)
+    return np.array(_walk(arr))
+
+
+def ion_inertial_length_refinement(d_i: np.ndarray, threshold: float) -> np.ndarray:
+    """Return mask where the ion inertial length ``d_i`` falls below ``threshold``."""
+    arr = d_i.data if hasattr(d_i, "data") else d_i
+    def _walk(a):
+        if isinstance(a, list):
+            return [_walk(x) for x in a]
+        return bool(a < threshold)
+    return np.array(_walk(arr))
+
+
+def pressure_gradient_refinement(pressure: np.ndarray, threshold: float) -> np.ndarray:
+    """Convenience wrapper applying :func:`plasma_gradient_refinement` to pressure."""
+    return plasma_gradient_refinement(pressure, threshold)
+
+
+def current_density_refinement(current: np.ndarray, threshold: float) -> np.ndarray:
+    """Return mask where the current density magnitude exceeds ``threshold``."""
+    arr = current.data if hasattr(current, "data") else current
+    def _walk(a):
+        if isinstance(a, list) and a and not isinstance(a[0], list):
+            if len(a) != 3:
+                raise ValueError("current vectors must have three components")
+            mag = (a[0]**2 + a[1]**2 + a[2]**2) ** 0.5
+            return mag > threshold
+        if isinstance(a, list):
+            return [_walk(x) for x in a]
+        raise ValueError("current must be an array of vectors")
+    return np.array(_walk(arr))
+
+
 def wavefront_refinement(field: np.ndarray, prev_field: np.ndarray, threshold: float) -> np.ndarray:
     """Tag cells where the change between two fields exceeds ``threshold``."""
     if field is None or prev_field is None:
@@ -68,7 +108,7 @@ def wavefront_refinement(field: np.ndarray, prev_field: np.ndarray, threshold: f
 class AMRMesh:
     """Light‑weight wrapper around a pyAMReX style AMR interface."""
 
-    shape: tuple[int, int, int]
+    shape: tuple[int, ...]
     criteria: Dict[str, float]
 
     def __post_init__(self) -> None:
@@ -87,17 +127,50 @@ class AMRMesh:
 
         density = plasma_state.get("density")
         field = plasma_state.get("field")
+        lambda_D = plasma_state.get("lambda_D")
+        d_i = plasma_state.get("d_i")
+        pressure = plasma_state.get("pressure")
+        current = plasma_state.get("current")
 
-        mask = np.zeros(self.shape, dtype=bool)
+        def _init_mask(shape):
+            if isinstance(shape, int):
+                return [False] * shape
+            if isinstance(shape, tuple):
+                return [_init_mask(s) for s in shape]
+            raise TypeError("shape must be int or tuple")
+
+        def _or(a, b):
+            if isinstance(a, list):
+                return [_or(x, y) for x, y in zip(a, b)]
+            return bool(a) or bool(b)
+
+        mask = _init_mask(self.shape)
+
         grad_thresh = self.criteria.get("gradient_threshold")
         if density is not None and grad_thresh is not None:
-            mask |= plasma_gradient_refinement(np.asarray(density), grad_thresh)
+            mask = _or(mask, plasma_gradient_refinement(density, grad_thresh).data)
 
         wave_thresh = self.criteria.get("wavefront_threshold")
         if field is not None and prev_field is not None and wave_thresh is not None:
-            mask |= wavefront_refinement(np.asarray(field), np.asarray(prev_field), wave_thresh)
+            mask = _or(mask, wavefront_refinement(field, prev_field, wave_thresh).data)
 
-        self._last_mask = mask
+        ld_thresh = self.criteria.get("lambda_D_threshold")
+        if lambda_D is not None and ld_thresh is not None:
+            mask = _or(mask, debye_length_refinement(lambda_D, ld_thresh).data)
+
+        di_thresh = self.criteria.get("d_i_threshold")
+        if d_i is not None and di_thresh is not None:
+            mask = _or(mask, ion_inertial_length_refinement(d_i, di_thresh).data)
+
+        gradp_thresh = self.criteria.get("pressure_gradient_threshold")
+        if pressure is not None and gradp_thresh is not None:
+            mask = _or(mask, pressure_gradient_refinement(pressure, gradp_thresh).data)
+
+        J_thresh = self.criteria.get("current_density_threshold")
+        if current is not None and J_thresh is not None:
+            mask = _or(mask, current_density_refinement(current, J_thresh).data)
+
+        self._last_mask = np.array(mask)
 
         if self._backend and hasattr(self._backend, "amr"):
             self._backend.amr.tag_cells(mask.astype(np.int8))
@@ -108,4 +181,4 @@ class AMRMesh:
     def tagging_stats(self) -> Dict[str, int]:
         if self._last_mask is None:
             return {"tagged_cells": 0}
-        return {"tagged_cells": int(self._last_mask.sum())}
+        return {"tagged_cells": int(np.sum(self._last_mask))}

--- a/src/dpf2/simulation/fluid_solver_high_order.py
+++ b/src/dpf2/simulation/fluid_solver_high_order.py
@@ -38,6 +38,7 @@ from .sheath_model import BohmSheath
 from .radiation_model import RadiationModel
 from .turbulence_model import TurbulenceModel
 from .models import PhysicsModule
+from typing import Optional, Callable, Dict, Any
 from .utils import FieldManager, SimulationState
 
 # Physical constants
@@ -195,7 +196,7 @@ class FluidSolverHighOrder:
             logger.error(f"Error initializing FluidSolverHighOrder: {e}")
             raise
 
-    def step(self, dt):
+    def step(self, dt, refinement_cb: Optional[Callable[[Dict[str, Any]], Dict[str, int]]] = None):
         try:
             # Track total energy for conservation diagnostics
             E_before = self.get_total_energy()
@@ -216,6 +217,10 @@ class FluidSolverHighOrder:
             self._dedner_clean(dt)
             if self.do_amr:
                 self._amr_refine()
+            if refinement_cb is not None:
+                stats = refinement_cb({"pressure": U_np1['pi'] + U_np1['pe']})
+                if stats:
+                    logger.info(f"AMR callback stats: {stats}")
             self._radiation_step(dt)
             self._photon_monte_carlo(dt)
 

--- a/src/dpf2/simulation/hybrid_pic_solver.py
+++ b/src/dpf2/simulation/hybrid_pic_solver.py
@@ -15,11 +15,15 @@ that it may be connected to the existing external circuit model.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Protocol, Optional, Callable, Dict
 
 import numpy as np
+import logging
 
 from ..core.bases import CouplingState, PlasmaSolverBase
+
+
+logger = logging.getLogger(__name__)
 
 
 class _FluidSolver(Protocol):
@@ -99,7 +103,7 @@ class HybridPICSolver(PlasmaSolverBase):
         spike = eta * abs(J)
         return eta, spike
 
-    def step(self, state: Any, dt: float, current: float, voltage: float) -> Any:
+    def step(self, state: Any, dt: float, current: float, voltage: float, refinement_cb: Optional[Callable[[Dict[str, Any]], Dict[str, int]]] = None) -> Any:
         """Advance both fluid and particle descriptions.
 
         The method updates the coupled solvers, evaluates ``m=0`` growth
@@ -120,6 +124,11 @@ class HybridPICSolver(PlasmaSolverBase):
         eta, spike = self.compute_anomalous_resistivity(J)
         self.last_voltage_spike = spike
         self.last_beam_current = self.particles.beam_current()
+
+        if refinement_cb is not None:
+            stats = refinement_cb({"current": J})
+            if stats:
+                logger.info(f"AMR callback stats: {stats}")
 
         # A crude inductance model incorporating m=0 growth.  In practice
         # this would be replaced by a full EM field solution.

--- a/src/dpf2/simulation/pic_solver.py
+++ b/src/dpf2/simulation/pic_solver.py
@@ -19,7 +19,7 @@ import json
 import threading
 import math
 from numba import njit, prange
-from typing import List, Dict, Tuple, Optional, Callable
+from typing import List, Dict, Tuple, Optional, Callable, Any
 from pathlib import Path
 from ..core.bases import CouplingState
 from ..diagnostics import synthetic_signals, IonBeamEDF, compute_beam_target_yield
@@ -557,7 +557,7 @@ class PICSolver(PhysicsModule):
     #-------------------------------------------------------------------------------------
     # Main step
     #-------------------------------------------------------------------------------------
-    def step(self, current: float = 0.0, voltage: float = 0.0, energy_tracker: EnergyTracker | None = None):
+    def step(self, current: float = 0.0, voltage: float = 0.0, energy_tracker: EnergyTracker | None = None, refinement_cb: Optional[Callable[[Dict[str, Any]], Dict[str, int]]] = None):
         """Advances the PIC simulation by one time step."""
         try:
             self.deposit_charge()
@@ -565,6 +565,15 @@ class PICSolver(PhysicsModule):
             self.solve_fields()
             E = self.field_manager.get_E()
             B = self.field_manager.get_B()
+            amr_stats: Dict[str, int] | None = None
+            if refinement_cb is not None:
+                plasma_state = {
+                    "density": self.field_manager.get_rho(),
+                    "current": self.field_manager.get_J(),
+                }
+                amr_stats = refinement_cb(plasma_state)
+                if amr_stats:
+                    logger.info(f"AMR callback stats: {amr_stats}")
             if voltage:
                 E[2] += voltage / (self.nz * self.dz)
                 self.field_manager.update_E(E)
@@ -639,6 +648,9 @@ class PICSolver(PhysicsModule):
                     np.sqrt(PICSolver.epsilon0 * PICSolver.k_B * Te / (ne * e**2))
                     if ne > 0 else float("inf")
                 )
+                amr_level = None
+                if amr_stats is not None:
+                    amr_level = 1 if amr_stats.get("tagged_cells", 0) > 0 else 0
                 self.quality.log(
                     self.step_count,
                     self.dt,
@@ -646,6 +658,7 @@ class PICSolver(PhysicsModule):
                     ppc,
                     cfl,
                     lambda_D,
+                    amr_level=amr_level,
                 )
         except Exception as e:
             logger.error(f"Error during PIC step: {e}")

--- a/tests/mesh/test_amr_triggers.py
+++ b/tests/mesh/test_amr_triggers.py
@@ -1,0 +1,43 @@
+import numpy as np
+from dpf2.mesh.amr import (
+    debye_length_refinement,
+    ion_inertial_length_refinement,
+    pressure_gradient_refinement,
+    current_density_refinement,
+    AMRMesh,
+)
+
+
+def test_debye_length_trigger():
+    ld = np.array([[0.1, 0.6], [0.4, 0.3]])
+    mask = debye_length_refinement(ld, 0.5)
+    assert float(np.sum(mask)) == 3
+
+
+def test_ion_inertial_length_trigger():
+    di = np.array([[1.0, 0.2], [0.7, 0.1]])
+    mask = ion_inertial_length_refinement(di, 0.5)
+    assert float(np.sum(mask)) == 2
+
+
+def test_pressure_gradient_trigger():
+    p = np.array([[1.0, 1.0], [2.0, 4.0]])
+    mask = pressure_gradient_refinement(p, 1.0)
+    data = mask.data if hasattr(mask, "data") else mask
+    assert any(any(row) for row in data)
+
+
+def test_current_density_trigger():
+    J = np.array([[[0.0, 0.0, 0.0], [3.0, 4.0, 0.0]],
+                  [[0.0, 0.0, 0.0], [0.0, 0.0, 6.0]]])
+    mask = current_density_refinement(J, 4.5)
+    assert float(np.sum(mask)) == 2
+
+
+def test_amrmesh_combines_triggers():
+    mesh = AMRMesh(shape=(2, 2), criteria={"lambda_D_threshold": 0.5, "current_density_threshold": 4.5})
+    ld = np.array([[0.1, 0.6], [0.4, 0.2]])
+    J = np.array([[[0.0, 0.0, 0.0], [3.0, 4.0, 0.0]],
+                  [[0.0, 0.0, 0.0], [0.0, 0.0, 6.0]]])
+    mesh.refine({"lambda_D": ld, "current": J})
+    assert mesh.tagging_stats()["tagged_cells"] == 4


### PR DESCRIPTION
## Summary
- support Debye length, ion inertial length, pressure gradient and current density triggers in AMR controller
- allow solvers to invoke refinement callbacks and report AMR stats
- extend quality dashboard to plot refinement levels
- add unit tests for AMR trigger helpers

## Testing
- `python -m pytest tests/mesh/test_amr_triggers.py -q`
- `python -m pytest tests/test_quality_dashboard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e46c528c832abfa5b19b6dee8e6d