### PR TITLE
Add dataset provenance validation and CLI utility

### DIFF
--- a/cli/validate_datasets.py
+++ b/cli/validate_datasets.py
@@ -1,0 +1,13 @@
+"""Entry point for dataset comparison helper.
+
+This thin wrapper simply exposes :func:`dpf2.cli.validate_datasets.main` as a
+stand-alone script so that users can invoke the dataset comparison utility via
+``python cli/validate_datasets.py``.
+"""
+
+from dpf2.cli.validate_datasets import main
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    raise SystemExit(main())
+

--- a/src/dpf2/chemistry/metadata.py
+++ b/src/dpf2/chemistry/metadata.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 import json
 from pathlib import Path
 from typing import Mapping
+import logging
 
 
 @dataclass
@@ -20,13 +21,24 @@ class DatasetMetadata:
     version: str
 
 
-def _load(path: Path | str) -> DatasetMetadata:
-    data = json.loads(Path(path).read_text())
+logger = logging.getLogger(__name__)
+
+
+def _require_metadata_fields(data: Mapping[str, object]) -> DatasetMetadata:
+    """Validate required provenance fields and build :class:`DatasetMetadata`."""
+
     doi = data.get("doi")
     version = data.get("version")
     if not doi or not version:
         raise ValueError("metadata requires 'doi' and 'version'")
     return DatasetMetadata(doi=str(doi), version=str(version))
+
+
+def _load(path: Path | str) -> DatasetMetadata:
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    meta = _require_metadata_fields(data)
+    logger.info("Loaded chemistry metadata: doi=%s version=%s", meta.doi, meta.version)
+    return meta
 
 
 def load_adas_metadata(meta_path: Path | str) -> DatasetMetadata:

--- a/src/dpf2/io/manifest.py
+++ b/src/dpf2/io/manifest.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 import hashlib
 from typing import Mapping
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def _hash_file(path: Path) -> str:
@@ -33,8 +37,13 @@ def capture_dataset_metadata(
         doi = info.get("doi")
         version = info.get("version")
         if path is None or doi is None or version is None:
-            raise ValueError("dataset metadata requires 'path', 'doi' and 'version'")
+            raise ValueError(
+                "dataset metadata requires 'path', 'doi' and 'version'"
+            )
         h = _hash_file(Path(path))
+        logger.info(
+            "dataset %s: hash=%s doi=%s version=%s", name, h, doi, version
+        )
         result[name] = {"hash": h, "doi": str(doi), "version": str(version)}
     return result
 

--- a/src/dpf2/radiation/metadata.py
+++ b/src/dpf2/radiation/metadata.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 import json
 from pathlib import Path
+from typing import Mapping
+import logging
 
 
 @dataclass
@@ -15,15 +17,26 @@ class DatasetMetadata:
     version: str
 
 
-def load_chianti_metadata(meta_path: Path | str) -> DatasetMetadata:
-    """Load metadata for a CHIANTI table."""
+logger = logging.getLogger(__name__)
 
-    data = json.loads(Path(meta_path).read_text())
+
+def _require_metadata_fields(data: Mapping[str, object]) -> DatasetMetadata:
     doi = data.get("doi")
     version = data.get("version")
     if not doi or not version:
         raise ValueError("metadata requires 'doi' and 'version'")
     return DatasetMetadata(doi=str(doi), version=str(version))
+
+
+def load_chianti_metadata(meta_path: Path | str) -> DatasetMetadata:
+    """Load metadata for a CHIANTI table."""
+
+    data = json.loads(Path(meta_path).read_text(encoding="utf-8"))
+    meta = _require_metadata_fields(data)
+    logger.info(
+        "Loaded CHIANTI metadata: doi=%s version=%s", meta.doi, meta.version
+    )
+    return meta
 
 
 __all__ = ["DatasetMetadata", "load_chianti_metadata"]


### PR DESCRIPTION
## Summary
- enforce DOI/version checks for chemistry and radiation metadata loaders
- log dataset hashes and DOI/version when capturing manifest metadata
- add `validate_datasets` CLI entry point to compare datasets

## Testing
- `PYTHONPATH=src pytest tests/chemistry/test_kinetics.py tests/radiation/test_multigroup.py -q`
- `PYTHONPATH=src pytest tests/test_manifest_metadata.py tests/test_manifest_warnings.py -q`
- `PYTHONPATH=src pytest tests/test_metadata.py -vv` *(fails: Metadata validation tests)*


------
https://chatgpt.com/codex/tasks/task_e_68b9e8ce5ce0832aa06fdb735e3bd892