### PR TITLE
Add lab mode manifest API and frontend component

### DIFF
--- a/src/dpf2/web/__init__.py
+++ b/src/dpf2/web/__init__.py
@@ -1,5 +1,9 @@
 """Lightweight web dashboard for running simulations."""
 
-from .app import create_app
-
-__all__ = ["create_app"]
+# ``create_app`` depends on optional ``flask``. Import lazily so downstream
+# modules like :mod:`lab_mode_api` can be used without the dependency.
+try:  # pragma: no cover - exercised in integration tests
+    from .app import create_app
+    __all__ = ["create_app"]
+except Exception:  # pragma: no cover - flask not installed
+    __all__: list[str] = []

--- a/src/dpf2/web/lab_mode_api.py
+++ b/src/dpf2/web/lab_mode_api.py
@@ -1,0 +1,78 @@
+"""Utilities for managing lab-mode manifests via a simple API."""
+from __future__ import annotations
+
+import json
+import random
+import zipfile
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from ..cli.lab import _code_hash
+
+
+def generate_manifest(config: Mapping[str, object], *, seed: int | None = None) -> dict[str, object]:
+    """Generate a single manifest describing a run.
+
+    Parameters
+    ----------
+    config:
+        Configuration mapping used for the run.
+    seed:
+        Optional random seed. When omitted a random seed is sampled.
+    """
+    if seed is None:
+        seed = random.randint(0, 2**32 - 1)
+    return {
+        "code_hash": _code_hash(),
+        "inputs": dict(config),
+        "random_seeds": {"python": int(seed)},
+    }
+
+
+def generate_manifest_bundle(
+    configs: Sequence[Mapping[str, object]],
+    *,
+    seeds: Sequence[int] | None = None,
+) -> list[dict[str, object]]:
+    """Generate manifests for a batch of configurations."""
+    bundle: list[dict[str, object]] = []
+    for idx, cfg in enumerate(configs):
+        seed = seeds[idx] if seeds and idx < len(seeds) else None
+        bundle.append(generate_manifest(cfg, seed=seed))
+    return bundle
+
+
+def export_manifest_bundle(
+    configs: Sequence[Mapping[str, object]],
+    output: str | Path,
+    *,
+    seeds: Sequence[int] | None = None,
+) -> Path:
+    """Write a zip bundle containing inputs and manifests for each run.
+
+    Parameters
+    ----------
+    configs:
+        Sequence of configuration dictionaries to include.
+    output:
+        Path to the zip file that should be written.
+    seeds:
+        Optional sequence of RNG seeds corresponding to ``configs``.
+    """
+    manifests = generate_manifest_bundle(configs, seeds=seeds)
+    out_path = Path(output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(out_path, "w") as z:
+        for idx, (cfg, manifest) in enumerate(zip(configs, manifests)):
+            cfg_name = f"inputs_{idx}.json"
+            manifest_name = f"run_manifest_{idx}.json"
+            z.writestr(cfg_name, json.dumps(cfg, indent=2))
+            z.writestr(manifest_name, json.dumps(manifest, indent=2))
+    return out_path
+
+
+__all__ = [
+    "generate_manifest",
+    "generate_manifest_bundle",
+    "export_manifest_bundle",
+]

--- a/tests/web/test_lab_mode_api.py
+++ b/tests/web/test_lab_mode_api.py
@@ -1,0 +1,34 @@
+import json
+import zipfile
+
+from dpf2.web.lab_mode_api import (
+    generate_manifest,
+    generate_manifest_bundle,
+    export_manifest_bundle,
+)
+
+
+def test_generate_manifest_bundle():
+    configs = [{"a": 1}, {"a": 2}]
+    seeds = [42, 43]
+    bundle = generate_manifest_bundle(configs, seeds=seeds)
+    assert bundle[0]["inputs"] == {"a": 1}
+    assert bundle[1]["random_seeds"]["python"] == 43
+    assert bundle[0]["code_hash"]
+
+
+def test_generate_manifest():
+    manifest = generate_manifest({"b": 3}, seed=99)
+    assert manifest["inputs"]["b"] == 3
+    assert manifest["random_seeds"]["python"] == 99
+
+
+def test_export_manifest_bundle(tmp_path):
+    configs = [{"x": 10}]
+    zip_path = export_manifest_bundle(configs, tmp_path / "bundle.zip", seeds=[123])
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path, "r") as z:
+        assert "inputs_0.json" in z.namelist()
+        manifest = json.loads(z.read("run_manifest_0.json"))
+        assert manifest["inputs"]["x"] == 10
+        assert manifest["random_seeds"]["python"] == 123

--- a/web/frontend/src/LabMode.jsx
+++ b/web/frontend/src/LabMode.jsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+
+export default function LabMode({ token }) {
+  const [configs, setConfigs] = useState(['{}']);
+  const [useJitter, setUseJitter] = useState(false);
+  const [switchJitter, setSwitchJitter] = useState(0.0);
+  const [pressureJitter, setPressureJitter] = useState(0.0);
+
+  const addRun = () => setConfigs((c) => [...c, '{}']);
+
+  const updateConfig = (idx, value) => {
+    setConfigs((c) => c.map((cfg, i) => (i === idx ? value : cfg)));
+  };
+
+  const exportBundle = async () => {
+    const runs = configs.map((text) => {
+      const cfg = JSON.parse(text || '{}');
+      if (useJitter) {
+        cfg.experimental_variability = {
+          pressure_jitter_pct: pressureJitter,
+          trigger_jitter_ns: switchJitter,
+        };
+      }
+      return cfg;
+    });
+    const { data } = await axios.post(
+      '/lab-mode/manifests',
+      { runs },
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        responseType: 'blob',
+      }
+    );
+    const url = window.URL.createObjectURL(new Blob([data]));
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'manifest_bundle.zip';
+    a.click();
+    window.URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div>
+      <h3>Lab Mode</h3>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={useJitter}
+            onChange={(e) => setUseJitter(e.target.checked)}
+          />
+          Enable Jitter
+        </label>
+        {useJitter && (
+          <div>
+            <label>
+              Switch Jitter (ns)
+              <input
+                type="number"
+                value={switchJitter}
+                onChange={(e) => setSwitchJitter(parseFloat(e.target.value))}
+              />
+            </label>
+            <label>
+              Pressure Jitter (%)
+              <input
+                type="number"
+                value={pressureJitter}
+                onChange={(e) => setPressureJitter(parseFloat(e.target.value))}
+              />
+            </label>
+          </div>
+        )}
+      </div>
+      {configs.map((cfg, idx) => (
+        <div key={idx}>
+          <h4>Run {idx + 1}</h4>
+          <textarea
+            rows={6}
+            cols={40}
+            value={cfg}
+            onChange={(e) => updateConfig(idx, e.target.value)}
+          />
+        </div>
+      ))}
+      <button type="button" onClick={addRun}>
+        Add Run
+      </button>
+      <button type="button" onClick={exportBundle} disabled={!token}>
+        Export Manifest Bundle
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add LabMode React component for jitter controls and batch manifest export
- provide lab_mode_api utilities to build run manifests and zipped bundles
- relax web package import to avoid optional flask dependency
- test manifest generation and export

## Testing
- `pytest tests/web/test_lab_mode_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e4825a4c832a925dd9bf13cf9ba6