### PR TITLE
feat: lower-hybrid spectral resistivity diagnostics

### DIFF
--- a/src/dpf2/diagnostics/modes.py
+++ b/src/dpf2/diagnostics/modes.py
@@ -17,7 +17,12 @@ from itertools import product
 import numpy as np
 from typing import Sequence
 
-__all__ = ["azimuthal_mode_spectrum", "growth_rate"]
+__all__ = [
+    "azimuthal_mode_spectrum",
+    "growth_rate",
+    "lh_azimuthal_power",
+    "log_impedance_ratio",
+]
 
 
 def azimuthal_mode_spectrum(field: np.ndarray, axis: int = -1) -> np.ndarray:
@@ -117,3 +122,41 @@ def growth_rate(previous: Sequence[float], current: Sequence[float], dt: float) 
         else:
             rate.append(0.0)
     return np.asarray(rate)
+
+
+# ---------------------------------------------------------------------------
+def lh_azimuthal_power(field: np.ndarray, omega_lh: float, axis: int = -1) -> float:
+    """Return azimuthal power near the lower-hybrid frequency.
+
+    The function computes the azimuthal mode spectrum of ``field`` and
+    selects the mode whose index most closely matches ``omega_lh``.  The
+    amplitude of this mode serves as a crude proxy for the power contained in
+    lower-hybrid drift waves.
+    """
+
+    spectrum = azimuthal_mode_spectrum(field, axis=axis)
+    if len(spectrum) == 0:
+        return 0.0
+    m = int(round(omega_lh)) % len(spectrum)
+    return float(spectrum[m])
+
+
+def log_impedance_ratio(
+    eta_plasma: np.ndarray,
+    ne: np.ndarray,
+    Te: np.ndarray,
+    Z: float | np.ndarray,
+) -> np.ndarray:
+    """Logarithmic plasma impedance relative to Spitzer prediction.
+
+    ``eta_plasma`` is compared against the classical Spitzer resistivity and
+    the base-10 logarithm of the ratio is returned.  The helper is designed
+    for lightweight diagnostics and therefore accepts array-like inputs for
+    convenience.
+    """
+
+    from dpf2.hall_mhd_solver import spitzer_resistivity
+
+    eta_s = spitzer_resistivity(ne, Te, Z)
+    eta_p = np.asarray(eta_plasma)
+    return np.log10(np.maximum(eta_p, 1e-30) / np.maximum(eta_s, 1e-30))

--- a/src/dpf2/dpf_config.py
+++ b/src/dpf2/dpf_config.py
@@ -122,6 +122,8 @@ class PhysicsModels(BaseModel):
     wall_ablation_rate: Optional[float] = None
     wall_ablation_latent_heat: Optional[float] = None
     resistivity_model: Optional[str] = None
+    anomalous_resistivity_enabled: bool = False
+    anomalous_resistivity_parameters: Dict[str, float] = Field(default_factory=dict)
     ionization_model: Optional[str] = None
     radiation_model: Optional[str] = None
     radiation_transport_model: Optional[str] = None

--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -40,6 +40,8 @@ from .boundary_conditions import KineticSheath
 from .physics.energy import EnergyTracker
 from .diagnostics.quality_dashboard import QualityDashboard
 from .diagnostics.modes import azimuthal_mode_spectrum
+from .physics.anomalous_resistivity import SpectralResistivity
+from .physics.lower_hybrid_drift import LowerHybridDrift
 
 logger = logging.getLogger(__name__)
 
@@ -384,6 +386,31 @@ class HallMHDSolver(PlasmaSolverBase):
         """Invoke the boundary-condition hook if provided."""
         if self.bc is not None:
             self.bc(state)
