### PR TITLE
Add performance KPI calculator and frontend metrics overlay

### DIFF
--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -56,6 +56,7 @@ from .neutron_spectra import (
     angular_spectrum,
     anisotropy_metric,
 )
+from .performance_metrics import compute_performance_metrics
 
 
 def apply_noise(
@@ -90,6 +91,7 @@ __all__ = [
     "tof_iv_cross_correlation",
     "angular_yield_map",
     "save_angular_yield_map_hdf5",
+    "compute_performance_metrics",
     "compute_xray_spectrum",
     "compute_scope_trace",
     "current_waveform",

--- a/src/dpf2/diagnostics/performance_metrics.py
+++ b/src/dpf2/diagnostics/performance_metrics.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Dict
+
+
+def compute_performance_metrics(
+    yield_per_shot: float,
+    *,
+    rep_rate_hz: float,
+    energy_out_j: float,
+    energy_in_j: float,
+    electrode_mass_g: float,
+    erosion_per_shot_g: float,
+) -> Dict[str, float]:
+    """Compute basic performance KPIs for a DPF system.
+
+    Parameters
+    ----------
+    yield_per_shot:
+        Neutron yield produced per individual shot.
+    rep_rate_hz:
+        Firing repetition rate in Hertz.
+    energy_out_j:
+        Output energy per shot in joules.
+    energy_in_j:
+        Input energy per shot in joules.
+    electrode_mass_g:
+        Mass of the sacrificial electrode material in grams available before
+        replacement is required.
+    erosion_per_shot_g:
+        Electrode mass lost per shot in grams.
+
+    Returns
+    -------
+    dict
+        Mapping containing ``yield_per_shot``, ``yield_per_hour``,
+        ``wall_plug_efficiency`` and ``lifetime_hours``.
+    """
+    if rep_rate_hz < 0:
+        raise ValueError("rep_rate_hz must be non-negative")
+
+    yield_hour = yield_per_shot * rep_rate_hz * 3600.0
+
+    wall = energy_out_j / energy_in_j if energy_in_j > 0 else 0.0
+
+    if erosion_per_shot_g <= 0 or rep_rate_hz == 0:
+        lifetime = float("inf")
+    else:
+        shots = electrode_mass_g / erosion_per_shot_g
+        lifetime = shots / rep_rate_hz / 3600.0
+
+    return {
+        "yield_per_shot": float(yield_per_shot),
+        "yield_per_hour": float(yield_hour),
+        "wall_plug_efficiency": float(wall),
+        "lifetime_hours": float(lifetime),
+    }

--- a/tests/diagnostics/test_performance_metrics.py
+++ b/tests/diagnostics/test_performance_metrics.py
@@ -1,0 +1,34 @@
+import math
+
+import pytest
+
+from dpf2.diagnostics.performance_metrics import compute_performance_metrics
+
+
+def test_basic_metrics():
+    metrics = compute_performance_metrics(
+        1e8,
+        rep_rate_hz=2.0,
+        energy_out_j=100.0,
+        energy_in_j=500.0,
+        electrode_mass_g=100.0,
+        erosion_per_shot_g=0.01,
+    )
+    assert metrics["yield_per_shot"] == pytest.approx(1e8)
+    assert metrics["yield_per_hour"] == pytest.approx(1e8 * 2.0 * 3600.0)
+    assert metrics["wall_plug_efficiency"] == pytest.approx(0.2)
+    expected_life = (100.0 / 0.01) / 2.0 / 3600.0
+    assert metrics["lifetime_hours"] == pytest.approx(expected_life)
+
+
+def test_zero_and_infinite_cases():
+    metrics = compute_performance_metrics(
+        0.0,
+        rep_rate_hz=0.0,
+        energy_out_j=0.0,
+        energy_in_j=0.0,
+        electrode_mass_g=10.0,
+        erosion_per_shot_g=0.0,
+    )
+    assert metrics["wall_plug_efficiency"] == 0.0
+    assert math.isinf(metrics["lifetime_hours"])

--- a/web/frontend/src/EfficiencyCurveOverlay.jsx
+++ b/web/frontend/src/EfficiencyCurveOverlay.jsx
@@ -3,13 +3,34 @@ import React, { useMemo, useRef } from 'react';
 export default function EfficiencyCurveOverlay({ datasets = [] }) {
   const svgRef = useRef(null);
 
+  const summary = useMemo(() => {
+    if (datasets.length === 0) return null;
+    const first = datasets[0].data || {};
+    const metrics = Object.values(first);
+    if (metrics.length === 0) return null;
+    const best = metrics.reduce((a, b) => {
+      const aEff = a.wall_plug_efficiency ?? a.efficiency ?? 0;
+      const bEff = b.wall_plug_efficiency ?? b.efficiency ?? 0;
+      return bEff > aEff ? b : a;
+    });
+    return {
+      yieldShot: best.yield_per_shot ?? 0,
+      yieldHour: best.yield_per_hour ?? 0,
+      wallPlug: best.wall_plug_efficiency ?? best.efficiency ?? 0,
+      lifetime: best.lifetime_hours ?? 0,
+    };
+  }, [datasets]);
+
   const computePoints = (data) => {
     const entries = Object.entries(data);
     if (entries.length === 0) return '';
     const width = 200;
     const height = 100;
     const sorted = entries
-      .map(([p, m]) => ({ param: parseFloat(p), value: m.efficiency }))
+      .map(([p, m]) => ({
+        param: parseFloat(p),
+        value: m.wall_plug_efficiency ?? m.efficiency,
+      }))
       .sort((a, b) => a.param - b.param);
     const minParam = sorted[0].param;
     const maxParam = sorted[sorted.length - 1].param;
@@ -44,6 +65,14 @@ export default function EfficiencyCurveOverlay({ datasets = [] }) {
           return <polyline key={label} points={pts} stroke={color} fill="none" />;
         })}
       </svg>
+      {summary && (
+        <ul className="metrics">
+          <li>Yield/shot: {summary.yieldShot.toLocaleString()}</li>
+          <li>Yield/hour: {summary.yieldHour.toLocaleString()}</li>
+          <li>Wall-plug eff.: {(summary.wallPlug * 100).toFixed(2)}%</li>
+          <li>Lifetime: {summary.lifetime.toFixed(1)} h</li>
+        </ul>
+      )}
       <button type="button" onClick={download}>
         Download
       </button>


### PR DESCRIPTION
## Summary
- implement compute_performance_metrics for yield/hour, efficiency, and electrode lifetime
- expose KPIs in EfficiencyCurveOverlay UI
- test KPI calculations

## Testing
- `pytest tests/diagnostics/test_performance_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e4762ba8832aab94b3547665fd0c