### PR TITLE
Add regime diagnostics and frontend panel

### DIFF
--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -40,6 +40,7 @@ from .synthetic_signals import (
 from .streaming import NeutronYieldStreamer, XRayEmissionStreamer, RealTimeComparator
 from .interferometry import interferometer_phase_shift
 from .pinhole_imaging import pinhole_image
+from .regime_panel import RegimePanel
 from .plasma import (
     bennett_radius,
     plasma_beta,
@@ -120,6 +121,7 @@ __all__ = [
     "synthetic_tof_spectrum",
     "angular_spectrum",
     "anisotropy_metric",
+    "RegimePanel",
     "Diagnostics",
     "DetectorArrayGenerator",
     "OutputField",

--- a/src/dpf2/diagnostics/quality_dashboard.py
+++ b/src/dpf2/diagnostics/quality_dashboard.py
@@ -20,6 +20,13 @@ class QualityDashboard:
     max_dt: float | None = None
     abort_on_violation: bool = False
     history: list[dict[str, float]] = field(default_factory=list)
+    min_S: float | None = None
+    max_beta: float | None = None
+    max_M_A: float | None = None
+    min_R_m: float | None = None
+    max_K_n: float | None = None
+    min_omega_ce_tau_e: float | None = None
+    regime_history: list[dict[str, float]] = field(default_factory=list)
 
     def log(
         self,
@@ -76,6 +83,55 @@ class QualityDashboard:
 
         self._update_plot()
 
+    def log_regime(
+        self,
+        step: int,
+        S: float,
+        beta: float,
+        M_A: float,
+        R_m: float,
+        K_n: float,
+        omega_ce_tau_e: float,
+    ) -> None:
+        """Record dimensionless regime parameters and flag threshold violations."""
+
+        entry = {
+            "step": step,
+            "S": S,
+            "beta": beta,
+            "M_A": M_A,
+            "R_m": R_m,
+            "K_n": K_n,
+            "omega_ce_tau_e": omega_ce_tau_e,
+        }
+
+        self.regime_history.append(entry)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        with open(self.output_dir / "regime.json", "w", encoding="utf-8") as fh:
+            json.dump(self.regime_history, fh, indent=2)
+
+        def _warn_or_abort(msg: str) -> None:
+            logger.warning(msg)
+            if self.abort_on_violation:
+                raise RuntimeError(msg)
+
+        if self.min_S is not None and S < self.min_S:
+            _warn_or_abort(f"Lundquist number below threshold: {S:g} < {self.min_S:g}")
+        if self.max_beta is not None and beta > self.max_beta:
+            _warn_or_abort(f"Plasma beta above threshold: {beta:g} > {self.max_beta:g}")
+        if self.max_M_A is not None and M_A > self.max_M_A:
+            _warn_or_abort(f"Alfvén Mach number above threshold: {M_A:g} > {self.max_M_A:g}")
+        if self.min_R_m is not None and R_m < self.min_R_m:
+            _warn_or_abort(f"Magnetic Reynolds number below threshold: {R_m:g} < {self.min_R_m:g}")
+        if self.max_K_n is not None and K_n > self.max_K_n:
+            _warn_or_abort(f"Knudsen number above threshold: {K_n:g} > {self.max_K_n:g}")
+        if self.min_omega_ce_tau_e is not None and omega_ce_tau_e < self.min_omega_ce_tau_e:
+            _warn_or_abort(
+                f"Cyclotron frequency–collision time below threshold: {omega_ce_tau_e:g} < {self.min_omega_ce_tau_e:g}"
+            )
+
+        self._update_regime_plot()
+
     # ------------------------------------------------------------------
     def _update_plot(self) -> None:
         """Render a simple plot of stability metrics."""
@@ -129,4 +185,36 @@ class QualityDashboard:
 
         fig.tight_layout()
         fig.savefig(self.output_dir / "stability.png")
+        plt.close(fig)
+
+    # ------------------------------------------------------------------
+    def _update_regime_plot(self) -> None:
+        """Render a plot of regime parameters over time."""
+        try:
+            import matplotlib
+            matplotlib.use("Agg")
+            import matplotlib.pyplot as plt
+        except Exception:  # pragma: no cover - matplotlib optional
+            return
+
+        if not self.regime_history:
+            return
+
+        steps = [h["step"] for h in self.regime_history]
+        metrics = [
+            ("S", "Lundquist"),
+            ("beta", "beta"),
+            ("M_A", "M_A"),
+            ("R_m", "R_m"),
+            ("K_n", "K_n"),
+            ("omega_ce_tau_e", "ω_ce τ_e"),
+        ]
+        fig, axes = plt.subplots(3, 2, sharex=True)
+        for ax, (key, label) in zip(axes.flat, metrics):
+            ax.plot(steps, [h[key] for h in self.regime_history])
+            ax.set_ylabel(label)
+        axes[2, 0].set_xlabel("step")
+        axes[2, 1].set_xlabel("step")
+        fig.tight_layout()
+        fig.savefig(self.output_dir / "regime.png")
         plt.close(fig)

--- a/src/dpf2/diagnostics/regime_panel.py
+++ b/src/dpf2/diagnostics/regime_panel.py
@@ -1,0 +1,105 @@
+"""Regime diagnostic panel tracking dimensionless parameters over time."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import logging
+from typing import Dict
+
+from .plasma import (
+    lundquist_number,
+    plasma_beta,
+    alfven_mach_number,
+    magnetic_reynolds_number,
+)
+from .quality_dashboard import QualityDashboard
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - SciPy optional
+    from scipy.constants import e, m_e
+except Exception:  # pragma: no cover - fallback values
+    e = 1.602176634e-19
+    m_e = 9.1093837015e-31
+
+
+@dataclass
+class RegimePanel:
+    """Compute and log dimensionless plasma regime parameters."""
+
+    L: float
+    quality: QualityDashboard | None = None
+    thresholds: Dict[str, float] = field(
+        default_factory=lambda: {
+            "S": 1.0,
+            "beta": 1.0,
+            "M_A": 1.0,
+            "R_m": 1.0,
+            "K_n": 0.1,
+            "omega_ce_tau_e": 1.0,
+        }
+    )
+    history: list[Dict[str, float]] = field(default_factory=list)
+
+    def log(
+        self,
+        step: int,
+        n: float,
+        T: float,
+        B: float,
+        v: float,
+        eta: float,
+        mfp: float,
+        tau_e: float,
+    ) -> Dict[str, float]:
+        """Compute parameters for a simulation step.
+
+        Parameters are specified in SI units. ``n`` is number density, ``T``
+        the temperature, ``B`` the magnetic-field magnitude, ``v`` a
+        characteristic flow speed, ``eta`` the resistivity, ``mfp`` the mean
+        free path and ``tau_e`` the electron collision time.
+        """
+
+        sigma = 1.0 / eta if eta > 0 else float("inf")
+        S = lundquist_number(B, n, self.L, sigma)
+        beta = plasma_beta(n, T, B)
+        M_A = alfven_mach_number(v, B, n)
+        R_m = magnetic_reynolds_number(v, self.L, sigma)
+        K_n = mfp / self.L
+        omega_ce_tau_e = (e * B / m_e) * tau_e
+
+        entry = {
+            "step": step,
+            "S": float(S),
+            "beta": float(beta),
+            "M_A": float(M_A),
+            "R_m": float(R_m),
+            "K_n": float(K_n),
+            "omega_ce_tau_e": float(omega_ce_tau_e),
+        }
+        self.history.append(entry)
+
+        if self.quality is not None:
+            self.quality.log_regime(
+                step,
+                entry["S"],
+                entry["beta"],
+                entry["M_A"],
+                entry["R_m"],
+                entry["K_n"],
+                entry["omega_ce_tau_e"],
+            )
+
+        violations: Dict[str, bool] = {}
+        for key, limit in self.thresholds.items():
+            val = entry[key]
+            if key in {"beta", "M_A", "K_n"}:
+                violations[key] = val > limit
+            else:
+                violations[key] = val < limit
+            if violations[key]:
+                logger.warning("Regime parameter %s out of bounds: %.3g", key, val)
+        entry["violations"] = violations
+
+        return entry
+

--- a/tests/gui/test_regime_dashboard.py
+++ b/tests/gui/test_regime_dashboard.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_regime_dashboard_websocket_subscription():
+    content = Path("web/frontend/src/RegimeDashboard.jsx").read_text()
+    assert "new WebSocket" in content
+    assert "/ws/regime" in content
+    for key in ["S", "beta", "M_A", "R_m", "K_n", "omega_ce_tau_e"]:
+        assert key in content
+

--- a/web/frontend/src/App.jsx
+++ b/web/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import ProjectManager from './ProjectManager.jsx';
 import InstabilityVisualizer from './InstabilityVisualizer.jsx';
 import SheathBeamOverlay from './SheathBeamOverlay.jsx';
+import RegimeDashboard from './RegimeDashboard.jsx';
 
 import QuickStartTutorial from './QuickStartTutorial.jsx';
 
@@ -266,6 +267,7 @@ export default function App() {
           </div>
           <InstabilityVisualizer />
           <SheathBeamOverlay voltage={voltage} pressure={pressure} />
+          <RegimeDashboard />
 
           <QuickStartTutorial
             setVoltage={setVoltage}

--- a/web/frontend/src/RegimeDashboard.jsx
+++ b/web/frontend/src/RegimeDashboard.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+
+export default function RegimeDashboard() {
+  const [data, setData] = useState([]);
+
+  useEffect(() => {
+    const ws = new WebSocket(
+      `${window.location.origin.replace('http', 'ws')}/ws/regime`
+    );
+    ws.onmessage = (evt) => {
+      try {
+        const msg = JSON.parse(evt.data);
+        setData((d) => [...d, msg]);
+      } catch {
+        /* ignore malformed messages */
+      }
+    };
+    return () => ws.close();
+  }, []);
+
+  const limits = {
+    S: 1,
+    beta: 1,
+    M_A: 1,
+    R_m: 1,
+    K_n: 0.1,
+    omega_ce_tau_e: 1,
+  };
+
+  const latest = data[data.length - 1] || {};
+  const check = (key) => {
+    const val = latest[key];
+    if (val === undefined) return '';
+    if (['beta', 'M_A', 'K_n'].includes(key)) {
+      return val > limits[key] ? 'violation' : '';
+    }
+    return val < limits[key] ? 'violation' : '';
+  };
+
+  return (
+    <div className="overlay" title="Tracks plasma regime parameters">
+      <h4>Regime Dashboard</h4>
+      <table>
+        <tbody>
+          {Object.keys(limits).map((k) => (
+            <tr key={k} className={check(k)}>
+              <td>{k}</td>
+              <td>{latest[k] !== undefined ? latest[k].toFixed(3) : '-'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- compute S, β, M_A, R_m, K_n, and ω_ceτ_e in new `RegimePanel`
- extend `QualityDashboard` with regime logging and plots
- add `RegimeDashboard` React panel subscribing to simulation websocket and surface in app

## Testing
- `pytest tests/gui/test_regime_dashboard.py -q`
- `pytest tests/test_quality_dashboard.py -q`
- `pytest tests/test_diagnostics.py -q` *(fails: TypeError: model_validator wrapper missing 'values')*


------
https://chatgpt.com/codex/tasks/task_e_68b9e47268b8832a955b8eff61544064