+
+    # ------------------------------------------------------------------
+    def enable_spectral_resistivity(
+        self,
+        lhd: LowerHybridDrift,
+        scale: float = 1.0,
+        floor: float = 0.0,
+    ) -> None:
+        """Enable lower-hybrid drift spectral anomalous resistivity.
+
+        Parameters
+        ----------
+        lhd:
+            Instance providing the local lower-hybrid frequency.
+        scale:
+            Scaling applied to the spectral power when mapping to
+            resistivity.
+        floor:
+            Minimum resistivity returned by the model.
+
+        The created model is attached to :attr:`lower_hybrid_drift` so it is
+        automatically included by :meth:`compute_anomalous_resistivity`.
+        """
+
+        self.lower_hybrid_drift = SpectralResistivity(lhd, scale=scale, floor=floor)
 
     def compute_anomalous_resistivity(self, J: np.ndarray) -> np.ndarray:
         """Evaluate anomalous resistivity models and record voltage spikes.

--- a/src/dpf2/physics/anomalous_resistivity.py
+++ b/src/dpf2/physics/anomalous_resistivity.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Lower-hybrid drift spectral anomalous resistivity model.
+
+This module provides a tiny utility class that estimates an effective
+resistivity from the azimuthal spectrum of the current density.  The
+intent is to mimic the enhanced resistivity that can arise from
+lower-hybrid drift waves.  The implementation is intentionally simple
+and primarily serves as a placeholder for more sophisticated models.
+
+Example
+-------
+>>> from dpf2.physics.lower_hybrid_drift import LowerHybridDrift
+>>> from dpf2.physics.anomalous_resistivity import SpectralResistivity
+>>> lhd = LowerHybridDrift(B=1.0, n_i=1e18)
+>>> model = SpectralResistivity(lhd, scale=1e-3)
+>>> J = np.zeros((4, 4, 3))
+>>> eta, E = model(J)
+>>> eta.shape
+(4, 4)
+"""
+
+from dataclasses import dataclass
+from typing import Any, Tuple
+import numpy as np
+
+from ..diagnostics.modes import azimuthal_mode_spectrum
+from .lower_hybrid_drift import LowerHybridDrift
+
+
+@dataclass
+class SpectralResistivity:
+    """Estimate anomalous resistivity from lower-hybrid drift spectra.
+
+    Parameters
+    ----------
+    lhd:
+        Instance supplying the lower-hybrid frequency through
+        :meth:`~dpf2.physics.lower_hybrid_drift.LowerHybridDrift.frequency`.
+    scale:
+        Multiplicative factor applied to the spectral power.
+    floor:
+        Minimum resistivity returned by the model.
+    """
+
+    lhd: LowerHybridDrift
+    scale: float = 1.0
+    floor: float = 0.0
+
+    def __call__(self, J: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """Return an anomalous resistivity estimate for ``J``.
+
+        The magnitude of ``J`` is decomposed into azimuthal modes and the
+        mode closest to the lower-hybrid frequency is used as a proxy for the
+        turbulent wave power.  The resistivity is ``scale`` times this power
+        with ``floor`` enforcing a minimum value.  A zero electric-field
+        contribution is returned so the object is compatible with
+        :meth:`HallMHDSolver.compute_anomalous_resistivity`.
+        """
+
+        try:
+            magJ = np.linalg.norm(J, axis=-1)
+            spectrum = azimuthal_mode_spectrum(magJ, axis=-1)
+            if len(spectrum) == 0:
+                power = 0.0
+            else:
+                m = int(round(self.lhd.frequency())) % len(spectrum)
+                power = float(spectrum[m])
+        except Exception:  # pragma: no cover - very small ``numpy`` stub
+            power = 0.0
+
+        eta = self.scale * power + self.floor
+        try:  # pragma: no cover - real ``numpy`` path
+            eta_field = np.broadcast_to(eta, J.shape[:-1])
+        except Exception:  # pragma: no cover - minimal stub fallback
+            eta_field = np.ones(J.shape[:-1]) * eta
+        return eta_field, np.zeros_like(J)
+
+
+__all__ = ["SpectralResistivity"]


### PR DESCRIPTION
## Summary
- add `SpectralResistivity` model computing anomalous resistivity from lower-hybrid drift spectra
- expose `HallMHDSolver.enable_spectral_resistivity` convenience API
- add mode diagnostics for lower-hybrid power and impedance ratio
- surface resistivity-model toggle and parameters in `PhysicsModels`

## Testing
- `pytest -q` *(fails: ImportError due to missing packages in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ee6a3e30832a83bd0d1922702670