### PR TITLE
Add neutron diagnostics and yield uncertainty support

### DIFF
--- a/src/dpf2/diagnostics/neutron.py
+++ b/src/dpf2/diagnostics/neutron.py
@@ -1,9 +1,22 @@
+"""Lightweight neutron diagnostic helpers."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Sequence, List, Dict, Any
 import json
+
+# Re-export core synthesis utilities from :mod:`neutron_spectra`
+from .neutron_spectra import (
+    Detector,
+    DetectorLayout,
+    synthetic_tof_spectrum,
+    angular_spectrum,
+    anisotropy_metric,
+    forward_radial_backward_counts,
+    anisotropy_ratios,
+    load_detector_layout,
+)
 
 
 def load_response(path: str | Path) -> Dict[str, Any]:
@@ -70,5 +83,44 @@ def apply_response(
 
     return vals
 
-__all__ = ["load_response", "apply_response"]
+
+def anisotropy_report(
+    layout: DetectorLayout,
+    spectra: Dict[str, Sequence[float]],
+) -> Dict[str, Any]:
+    """Aggregate detector counts and compute anisotropy metrics.
+
+    Parameters
+    ----------
+    layout:
+        Detector arrangement used to determine detector orientation.
+    spectra:
+        Mapping of detector name to time-resolved counts.
+
+    Returns
+    -------
+    dict
+        A dictionary with ``"counts"`` holding forward/radial/backward totals,
+        ``"ratios"`` with simple anisotropy ratios and ``"metric"`` providing a
+        ``(max-min)/mean`` style anisotropy measure.
+    """
+
+    counts = forward_radial_backward_counts(layout, spectra)
+    ratios = anisotropy_ratios(counts)
+    metric = anisotropy_metric(list(counts.values()))
+    return {"counts": counts, "ratios": ratios, "metric": metric}
+
+__all__ = [
+    "Detector",
+    "DetectorLayout",
+    "synthetic_tof_spectrum",
+    "angular_spectrum",
+    "anisotropy_metric",
+    "forward_radial_backward_counts",
+    "anisotropy_ratios",
+    "load_detector_layout",
+    "load_response",
+    "apply_response",
+    "anisotropy_report",
+]
 

--- a/src/dpf2/neutron_yield_model.py
+++ b/src/dpf2/neutron_yield_model.py
@@ -329,20 +329,49 @@ def partition_yield(
     thermonuclear_rate: Sequence[float],
     beam_target_rate: Sequence[float],
     dt: float,
+    thermonuclear_sigma: Sequence[float] | None = None,
+    beam_target_sigma: Sequence[float] | None = None,
 ) -> Dict[str, Tuple[float, float]]:
-    """Integrate rate histories and return yields with Poisson uncertainties."""
+    """Integrate rate histories and return yields with uncertainties.
+
+    Parameters
+    ----------
+    thermonuclear_rate, beam_target_rate:
+        Rate histories sampled with timestep ``dt``.
+    dt:
+        Time step width in seconds.
+    thermonuclear_sigma, beam_target_sigma:
+        Optional per-sample uncertainties for the provided rates.  When given,
+        the uncertainties are propagated in quadrature and combined with a
+        simple Poisson estimate (``sqrt(N)``) of the counting statistics.
+    """
 
     if dt <= 0:
         raise ValueError("dt must be positive")
     if len(thermonuclear_rate) != len(beam_target_rate):
         raise ValueError("rate histories must have the same length")
+
     th = sum(float(v) for v in thermonuclear_rate) * dt
     bt = sum(float(v) for v in beam_target_rate) * dt
+
+    th_var = th if th > 0 else 0.0
+    bt_var = bt if bt > 0 else 0.0
+    if thermonuclear_sigma is not None:
+        if len(thermonuclear_sigma) != len(thermonuclear_rate):
+            raise ValueError("thermonuclear_sigma must match rate length")
+        th_var += sum((float(s) * dt) ** 2 for s in thermonuclear_sigma)
+    if beam_target_sigma is not None:
+        if len(beam_target_sigma) != len(beam_target_rate):
+            raise ValueError("beam_target_sigma must match rate length")
+        bt_var += sum((float(s) * dt) ** 2 for s in beam_target_sigma)
+
     total = th + bt
+    total_var = th_var + bt_var
+
     return {
-        "thermonuclear": (th, math.sqrt(th) if th > 0 else 0.0),
-        "beam_target": (bt, math.sqrt(bt) if bt > 0 else 0.0),
-        "total": (total, math.sqrt(total) if total > 0 else 0.0),
+        "thermonuclear": (th, math.sqrt(th_var) if th_var > 0 else 0.0),
+        "beam_target": (bt, math.sqrt(bt_var) if bt_var > 0 else 0.0),
+        "total": (total, math.sqrt(total_var) if total_var > 0 else 0.0),
     }
 
 

--- a/tests/diagnostics/test_neutron_helpers.py
+++ b/tests/diagnostics/test_neutron_helpers.py
@@ -1,0 +1,29 @@
+import math
+
+from dpf2.diagnostics.neutron import (
+    synthetic_tof_spectrum,
+    angular_spectrum,
+    anisotropy_report,
+    DetectorLayout,
+)
+
+
+def test_basic_wrappers_and_anisotropy():
+    energies = [1.0, 2.0]
+    flux = [1.0, 1.0]
+    distance = 1.0
+    time_bins = [0.0, 1.0]
+    hist = synthetic_tof_spectrum(energies, flux, distance, time_bins)
+    assert hist == [1.0]
+
+    spectrum = angular_spectrum([0.0, 90.0, 180.0], base_yield=1.0, anisotropy=1.0)
+    assert spectrum == [2.0, 1.0, 0.0]
+
+    layout = DetectorLayout(angles=[0.0, 90.0, 180.0], distance_m=1.0, names=["f", "r", "b"])
+    spectra = {"f": [1.0], "r": [1.0], "b": [1.0]}
+    report = anisotropy_report(layout, spectra)
+    counts = report["counts"]
+    assert counts["forward"] == counts["radial"] == counts["backward"]
+    assert math.isclose(report["metric"], 0.0)
+    assert report["ratios"]["forward_backward"] == 1.0
+

--- a/tests/diagnostics/test_neutron_yield.py
+++ b/tests/diagnostics/test_neutron_yield.py
@@ -17,6 +17,22 @@ def test_partition_yield_components():
     assert math.isclose(tot_u, math.sqrt(tot))
 
 
+def test_partition_yield_with_uncertainties():
+    thermo = [2.0, 2.0, 2.0]
+    beam = [1.0, 1.0, 1.0]
+    thermo_sigma = [0.5, 0.5, 0.5]
+    beam_sigma = [0.2, 0.2, 0.2]
+    res = partition_yield(thermo, beam, dt=0.5, thermonuclear_sigma=thermo_sigma, beam_target_sigma=beam_sigma)
+    th, th_u = res["thermonuclear"]
+    bt, bt_u = res["beam_target"]
+    tot, tot_u = res["total"]
+    expected_th_var = th + sum((s * 0.5) ** 2 for s in thermo_sigma)
+    expected_bt_var = bt + sum((s * 0.5) ** 2 for s in beam_sigma)
+    assert math.isclose(th_u, math.sqrt(expected_th_var))
+    assert math.isclose(bt_u, math.sqrt(expected_bt_var))
+    assert math.isclose(tot_u, math.sqrt(expected_th_var + expected_bt_var))
+
+
 def test_dd_yield_components_zero_beam():
     res = dd_yield_components(
         T_keV=10.0,


### PR DESCRIPTION
## Summary
- support per-sample uncertainty propagation when splitting neutron yields
- expose angular spectrum, time-of-flight synthesis and detector layout helpers with anisotropy reporting
- add tests for neutron diagnostics helpers

## Testing
- `pytest tests/diagnostics/test_neutron_yield.py tests/diagnostics/test_neutron_helpers.py tests/test_neutron_spectra.py tests/diagnostics/test_neutron_tof.py`

------
https://chatgpt.com/codex/tasks/task_e_68b9e8c956c8832a91dfc96cc7a48b28