### PR TITLE
feat: expand circuit driver capabilities

### DIFF
--- a/examples/circuit/advanced_driver.ipynb
+++ b/examples/circuit/advanced_driver.ipynb
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Advanced Driver\n",
+    "Demonstrates multi-section RLC blocks, transmission-line segments and crowbar stages."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dpf2.circuit import TransmissionLineSegment, CrowbarStage\n",
+    "from dpf2.rlc_solver import solve_distributed_circuit\n",
+    "segments = [\n",
+    "    TransmissionLineSegment(0,1,length=1.0,L_per_m=1e-6,R_per_m=0.0,C_per_m=0.0),\n",
+    "    TransmissionLineSegment(1,2,length=1.0,L_per_m=0.0,R_per_m=0.0,C_per_m=1e-6),\n",
+    "]\n",
+    "crowbar = CrowbarStage(0,2,resistance=1e-3,trigger_time=1e-6)\n",
+    "res = solve_distributed_circuit(segments,[crowbar],V0=1e3,t_end=2e-6,dt=1e-7)\n",
+    "res.current[:5]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dpf2/circuit/__init__.py
+++ b/src/dpf2/circuit/__init__.py
@@ -1,7 +1,13 @@
 
 """Circuit subpackage providing models for distributed networks."""
 
-from .distributed import TransmissionLineSegment, TriggeredSwitch, assemble_matrices
+from .distributed import TransmissionLineSegment, assemble_matrices
+from .switches import TriggeredSwitch, CrowbarStage
 
-__all__ = ["TransmissionLineSegment", "TriggeredSwitch", "assemble_matrices"]
+__all__ = [
+    "TransmissionLineSegment",
+    "TriggeredSwitch",
+    "CrowbarStage",
+    "assemble_matrices",
+]
 

--- a/src/dpf2/circuit/distributed.py
+++ b/src/dpf2/circuit/distributed.py
@@ -21,7 +21,7 @@ simple – topology is ignored and all elements are assumed to be in series –
 which is perfectly adequate for the unit tests that exercise this module.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Iterable, Sequence, List, Any
 
 import numpy as np
@@ -30,6 +30,7 @@ import cmath
 import warnings
 
 from dpf2.core.bases import PlasmaSolverBase
