### PR TITLE
Track LH drift power and plasma impedance

### DIFF
--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -19,6 +19,7 @@ from .neutron_yield import (
     simulate_tof_detectors,
     save_tof_hdf5,
     tof_iv_cross_correlation,
+    ez_beam_correlation,
     angular_yield_map,
     save_angular_yield_map_hdf5,
 )
@@ -90,6 +91,7 @@ __all__ = [
     "simulate_tof_detectors",
     "save_tof_hdf5",
     "tof_iv_cross_correlation",
+    "ez_beam_correlation",
     "angular_yield_map",
     "save_angular_yield_map_hdf5",
     "compute_performance_metrics",

--- a/src/dpf2/diagnostics/neutron_yield.py
+++ b/src/dpf2/diagnostics/neutron_yield.py
@@ -351,6 +351,32 @@ def tof_iv_cross_correlation(
     }
 
 
+def ez_beam_correlation(
+    ez: Sequence[float],
+    ion_beam: Sequence[float],
+    electron_beam: Sequence[float],
+) -> Dict[str, float]:
+    """Return zero-lag correlation between ``E_z`` and beam signals."""
+
+    if not (len(ez) == len(ion_beam) == len(electron_beam)):
+        raise ValueError("signals must have the same length")
+
+    def _corr(a: Sequence[float], b: Sequence[float]) -> float:
+        mean_a = sum(a) / len(a)
+        mean_b = sum(b) / len(b)
+        num = sum((x - mean_a) * (y - mean_b) for x, y in zip(a, b))
+        den = math.sqrt(
+            sum((x - mean_a) ** 2 for x in a)
+            * sum((y - mean_b) ** 2 for y in b)
+        )
+        return num / den if den != 0 else 0.0
+
+    return {
+        "ion": _corr(ez, ion_beam),
+        "electron": _corr(ez, electron_beam),
+    }
+
+
 def angular_yield_map(
     ion_edf: IonBeamEDF,
     cross_section: Callable[[float], float],
@@ -399,6 +425,7 @@ __all__ = [
     "simulate_tof_detectors",
     "save_tof_hdf5",
     "tof_iv_cross_correlation",
+    "ez_beam_correlation",
     "angular_yield_map",
     "save_angular_yield_map_hdf5",
 ]

--- a/src/dpf2/diagnostics/quality_dashboard.py
+++ b/src/dpf2/diagnostics/quality_dashboard.py
@@ -38,7 +38,9 @@ class QualityDashboard:
         ppc: float,
         cfl: float,
         lambda_D: float,
-
+        amr_level: int | None = None,
+        lower_hybrid_power: float | None = None,
+        plasma_impedance: float | None = None,
         divergence_error: float = 0.0,
         energy_drift: float = 0.0,
 

--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -351,6 +351,8 @@ class HallMHDSolver(PlasmaSolverBase):
     impedance_growth: list[float] = field(default_factory=list)
     last_voltage_spike: float = field(init=False, default=0.0)
     last_lh_power: float = field(init=False, default=0.0)
+    last_eta_anom_mean: float = field(init=False, default=0.0)
+    last_eta_total_mean: float = field(init=False, default=0.0)
     last_pressure: np.ndarray | None = field(init=False, default=None)
     last_ionization: np.ndarray | None = field(init=False, default=None)
     last_rad_loss: np.ndarray | None = field(init=False, default=None)
@@ -459,6 +461,10 @@ class HallMHDSolver(PlasmaSolverBase):
             self.voltage_spikes.append(spike)
         self.last_voltage_spike = spike
         self.last_E_anom = E
+        try:
+            self.last_eta_anom_mean = float(np.mean(eta))
+        except Exception:
+            self.last_eta_anom_mean = 0.0
         return eta
 
     # ------------------------------------------------------------------
@@ -721,6 +727,10 @@ class HallMHDSolver(PlasmaSolverBase):
         )
         eta_anom = self.compute_anomalous_resistivity(J)
         eta_total = eta_local + eta_anom
+        try:
+            self.last_eta_total_mean = float(np.mean(eta_total))
+        except Exception:
+            self.last_eta_total_mean = 0.0
         E = -np.cross(v, B) + eta_total[..., None] * J - grad_pe_vec / ne[..., None]
         if self.last_E_anom is not None:
             E += self.last_E_anom
@@ -863,7 +873,7 @@ class HallMHDSolver(PlasmaSolverBase):
             lambda_D = np.sqrt(epsilon_0 * k * T / (ne * e**2))
             ppc = float(np.mean(ne) * cell_volume)
             lh_power = self.last_lh_power
-            impedance = self.impedance_growth[-1] if self.impedance_growth else 0.0
+            impedance = self.last_eta_total_mean
             self.quality.log(
                 self.step_count,
                 dt,
@@ -871,7 +881,9 @@ class HallMHDSolver(PlasmaSolverBase):
                 ppc,
                 cfl,
                 float(np.mean(lambda_D)),
-
+                amr_level=getattr(self, "amr_level", None),
+                lower_hybrid_power=lh_power,
+                plasma_impedance=impedance,
                 divergence_error=getattr(self, "divergence_error", 0.0),
                 energy_drift=getattr(self, "energy_drift", 0.0),
 

--- a/src/dpf2/physics/lower_hybrid_drift.py
+++ b/src/dpf2/physics/lower_hybrid_drift.py
@@ -43,6 +43,7 @@ class LowerHybridDrift:
     energy: Any | None = None  # Stored wave energy
     last_k: Any | None = None  # Wave number of last evolution
     last_phase_velocity: Any | None = None  # Cached phase velocity
+    last_power: Any | None = None  # Cached wave power
 
     def frequency(self) -> float:
         omega_ci = e * self.B / self.m_i
@@ -63,6 +64,14 @@ class LowerHybridDrift:
         self.amplitude = evolved
         self.last_k = ks
         self.wave_energy()  # update stored energy
+        try:
+            self.phase_velocity(ks)
+        except Exception:  # pragma: no cover - numpy stub limitations
+            self.last_phase_velocity = None
+        try:
+            self.last_power = self.power()
+        except Exception:  # pragma: no cover - numpy stub limitations
+            self.last_power = None
         return evolved
 
     # ------------------------------------------------------------------
@@ -82,7 +91,10 @@ class LowerHybridDrift:
         if k is None:
             k = self.last_k if self.last_k is not None else 0.0
         ks = _to_array(k)
-        with np.errstate(divide="ignore", invalid="ignore"):
+        try:  # pragma: no cover - optional errstate
+            with np.errstate(divide="ignore", invalid="ignore"):
+                vel = self.frequency() / ks
+        except Exception:  # pragma: no cover - numpy stub lacks errstate
             vel = self.frequency() / ks
         self.last_phase_velocity = vel
         return vel
@@ -91,7 +103,9 @@ class LowerHybridDrift:
         """Return a simple estimate of wave power ``energy * ω``."""
 
         energy = self.wave_energy()
-        return energy * self.frequency()
+        p = energy * self.frequency()
+        self.last_power = p
+        return p
 
 
 

--- a/tests/diagnostics/test_ez_beam_correlation.py
+++ b/tests/diagnostics/test_ez_beam_correlation.py
@@ -1,0 +1,10 @@
+from dpf2.diagnostics import ez_beam_correlation
+
+
+def test_ez_beam_correlation_basic():
+    ez = [0.0, 1.0, 2.0, 3.0]
+    ion = [0.0, 2.0, 4.0, 6.0]
+    electron = [3.0, 2.0, 1.0, 0.0]
+    corr = ez_beam_correlation(ez, ion, electron)
+    assert corr["ion"] > 0.9
+    assert corr["electron"] < -0.9


### PR DESCRIPTION
## Summary
- track wave energy, power and phase velocity in the lower-hybrid drift model
- expose Ez-beam correlation diagnostics and log plasma impedance in QualityDashboard
- propagate effective resistivity and impedance metrics through HallMHDSolver

## Testing
- `pytest tests/diagnostics/test_ez_beam_correlation.py tests/test_quality_dashboard.py tests/physics/test_instabilities.py::test_lower_hybrid_grid_evolution -q`
- `pytest tests/diagnostics/test_ez_beam_correlation.py tests/test_quality_dashboard.py tests/physics/test_anomalous_resistivity.py tests/physics/test_instabilities.py tests/test_hall_mhd_solver.py tests/solvers/test_hall_mhd.py -q` *(fails: AttributeError and TypeError in HallMHDSolver tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e8c816e8832ab94af146a2856e79