### PR TITLE
feat: add surrogate OOD detection

### DIFF
--- a/src/dpf2/ai/simple_surrogates.py
+++ b/src/dpf2/ai/simple_surrogates.py
@@ -16,6 +16,7 @@ from typing import Iterable, Sequence
 import numpy as np
 
 from .surrogate import ONNXSurrogateModel
+from ..optimization import OptimizationWarning
 
 
 @dataclass
@@ -25,6 +26,9 @@ class LinearSurrogate:
     coeffs: Sequence[float]
     domain: Sequence[float]
     error: float
+    mean: float | None = None
+    covariance: float | None = None
+    ood_threshold: float | None = None
 
     def predict(self, x: float | Iterable[float]) -> float | list[float]:
         if isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
@@ -32,16 +36,43 @@ class LinearSurrogate:
             return [self._predict_single(val) for val in inputs]
         return self._predict_single(float(x))
 
+    def predict_with_uncertainty(
+        self, x: float | Iterable[float]
+    ) -> tuple[float, tuple[float, float]] | list[tuple[float, tuple[float, float]]]:
+        """Return prediction and conformal error band."""
+
+        if isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
+            inputs = list(x)
+            return [self._predict_with_uncertainty_single(val) for val in inputs]
+        return self._predict_with_uncertainty_single(float(x))
+
     def _predict_single(self, val: float) -> float:
         lo, hi = self.domain
-        if val < lo or val > hi:
+        dist = self._mahalanobis(val)
+        if val < lo or val > hi or (
+            self.ood_threshold is not None and dist > self.ood_threshold
+        ):
             warnings.warn(
-                f"Input {val} outside training range [{lo}, {hi}]",
-                RuntimeWarning,
+                f"Input {val} outside training range [{lo}, {hi}] (distance={dist:.2f})",
+                OptimizationWarning,
                 stacklevel=2,
             )
         a, b = self.coeffs
         return a * val + b
+
+    def _predict_with_uncertainty_single(
+        self, val: float
+    ) -> tuple[float, tuple[float, float]]:
+        pred = self._predict_single(val)
+        dist = self._mahalanobis(val)
+        band = self.error * (1.0 + dist)
+        return pred, (pred - band, pred + band)
+
+    def _mahalanobis(self, val: float) -> float:
+        if self.mean is None or self.covariance is None:
+            return 0.0
+        diff = val - self.mean
+        return float(abs(diff) / np.sqrt(self.covariance))
 
     @classmethod
     def load(cls, path: Path) -> "LinearSurrogate":
@@ -50,7 +81,17 @@ class LinearSurrogate:
         coeffs = data.get("coeffs", [0.0, 0.0])
         domain = data.get("training_domain", [0.0, 0.0])
         error = data.get("error", 0.0)
-        return cls(coeffs=coeffs, domain=domain, error=error)
+        mean = data.get("mean")
+        covariance = data.get("covariance")
+        threshold = data.get("ood_threshold")
+        return cls(
+            coeffs=coeffs,
+            domain=domain,
+            error=error,
+            mean=mean,
+            covariance=covariance,
+            ood_threshold=threshold,
+        )
 
 
 @dataclass
@@ -60,6 +101,9 @@ class ONNXLinearSurrogate:
     model: ONNXSurrogateModel
     domain: Sequence[float]
     error: float
+    mean: float | None = None
+    covariance: float | None = None
+    ood_threshold: float | None = None
 
     def predict(self, x: float | Iterable[float]) -> float | list[float]:
         if isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
@@ -67,16 +111,41 @@ class ONNXLinearSurrogate:
             return [self._predict_single(v) for v in arr[:, 0]]
         return float(self._predict_single(float(x)))
 
+    def predict_with_uncertainty(
+        self, x: float | Iterable[float]
+    ) -> tuple[float, tuple[float, float]] | list[tuple[float, tuple[float, float]]]:
+        if isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
+            arr = np.asarray(list(x), dtype=np.float32).reshape(-1, 1)
+            return [self._predict_with_uncertainty_single(v) for v in arr[:, 0]]
+        return self._predict_with_uncertainty_single(float(x))
+
     def _predict_single(self, val: float) -> float:
         lo, hi = self.domain