+from .switches import TriggeredSwitch, CrowbarStage
 
 __all__ = [
     "TransmissionLineSegment",
@@ -209,93 +210,6 @@ class TransmissionLineSegment:
             return 1.0 + 0.0j
         ZL = complex(Z_load)
         return (ZL - Z0) / (ZL + Z0)
-
-
-@dataclass
-class TriggeredSwitch:
-    """Ideal resistive switch with optional trigger times and parasitics."""
-
-    from_node: int
-    to_node: int
-    closed: bool = True
-    R_on: float = 1e-3
-    R_off: float = 1e6
-    trigger_times: Sequence[float] | None = None
-    trigger_time: float | None = None  # backward compatible single trigger
-    jitter_std: float = 0.0
-    arc_resistance: float = 0.0
-    L_parasitic: float = 0.0
-    R_parasitic: float = 0.0
-    C_parasitic: float = 0.0
-    _next_trigger: int = field(init=False, default=0)
-    _closed_since: float | None = field(init=False, default=None)
-
-    def __post_init__(self) -> None:
-        # Allow ``trigger_time`` alias for a single entry
-        if self.trigger_times is None:
-            if self.trigger_time is not None:
-                self.trigger_times = [self.trigger_time]
-            else:
-                self.trigger_times = []
-        else:
-            self.trigger_times = list(self.trigger_times)
-            if self.trigger_time is not None:
-                self.trigger_times.append(self.trigger_time)
-        # Optional Gaussian jitter applied to trigger times
-        if self.jitter_std > 0.0 and self.trigger_times:
-            jitter = np.random.normal(0.0, self.jitter_std, len(self.trigger_times))
-            self.trigger_times = [t + j for t, j in zip(self.trigger_times, jitter)]
-        # Ensure times are in ascending order for efficient processing
-        self.trigger_times = sorted(self.trigger_times)
-
-    # ------------------------------------------------------------------
-    def update(self, t: float) -> None:
-        """Update the switch state based on ``t``.
-
-        Every time a trigger time is crossed the state is toggled.  The update
-        is idempotent: calling it multiple times with the same ``t`` has no
-        effect.
-        """
-
-        while self._next_trigger < len(self.trigger_times) and t >= self.trigger_times[self._next_trigger]:
-            self.closed = not self.closed
-            # Track time since closure for arc resistance evolution
-            self._closed_since = t if self.closed else None
-            self._next_trigger += 1
-
-    # ------------------------------------------------------------------
-    def resistance(self, t: float | None = None) -> float:
-        """Return instantaneous resistance including parasitic component."""
-
-        if t is not None:
-            self.update(t)
-        base = self.R_on if self.closed else self.R_off
-        if self.closed and self.arc_resistance > 0.0 and self._closed_since is not None and t is not None:
-            base += self.arc_resistance * max(0.0, t - self._closed_since)
-        return base + self.R_parasitic
-
-
-@dataclass
-class CrowbarStage(TriggeredSwitch):
-    """Resistive crowbar stage engaging at ``trigger_time`` with optional jitter."""
-
-    def __init__(
-        self,
-        from_node: int,
-        to_node: int,
-        resistance: float,
-        trigger_time: float,
-        jitter_std: float = 0.0,
-    ) -> None:
-        super().__init__(
-            from_node=from_node,
-            to_node=to_node,
-            closed=False,
-            R_on=resistance,
-            R_off=1e12,
-            trigger_times=[trigger_time],
-            jitter_std=jitter_std,
-        )
 
 
 @dataclass

--- a/src/dpf2/circuit/switches.py
+++ b/src/dpf2/circuit/switches.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+"""Switch models for the distributed circuit solver.
+
+This module exposes a minimal subset of the behaviour of the real project in a
+form that is sufficient for the unit tests.  Two switch types are provided:
+
+``TriggeredSwitch``
+    Generic resistive switch which can change its state at specified trigger
+    times.  Each trigger time may be subjected to optional Gaussian jitter.  The
+    switch can also model arc growth by increasing its on--resistance linearly
+    with time after closure.
+
+``CrowbarStage``
+    Convenience wrapper representing a crowbar branch that engages at a given
+    trigger time with a fixed resistance.
+
+The classes here mirror the implementations previously embedded in
+``circuit.distributed`` but are factored out to keep the solver logic focused on
+network assembly.
+"""
+
+from dataclasses import dataclass, field
+from typing import Sequence
+
+import numpy as np
+
+__all__ = ["TriggeredSwitch", "CrowbarStage"]
+
+
+# ---------------------------------------------------------------------------
+# Base switch model
+
+
+@dataclass
+class TriggeredSwitch:
+    """Ideal resistive switch with optional trigger times and parasitics.
+
+    Parameters
+    ----------
+    from_node, to_node:
+        Node identifiers the switch connects.
+    closed:
+        Initial state of the switch.
+    R_on, R_off:
+        Resistance when the switch is closed or open respectively.
+    trigger_times:
+        Sequence of times (in seconds) at which the state toggles.  Gaussian
+        jitter with standard deviation ``jitter_std`` may be applied to each
+        trigger time.
+    arc_resistance:
+        Optional linear increase of the on--resistance after the switch has
+        closed to emulate arc growth.  The value represents Ohms per second.
+    L_parasitic, R_parasitic, C_parasitic:
+        Optional lumped parasitic components associated with the switch.
+    """
+
+    from_node: int
+    to_node: int
+    closed: bool = True
+    R_on: float = 1e-3
+    R_off: float = 1e6
+    trigger_times: Sequence[float] | None = None
+    trigger_time: float | None = None  # backward compatible single trigger
+    jitter_std: float = 0.0
+    arc_resistance: float = 0.0
+    L_parasitic: float = 0.0
+    R_parasitic: float = 0.0
+    C_parasitic: float = 0.0
+
+    _next_trigger: int = field(init=False, default=0)
+    _closed_since: float | None = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        # Allow ``trigger_time`` alias for a single entry
+        if self.trigger_times is None:
+            if self.trigger_time is not None:
+                self.trigger_times = [self.trigger_time]
+            else:
+                self.trigger_times = []
+        else:
+            self.trigger_times = list(self.trigger_times)
+            if self.trigger_time is not None:
+                self.trigger_times.append(self.trigger_time)
+        # Apply optional Gaussian jitter
+        if self.jitter_std > 0.0 and self.trigger_times:
+            jitter = np.random.normal(0.0, self.jitter_std, len(self.trigger_times))
+            self.trigger_times = [t + j for t, j in zip(self.trigger_times, jitter)]
+        self.trigger_times = sorted(self.trigger_times)
+
+    # ------------------------------------------------------------------
+    def update(self, t: float) -> None:
+        """Update the switch state based on ``t``.
+
+        Every time a trigger time is crossed the switch toggles.  The update is
+        idempotent so calling it multiple times with the same ``t`` is safe.
+        """
+
+        while self._next_trigger < len(self.trigger_times) and t >= self.trigger_times[self._next_trigger]:
+            self.closed = not self.closed
+            self._closed_since = t if self.closed else None
+            self._next_trigger += 1
+
+    # ------------------------------------------------------------------
+    def resistance(self, t: float | None = None) -> float:
+        """Return instantaneous resistance including parasitic component."""
+
+        if t is not None:
+            self.update(t)
+        base = self.R_on if self.closed else self.R_off
+        if (
+            self.closed
+            and self.arc_resistance > 0.0
+            and self._closed_since is not None
+            and t is not None
+        ):
+            base += self.arc_resistance * max(0.0, t - self._closed_since)
+        return base + self.R_parasitic
+
+
+# ---------------------------------------------------------------------------
+# Crowbar stage convenience wrapper
+
+
+@dataclass
+class CrowbarStage(TriggeredSwitch):
+    """Resistive crowbar stage engaging at ``trigger_time`` with optional jitter."""
+
+    def __init__(
+        self,
+        from_node: int,
+        to_node: int,
+        resistance: float,
+        trigger_time: float,
+        jitter_std: float = 0.0,
+    ) -> None:
+        super().__init__(
+            from_node=from_node,
+            to_node=to_node,
+            closed=False,
+            R_on=resistance,
+            R_off=1e12,
+            trigger_times=[trigger_time],
+            jitter_std=jitter_std,
+        )

--- a/src/dpf2/circuit_config.py
+++ b/src/dpf2/circuit_config.py
@@ -351,6 +351,16 @@ class CircuitConfig(ConfigSectionBase):
     def get_field_metadata(self) -> Dict[str, Dict[str, object]]:
         return {name: (field.json_schema_extra or field.metadata or {}) for name, field in self.model_fields.items()}
 
+    # Pydantic ``model_copy`` behaviour is inconsistent across the lightweight
+    # testing stubs and different pydantic versions.  Implement a small wrapper
+    # that always honours the ``update`` argument so tests can create modified
+    # configurations without depending on the underlying library.
+    def model_copy(self, update: Dict[str, object] | None = None, **kwargs) -> "CircuitConfig":
+        data = self.model_dump()
+        if update:
+            data.update(update)
+        return type(self)(**data)
+
     def summarize(self) -> str:
         w_desc = "none"
         if self.waveform_profile is not None:

--- a/src/dpf2/circuit_solver.py
+++ b/src/dpf2/circuit_solver.py
@@ -60,6 +60,8 @@ from .core.circuit import RLCCircuitSolver
 from .core.bases import PlasmaSolverBase, CouplingState
 
 from .geometry.inductance import loop_mutual_inductance
+from .circuit import TransmissionLineSegment, CrowbarStage, TriggeredSwitch
+from .rlc_solver import solve_distributed_circuit
 
 
 __all__ = ["CircuitSolver", "RLCCircuit", "run_circuit_simulation"]
@@ -324,12 +326,59 @@ def run_circuit_simulation(
         mutual-induced voltage [V].
     """
 
-    if cfg.segments:
-        # Build distributed model and delegate to the lightweight solver
-        segments, switches = cfg.build_distributed_model()
+    # ------------------------------------------------------------------
+    # Distributed multi‑section circuit handling
+    if getattr(cfg, "segments", None) or getattr(cfg, "rlc_sections", None) or getattr(cfg, "crowbar_stages", None):
+        segments: list[TransmissionLineSegment] = []
+        switches: list[CrowbarStage | TriggeredSwitch] = []
+
+        # Existing transmission line segments defined via configuration
+        if getattr(cfg, "segments", None):
+            segs, sws = cfg.build_distributed_model()
+            segments.extend(segs)
+            switches.extend(sws)
+
+        # Optional multi‑section lumped elements
+        secs = getattr(cfg, "rlc_sections", None)
+        if secs:
+            node = 0
+            for sec in secs:
+                L = sec.get("L", 0.0)
+                R = sec.get("R", 0.0)
+                C = sec.get("C", 0.0)
+                segments.append(
+                    TransmissionLineSegment(
+                        from_node=node,
+                        to_node=node + 1,
+                        length=1.0,
+                        L_per_m=L,
+                        R_per_m=R,
+                        C_per_m=C,
+                    )
+                )
+                node += 1
+
+        # Optional crowbar stages connecting source to return
+        cbs = getattr(cfg, "crowbar_stages", None)
+        if cbs:
+            if segments:
+                src_node = segments[0].from_node
+                last_node = segments[-1].to_node
+            else:
+                src_node, last_node = 0, 1
+            for stage in cbs:
+                res = stage.get("resistance", 0.0)
+                trig = stage.get("trigger", 0.0)
+                switches.append(CrowbarStage(src_node, last_node, res, trig))
+
         dt = t_end * 1e-6 / (num_points - 1)
         sol = solve_distributed_circuit(
-            segments, switches, V0=cfg.V0 * 1e3, t_end=t_end * 1e-6, dt=dt
+            segments,
+            switches,
+            V0=cfg.V0 * 1e3,
+            t_end=t_end * 1e-6,
+            dt=dt,
+            em_solver=plasma_solver,
         )
         z = np.zeros_like(sol.current)
         return sol.t, sol.current, sol.voltage, z, z
@@ -353,14 +402,27 @@ def run_circuit_simulation(
     v_hist = [voltage]
     im_hist = [Im_val(0.0)]
     vm_hist = [0.0]
+    prev_Lp = Lp_val(0.0)
 
     for t in t_total[1:]:
-        Lp = Lp_val(t)
-        dLpdt = Lp_der(t)
+        if plasma_solver is not None:
+            plasma_state = plasma_solver.step(plasma_state, dt, current, voltage)
+            fb = plasma_solver.coupling_interface()
+            Lp = getattr(fb, "Lp", 0.0)
+            emf = getattr(fb, "emf", 0.0)
+            back_emf = getattr(fb, "back_reaction", 0.0)
+            dLpdt = (Lp - prev_Lp) / dt if dt > 0 else 0.0
+            prev_Lp = Lp
+            M = getattr(fb, "mutual_inductance", 0.0)
+        else:
+            Lp = Lp_val(t)
+            dLpdt = Lp_der(t)
+            M = M_val(t)
+            back_emf = M * Im_der(t) + Im_val(t) * M_der(t)
+            emf = 0.0
+
         Ltot = L_ext + Lp
-        M = M_val(t)
-        back_emf = M * Im_der(t) + Im_val(t) * M_der(t)
-        dIdt = (voltage - R_ext * current - back_emf - current * dLpdt) / Ltot
+        dIdt = (voltage - R_ext * current - back_emf - current * dLpdt - emf) / Ltot
         dVdt = -current / C_ext
         current += dIdt * dt
         voltage += dVdt * dt

--- a/src/dpf2/rlc_solver.py
+++ b/src/dpf2/rlc_solver.py
@@ -499,6 +499,11 @@ def solve_distributed_circuit(
             currents[k, :] += fb.back_reaction
             node_voltages[k, :] += fb.voltage
             plasma_L = getattr(fb, "Lp", plasma_L)
+            if hasattr(em_solver, "plasma_inductance"):
+                try:
+                    plasma_L = float(em_solver.plasma_inductance(em_state))
+                except Exception:
+                    pass
 
         total_I[k] = tot
 


### PR DESCRIPTION
## Summary
- add switch models with jitter and arc-growth resistance
- support multi-section RLC and crowbar stages in circuit solver
- feed HallMHD plasma inductance back into circuit
- provide advanced circuit driver notebook example

## Testing
- `PYTHONPATH=src ./venv/bin/pytest tests/test_rlc_solver.py tests/test_plasma_inductance_coupling.py tests/test_circuit_multisection.py tests/test_distributed_circuit.py`

------
https://chatgpt.com/codex/tasks/task_e_68b9e457c070832a8164ed8effa8b621