### PR TITLE
Model flashover hold-off evolution and expose jitter diagnostics

### DIFF
--- a/src/dpf2/breakdown/__init__.py
+++ b/src/dpf2/breakdown/__init__.py
@@ -6,6 +6,9 @@ from .flashover import (
     seea_stochastic_delay,
     delay_series,
     delay_statistics,
+    holdoff_voltage,
+    holdoff_series,
+    jitter_statistics,
 )
 
 __all__ = [
@@ -14,4 +17,7 @@ __all__ = [
     "seea_stochastic_delay",
     "delay_series",
     "delay_statistics",
+    "holdoff_voltage",
+    "holdoff_series",
+    "jitter_statistics",
 ]

--- a/src/dpf2/breakdown/flashover.py
+++ b/src/dpf2/breakdown/flashover.py
@@ -13,6 +13,8 @@ import math
 import random
 from typing import Sequence, Dict
 
+from ..geometry import triple_junction_field
+
 
 @dataclass
 class FlashoverParameters:
@@ -96,4 +98,55 @@ def delay_statistics(delays: Sequence[float]) -> Dict[str, float]:
     mean = sum(delays) / n
     var = sum((d - mean) ** 2 for d in delays) / n
     return {"count": n, "mean": mean, "stddev": var ** 0.5}
+
+
+def holdoff_voltage(
+    geometry: str,
+    params: FlashoverParameters,
+    shot: int = 0,
+) -> float:
+    """Sample a hold-off voltage for ``geometry``.
+
+    The baseline hold-off is ``params.field_threshold`` scaled by the
+    geometry-dependent triple-junction field factor.  Conditioning is modeled
+    with :func:`conditioning_curve` such that the expected hold-off increases
+    with shot count.  A log-normal distribution with ``params.sigma`` is used
+    to introduce stochastic jitter.
+    """
+
+    if params.field_threshold <= 0:
+        raise ValueError("field_threshold must be positive")
+
+    tj_factor = triple_junction_field(geometry)
+    base = params.field_threshold * tj_factor
+    conditioned = base / conditioning_curve(shot, params.conditioning)
+    mean = max(conditioned, 1e-12)
+    mu = math.log(mean)
+    rng = random.Random(params.seed)
+    return rng.lognormvariate(mu, params.sigma)
+
+
+def holdoff_series(
+    geometry: str,
+    params: FlashoverParameters,
+    shots: int,
+) -> Sequence[float]:
+    """Generate a sequence of hold-off voltages over multiple shots."""
+
+    values = []
+    for n in range(shots):
+        p = FlashoverParameters(
+            field_threshold=params.field_threshold,
+            sigma=params.sigma,
+            conditioning=params.conditioning,
+            seed=None if params.seed is None else params.seed + n,
+        )
+        values.append(holdoff_voltage(geometry, p, shot=n))
+    return values
+
+
+def jitter_statistics(jitters: Sequence[float]) -> Dict[str, float]:
+    """Return statistics for jitter values."""
+
+    return delay_statistics(jitters)
 

--- a/src/dpf2/synthetic_diagnostics.py
+++ b/src/dpf2/synthetic_diagnostics.py
@@ -145,6 +145,15 @@ def flashover_delay_stats(delays: Sequence[float]) -> Dict[str, float]:
     return {"count": n, "mean": mean, "stddev": var ** 0.5}
 
 
+def flashover_jitter_stats(holdoffs: Sequence[float]) -> Dict[str, float]:
+    """Return jitter statistics for flashover hold-off voltages.
+
+    This simply forwards to :func:`flashover_delay_stats` for clarity.
+    """
+
+    return flashover_delay_stats(holdoffs)
+
+
 def export_directional_yields(path: Path | str, totals: Dict[str, float]) -> Path:
     """Write directional yield ``totals`` to ``path`` in JSON format."""
 

--- a/tests/breakdown/test_flashover.py
+++ b/tests/breakdown/test_flashover.py
@@ -2,13 +2,15 @@ from dpf2.breakdown.flashover import (
     FlashoverParameters,
     conditioning_curve,
     seea_stochastic_delay,
+    holdoff_voltage,
+    holdoff_series,
 )
 from dpf2.geometry import (
     triple_junction_field,
     set_triple_junction_field_map,
 )
 from dpf2.dpf_config import BreakdownModel
-from dpf2.synthetic_diagnostics import flashover_delay_stats
+from dpf2.synthetic_diagnostics import flashover_delay_stats, flashover_jitter_stats
 
 def test_conditioning_curve_monotonic():
     vals = [conditioning_curve(i, 0.1) for i in range(5)]
@@ -39,3 +41,20 @@ def test_flashover_delay_stats():
     assert stats["count"] == 3
     assert abs(stats["mean"] - 3.0) < 1e-12
     assert "stddev" in stats and stats["stddev"] > 0
+
+
+def test_holdoff_voltage_evolves_and_geometry_factor():
+    params = FlashoverParameters(field_threshold=10.0, sigma=0.0, conditioning=0.1, seed=123)
+    h0 = holdoff_voltage("mather", params, shot=0)
+    h5 = holdoff_voltage("mather", params, shot=5)
+    h_geom = holdoff_voltage("tapered", params, shot=0)
+    assert h5 > h0
+    assert h_geom > h0
+
+
+def test_flashover_jitter_stats():
+    params = FlashoverParameters(field_threshold=10.0, sigma=0.2, conditioning=0.0, seed=1)
+    series = holdoff_series("mather", params, shots=5)
+    stats = flashover_jitter_stats(series)
+    assert stats["count"] == 5
+    assert stats["stddev"] > 0


### PR DESCRIPTION
## Summary
- Extend flashover breakdown model with hold-off voltage sampling including triple-junction field factors and conditioning
- Provide utilities to generate hold-off voltage series and jitter statistics
- Surface flashover jitter statistics in `synthetic_diagnostics`
- Add regression tests for hold-off evolution and jitter reporting

## Testing
- `pytest tests/breakdown/test_flashover.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9e8cb5398832a8f4761497107e1a7