-        if val < lo or val > hi:
+        dist = self._mahalanobis(val)
+        if val < lo or val > hi or (
+            self.ood_threshold is not None and dist > self.ood_threshold
+        ):
             warnings.warn(
-                f"Input {val} outside training range [{lo}, {hi}]",
-                RuntimeWarning,
+                f"Input {val} outside training range [{lo}, {hi}] (distance={dist:.2f})",
+                OptimizationWarning,
                 stacklevel=2,
             )
         inp = np.array([[val]], dtype=np.float32)
         return float(self.model.predict(inp)[0, 0])
+
+    def _predict_with_uncertainty_single(
+        self, val: float
+    ) -> tuple[float, tuple[float, float]]:
+        pred = self._predict_single(val)
+        dist = self._mahalanobis(val)
+        band = self.error * (1.0 + dist)
+        return pred, (pred - band, pred + band)
+
+    def _mahalanobis(self, val: float) -> float:
+        if self.mean is None or self.covariance is None:
+            return 0.0
+        diff = val - self.mean
+        return float(abs(diff) / np.sqrt(self.covariance))
 
 
 # Convenience loaders ---------------------------------------------------------
@@ -94,17 +163,34 @@ def load_yield_surrogate() -> LinearSurrogate | ONNXLinearSurrogate:
     domain = data.get("training_domain", [0.0, 0.0])
     error = data.get("error", 0.0)
     coeffs = data.get("coeffs", [0.0, 0.0])
+    mean = data.get("mean")
+    covariance = data.get("covariance")
+    threshold = data.get("ood_threshold")
     onnx_file = data.get("onnx")
 
     if onnx_file:
         onnx_path = meta.parent / onnx_file
         try:
             model = ONNXSurrogateModel.load(onnx_path)
-            return ONNXLinearSurrogate(model=model, domain=domain, error=error)
+            return ONNXLinearSurrogate(
+                model=model,
+                domain=domain,
+                error=error,
+                mean=mean,
+                covariance=covariance,
+                ood_threshold=threshold,
+            )
         except Exception:
             pass
 
-    return LinearSurrogate(coeffs=coeffs, domain=domain, error=error)
+    return LinearSurrogate(
+        coeffs=coeffs,
+        domain=domain,
+        error=error,
+        mean=mean,
+        covariance=covariance,
+        ood_threshold=threshold,
+    )
 
 
 def load_pinch_time_surrogate() -> LinearSurrogate:

--- a/src/dpf2/gui/interactive.py
+++ b/src/dpf2/gui/interactive.py
@@ -15,10 +15,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import List
 import json
+import warnings
 
 from .project_manager import ProjectManager
 from ..core.config import DPFConfig
 from ..device_profiles import DeviceProfiles
+from ..optimization import OptimizationWarning
 
 try:  # pragma: no cover - optional dependency
     import dash
@@ -56,6 +58,9 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
 
     pm = ProjectManager()
     app = Dash(__name__)
+
+    # Surface optimisation warnings to the user interface
+    warnings.simplefilter("always", OptimizationWarning)
 
     presets = DeviceProfiles.with_defaults().devices
     preset_options = [{"label": name, "value": name} for name in presets.keys()]

--- a/src/dpf2/ml_model_config.py
+++ b/src/dpf2/ml_model_config.py
@@ -92,6 +92,13 @@ class MLModelConfig(ConfigSectionBase):
     model_config_hash: Optional[str] = None
 
     # ------------------------------------------------------------------
