### PR TITLE
Integrate performance and regime diagnostics

### DIFF
--- a/src/dpf2/diagnostics/regime_panel.py
+++ b/src/dpf2/diagnostics/regime_panel.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 import logging
 from typing import Dict
 
@@ -102,4 +103,58 @@ class RegimePanel:
         entry["violations"] = violations
 
         return entry
+
+    # ------------------------------------------------------------------
+    def plot(self, path: str | Path) -> Path:
+        """Render the logged regime parameters versus time.
+
+        Parameters
+        ----------
+        path:
+            Destination for the generated plot.  Parent directories are
+            created automatically.  The plot contains six subplots for the
+            Lundquist number ``S``, plasma beta ``β``, Alfvén Mach number
+            ``M_A``, magnetic Reynolds number ``R_m``, Knudsen number ``K_n``
+            and the magnetisation parameter ``ω_ce τ_e``.
+
+        Returns
+        -------
+        Path
+            The path where the plot was written.  If matplotlib is unavailable
+            the file is not created but the path is still returned.
+        """
+
+        try:  # pragma: no cover - matplotlib optional
+            import matplotlib
+            matplotlib.use("Agg")
+            import matplotlib.pyplot as plt
+        except Exception:  # pragma: no cover - gracefully handle missing dep
+            return Path(path)
+
+        if not self.history:
+            raise ValueError("no regime data logged")
+
+        steps = [h["step"] for h in self.history]
+        metrics = [
+            ("S", "Lundquist"),
+            ("beta", "beta"),
+            ("M_A", "M_A"),
+            ("R_m", "R_m"),
+            ("K_n", "K_n"),
+            ("omega_ce_tau_e", "ω_ce τ_e"),
+        ]
+
+        fig, axes = plt.subplots(3, 2, sharex=True)
+        for ax, (key, label) in zip(axes.flat, metrics):
+            ax.plot(steps, [h[key] for h in self.history])
+            ax.set_ylabel(label)
+        axes[2, 0].set_xlabel("step")
+        axes[2, 1].set_xlabel("step")
+        fig.tight_layout()
+
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        fig.savefig(p)
+        plt.close(fig)
+        return p
 

--- a/src/dpf2/optimization/param_sweep.py
+++ b/src/dpf2/optimization/param_sweep.py
@@ -9,6 +9,7 @@ from dataclasses import asdict
 from ..core.config import DPFConfig
 from ..core.simulation import DPFSimulation
 from dpf2.cli.lab import write_manifest
+from ..diagnostics import compute_performance_metrics
 import random
 import numpy as np
 
@@ -133,6 +134,9 @@ def compute_sweep_metrics(
 
     metrics: Dict[float, Dict[str, float]] = {}
     energy_in = 0.5 * base_config.capacitance * base_config.charging_voltage**2
+    rep_rate = getattr(base_config, "rep_rate_hz", 1.0)
+    electrode_mass = getattr(base_config, "electrode_mass_g", 100.0)
+    erosion_per_shot = getattr(base_config, "erosion_per_shot_g", 0.01)
 
     for val, (t, current, voltage) in results.items():
         t_arr = np.array(t)
@@ -144,10 +148,19 @@ def compute_sweep_metrics(
         peak_idx = int(i_arr.argmax()) if len(i_arr) else 0
         yield_est = float(i_arr[peak_idx])
         pinch_time = float(t_arr[peak_idx]) if len(t_arr) else 0.0
+        perf = compute_performance_metrics(
+            yield_est,
+            rep_rate_hz=rep_rate,
+            energy_out_j=energy_out,
+            energy_in_j=energy_in,
+            electrode_mass_g=electrode_mass,
+            erosion_per_shot_g=erosion_per_shot,
+        )
         metric = {
             "yield": yield_est,
             "efficiency": efficiency,
             "pinch_time": pinch_time,
+            **perf,
         }
         if parameter == "initial_pressure":
             pressure = val

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from dpf2.dpf_config import DPFConfig
 from dpf2.optimization.param_sweep import compute_sweep_metrics
+from dpf2.diagnostics import RegimePanel
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 AUDIT_LOG = BASE_DIR / "audit.log"
@@ -32,6 +33,7 @@ progress_clients: Dict[str, set[WebSocket]] = {}
 diagnostic_clients: Dict[str, set[WebSocket]] = {}
 sweep_clients: Dict[str, set[WebSocket]] = {}
 sweep_results: Dict[str, Dict[float, Dict[str, float]]] = {}
+regime_clients: set[WebSocket] = set()
 
 
 def get_current_user(token: str = Depends(oauth2_scheme)):
@@ -93,16 +95,42 @@ async def broadcast_sweep(run_id: str, param: float, metrics: Dict[str, float]) 
         await ws.send_json(payload)
 
 
+async def broadcast_regime(data: Dict[str, float]) -> None:
+    for ws in list(regime_clients):
+        await ws.send_json(data)
+
+
 @app.post("/run")
 async def run_simulation(req: RunRequest, user=Depends(get_current_user)):
     cfg = DPFConfig.model_validate(req.config)
     run_id = dispatch_to_hpc(cfg, user["username"])
     logger.info("action=submit user=%s run_id=%s", user["username"], run_id)
 
+    panel = RegimePanel(L=1.0)
+
     async def _mock_progress() -> None:
         for step in range(1, 11):
             await asyncio.sleep(0.1)
             await broadcast_progress(run_id, step / 10)
+            reg = panel.log(
+                step,
+                n=1e20,
+                T=1e3,
+                B=1.0,
+                v=1e5,
+                eta=1e-6,
+                mfp=0.01,
+                tau_e=1e-9,
+            )
+            payload = {k: reg[k] for k in [
+                "S",
+                "beta",
+                "M_A",
+                "R_m",
+                "K_n",
+                "omega_ce_tau_e",
+            ]}
+            await broadcast_regime(payload)
         await broadcast_diagnostics(run_id, {"status": "completed"})
 
     asyncio.create_task(_mock_progress())
@@ -199,3 +227,14 @@ async def ws_sweep(websocket: WebSocket, run_id: str):
             await websocket.receive_text()
     except WebSocketDisconnect:
         sweep_clients[run_id].discard(websocket)
+
+
+@app.websocket("/ws/regime")
+async def ws_regime(websocket: WebSocket):
+    await websocket.accept()
+    regime_clients.add(websocket)
+    try:
+        while True:
+            await websocket.receive_text()
+    except WebSocketDisconnect:
+        regime_clients.discard(websocket)

--- a/web/frontend/src/ProjectManager.jsx
+++ b/web/frontend/src/ProjectManager.jsx
@@ -40,6 +40,10 @@ export default function ProjectManager({ projects = [] }) {
               [msg.parameter]: {
                 yield: msg.yield,
                 efficiency: msg.efficiency,
+                yield_per_shot: msg.yield_per_shot,
+                yield_per_hour: msg.yield_per_hour,
+                wall_plug_efficiency: msg.wall_plug_efficiency,
+                lifetime_hours: msg.lifetime_hours,
               },
             },
           }));


### PR DESCRIPTION
## Summary
- compute yield/hour, wall-plug efficiency and lifetime in `compute_sweep_metrics`
- add plotting to `RegimePanel` and stream regime metrics via `/ws/regime`
- surface sweep performance metrics on the project manager dashboard

## Testing
- `pytest tests/diagnostics/test_performance_metrics.py tests/gui/test_regime_dashboard.py tests/test_param_sweep.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9e8cd3a48832a9f30277a1de6a224