### PR TITLE
Add crowbar and jitter to circuit solver with Hall MHD feedback

### DIFF
--- a/examples/circuit/advanced_driver.ipynb
+++ b/examples/circuit/advanced_driver.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Advanced Driver\n",
-    "Demonstrates multi-section RLC blocks, transmission-line segments and crowbar stages."
+    "Demonstrates multi-section RLC blocks, transmission-line segments, crowbar stages and switch jitter."
    ]
   },
   {
@@ -23,6 +23,25 @@
     "crowbar = CrowbarStage(0,2,resistance=1e-3,trigger_time=1e-6)\n",
     "res = solve_distributed_circuit(segments,[crowbar],V0=1e3,t_end=2e-6,dt=1e-7)\n",
     "res.current[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Switch jitter\n",
+    "Random Gaussian jitter can be applied to trigger times using the `jitter_std` parameter."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dpf2.circuit import TriggeredSwitch\n",
+    "sw = TriggeredSwitch(0,1,closed=False,R_on=1e-3,trigger_times=[1e-6],jitter_std=5e-9)\n",
+    "sw.trigger_times"
    ]
   }
  ],

--- a/src/dpf2/circuit_solver.py
+++ b/src/dpf2/circuit_solver.py
@@ -257,6 +257,8 @@ def _run_distributed_network(
         C_nodes[j] = segments[j - 1].totals()[2]
 
     delay = cfg.switch_delay * 1e-9
+    if getattr(cfg, "trigger_jitter_stddev", 0.0):
+        delay += float(np.random.normal(0.0, cfg.trigger_jitter_stddev * 1e-9))
     V0 = cfg.V0 * 1e3
     t_total = list(np.linspace(0.0, t_end * 1e-6, num_points))
 
@@ -333,10 +335,19 @@ def run_circuit_simulation(
         switches: list[CrowbarStage | TriggeredSwitch] = []
 
         # Existing transmission line segments defined via configuration
-        if getattr(cfg, "segments", None):
+        if getattr(cfg, "segments", None) or getattr(cfg, "switches", None):
             segs, sws = cfg.build_distributed_model()
             segments.extend(segs)
             switches.extend(sws)
+        if switches and getattr(cfg, "trigger_jitter_stddev", 0.0):
+            jitter = cfg.trigger_jitter_stddev * 1e-9
+            for sw in switches:
+                if getattr(sw, "trigger_times", None):
+                    sw.trigger_times = [
+                        tt + float(np.random.normal(0.0, jitter)) for tt in sw.trigger_times
+                    ]
+                    sw.trigger_times.sort()
+                    sw._next_trigger = 0
 
         # Optional multi‑section lumped elements
         secs = getattr(cfg, "rlc_sections", None)
@@ -369,7 +380,10 @@ def run_circuit_simulation(
             for stage in cbs:
                 res = stage.get("resistance", 0.0)
                 trig = stage.get("trigger", 0.0)
-                switches.append(CrowbarStage(src_node, last_node, res, trig))
+                jitter = stage.get("jitter", getattr(cfg, "trigger_jitter_stddev", 0.0))
+                switches.append(
+                    CrowbarStage(src_node, last_node, res, trig, jitter_std=jitter * 1e-9)
+                )
 
         dt = t_end * 1e-6 / (num_points - 1)
         sol = solve_distributed_circuit(
@@ -409,6 +423,11 @@ def run_circuit_simulation(
             plasma_state = plasma_solver.step(plasma_state, dt, current, voltage)
             fb = plasma_solver.coupling_interface()
             Lp = getattr(fb, "Lp", 0.0)
+            if hasattr(plasma_solver, "plasma_inductance"):
+                try:
+                    Lp = float(plasma_solver.plasma_inductance(plasma_state))
+                except Exception:
+                    pass
             emf = getattr(fb, "emf", 0.0)
             back_emf = getattr(fb, "back_reaction", 0.0)
             dLpdt = (Lp - prev_Lp) / dt if dt > 0 else 0.0

--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -879,6 +879,31 @@ class HallMHDSolver(PlasmaSolverBase):
 
         return new_state
 
+    # ------------------------------------------------------------------
+    def coupling_interface(self) -> CouplingState:
+        """Expose plasma inductance and back‑EMF to circuit solvers."""
+
+        if self.circuit_feedback is not None:
+            return self.circuit_feedback
+        return CouplingState(Lp=self.inductance, emf=self.back_emf, current=self.current)
+
+    def plasma_inductance(self, state: MHDState | None = None) -> float:
+        """Return current plasma inductance estimate.
+
+        Parameters
+        ----------
+        state:
+            Optional plasma state.  When provided the inductance is recomputed
+            from ``state``; otherwise the last stored value is returned.
+        """
+
+        if state is None:
+            return self.inductance
+        try:
+            return float(self.compute_plasma_inductance(state, self.current))
+        except Exception:
+            return self.inductance
+
     def compute_plasma_inductance(self, state: MHDState, current: float, cell_volume: float = 1.0) -> float:
         """Estimate plasma inductance from magnetic energy.
 


### PR DESCRIPTION
## Summary
- model switch jitter and crowbar stages in circuit solver
- expose HallMHD plasma inductance to circuit during runtime
- document advanced driver configuration examples

## Testing
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e8cf9144832a8f2cade783fa478f