+    # Out-of-distribution detection
+    ood_detection_enabled: bool = False
+    training_mean: Optional[List[float]] = None
+    training_covariance: Optional[List[List[float]]] = None
+    ood_threshold: float = 3.0
+
+    # ------------------------------------------------------------------
     @classmethod
     def with_defaults(cls) -> "MLModelConfig":
         return cls(
@@ -132,6 +139,25 @@ class MLModelConfig(ConfigSectionBase):
             parts.append(f"Inference: {inf} | Confidence{conf}")
         return "\n".join(parts)
 
+    # ------------------------------------------------------------------
+    def mahalanobis_distance(self, x: "np.ndarray") -> float:
+        """Return Mahalanobis distance of ``x`` to the training hull."""
+
+        if self.training_mean is None or self.training_covariance is None:
+            raise ValueError("training_mean and training_covariance required for OOD detection")
+        import numpy as np  # local import to support numpy stubs
+
+        mean = np.asarray(self.training_mean, dtype=float)
+        cov = np.asarray(self.training_covariance, dtype=float)
+        inv = np.linalg.pinv(cov)
+        diff = np.asarray(x, dtype=float) - mean
+        return float(np.sqrt(diff.T @ inv @ diff))
+
+    def in_distribution(self, x: "np.ndarray") -> bool:
+        if not self.ood_detection_enabled:
+            return True
+        return self.mahalanobis_distance(x) <= self.ood_threshold
+
     def hash_ml_model_config(self) -> str:
         data = self.model_dump(by_alias=True, exclude={"model_config_hash"}, exclude_none=True)
         serialized = json.dumps(data, sort_keys=True, default=str)
@@ -153,6 +179,12 @@ class MLModelConfig(ConfigSectionBase):
             raise ValueError("validation_split must be None when cv_folds is set")
         if values.load_existing_model and values.existing_model_path is None:
             raise ValueError("existing_model_path required when load_existing_model is True")
+        if values.ood_detection_enabled and (
+            values.training_mean is None or values.training_covariance is None
+        ):
+            raise ValueError(
+                "training_mean and training_covariance required when ood_detection_enabled"
+            )
         values = values.model_copy(update={"model_config_hash": values.hash_ml_model_config()})
         return values
 

--- a/src/dpf2/optimization/__init__.py
+++ b/src/dpf2/optimization/__init__.py
@@ -4,11 +4,30 @@ from .bayesian import BayesianParameterInference, ParameterEstimate
 from .param_sweep import plot_sweep_results, run_parametric_sweep
 from .multi_objective import random_pareto_search
 
+import warnings
+
+
+class OptimizationWarning(RuntimeWarning):
+    """Warning raised when queries fall outside the trained domain."""
+
+
+def enable_optimization_warning_as_error() -> None:
+    """Escalate :class:`OptimizationWarning` to an exception.
+
+    Optimisation routines may call this to ensure that out-of-distribution
+    queries halt the search rather than silently producing invalid results.
+    """
+
+    warnings.filterwarnings("error", category=OptimizationWarning)
+
+
 __all__ = [
     "BayesianParameterInference",
     "ParameterEstimate",
     "run_parametric_sweep",
     "plot_sweep_results",
     "random_pareto_search",
+    "OptimizationWarning",
+    "enable_optimization_warning_as_error",
 ]
 

--- a/tests/ml/test_ood_detection.py
+++ b/tests/ml/test_ood_detection.py
@@ -1,0 +1,43 @@
+import warnings
+
+import pytest
+
+from dpf2.ai.simple_surrogates import LinearSurrogate
+from dpf2.optimization import OptimizationWarning, enable_optimization_warning_as_error
+
+
+def _surrogate():
+    # Simple model y = x with unit variance around mean 0
+    return LinearSurrogate(
+        coeffs=(1.0, 0.0),
+        domain=(-5.0, 5.0),
+        error=0.5,
+        mean=0.0,
+        covariance=1.0,
+        ood_threshold=2.0,
+    )
+
+
+def test_in_distribution_prediction_has_band():
+    model = _surrogate()
+    pred, (lo, hi) = model.predict_with_uncertainty(1.0)
+    assert pytest.approx(pred) == 1.0
+    assert lo < pred < hi
+    # distance = 1 -> band scaled by (1 + 1)
+    assert pytest.approx(hi - pred, rel=1e-6) == model.error * (1 + model._mahalanobis(1.0))
+
+
+def test_out_of_distribution_warning_raised():
+    model = _surrogate()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        model.predict(10.0)
+    assert any(issubclass(wi.category, OptimizationWarning) for wi in w)
+
+
+def test_enable_warning_as_error_blocks():
+    model = _surrogate()
+    with warnings.catch_warnings():
+        enable_optimization_warning_as_error()
+        with pytest.raises(OptimizationWarning):
+            model.predict(10.0)


### PR DESCRIPTION
## Summary
- add Mahalanobis-based OOD checks and conformal error bands for surrogate models
- expose OptimizationWarning and helper to escalate warnings during optimization
- surface optimization warnings in interactive GUI
- extend ML model config for OOD metadata
- test surrogate OOD detection and warning escalation

## Testing
- `pytest tests/ml/test_ood_detection.py tests/test_surrogate_models.py tests/test_ai_surrogate.py -q`
- `pytest tests/test_ml_model_config.py -q` *(fails: DID NOT RAISE <class 'ValueError'>)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e4741330832a967b2b286535c4a2