### PR TITLE
feat(gui): geometry editing and multi-project sweep overlays

### DIFF
--- a/docs/gui_tutorials/geometry_edits.md
+++ b/docs/gui_tutorials/geometry_edits.md
@@ -1,0 +1,15 @@
+# Editing Geometries in the GUI
+
+The interactive and Qt interfaces can now import STEP, STL or VTK geometry files.
+Use the *Upload Geometry* control to load a mesh and visualise the resulting
+anode/cathode shapes.  Translation controls apply simple offsets for quick
+position tweaks.
+
+```python
+from dpf2.gui import interactive
+interactive.launch()
+```
+
+After uploading a geometry file you may translate it and view the updated mesh
+in real time.  Electrode outlines are rendered using Plotly allowing basic
+inspection without external tools.

--- a/docs/gui_tutorials/sweep_comparisons.md
+++ b/docs/gui_tutorials/sweep_comparisons.md
@@ -1,0 +1,14 @@
+# Comparing Sweeps Across Projects
+
+The Qt sweep tool supports multiple projects.  Enter a project name before
+running a sweep to group results.  The overlay panel at the bottom of the window
+shows yield curves from every project, enabling quick comparison of
+"Yield vs Pressure" or other KPIs.
+
+```python
+from dpf2.gui.qt_sweep import launch
+launch()
+```
+
+Sweeps from different projects are colour coded and can be exported to CSV for
+further analysis.

--- a/src/dpf2/gui/interactive.py
+++ b/src/dpf2/gui/interactive.py
@@ -16,6 +16,8 @@ from pathlib import Path
 from typing import List
 import json
 import warnings
+import base64
+import io
 
 from .project_manager import ProjectManager
 from ..core.config import DPFConfig
@@ -221,6 +223,35 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
                 style={} if not simplified else {"display": "none"},
             ),
             dcc.Graph(id="metrics_plot"),
+            html.Hr(),
+            html.H2("Geometry"),
+            dcc.Upload(
+                id="geom_upload",
+                children=html.Button("Upload Geometry"),
+                multiple=False,
+            ),
+            html.Div(
+                [
+                    dcc.Input(id="geom_label", placeholder="label", type="text"),
+                    dcc.Input(id="geom_dx", type="number", placeholder="dx"),
+                    dcc.Input(id="geom_dy", type="number", placeholder="dy"),
+                    dcc.Input(id="geom_dz", type="number", placeholder="dz"),
+                    html.Button("Translate", id="geom_translate"),
+                ],
+                style={"display": "flex", "gap": "0.5em"},
+            ),
+            dcc.Graph(id="geometry_view"),
+            html.H2("Circuit"),
+            html.Div(
+                [
+                    dcc.Input(id="node_a", type="text", placeholder="node A"),
+                    dcc.Input(id="node_b", type="text", placeholder="node B"),
+                    dcc.Input(id="component", type="text", placeholder="component"),
+                    html.Button("Add Component", id="add_component"),
+                ],
+                style={"display": "flex", "gap": "0.5em"},
+            ),
+            dcc.Graph(id="circuit_view"),
         ]
     )
 
@@ -378,6 +409,48 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
         fig.update_xaxes(title_text="S")
         fig.update_yaxes(title_text="Yield")
         return fig
+
+    @app.callback(
+        Output("geometry_view", "figure"),
+        Input("geom_upload", "contents"),
+        Input("geom_translate", "n_clicks"),
+        State("geom_upload", "filename"),
+        State("geom_label", "value"),
+        State("geom_dx", "value"),
+        State("geom_dy", "value"),
+        State("geom_dz", "value"),
+        prevent_initial_call=True,
+    )
+    def _update_geometry(contents, n_clicks, filename, label, dx, dy, dz):
+        ctx = dash.callback_context
+        if not ctx.triggered:
+            return go.Figure()
+        trigger = ctx.triggered[0]["prop_id"].split(".")[0]
+        lbl = label or "geom"
+        if trigger == "geom_upload" and contents and filename:
+            data = contents.split(",", 1)[1]
+            decoded = base64.b64decode(data)
+            tmp = Path("uploads") / filename
+            tmp.parent.mkdir(parents=True, exist_ok=True)
+            tmp.write_bytes(decoded)
+            pm.import_geometry(lbl, tmp)
+        elif trigger == "geom_translate" and lbl in pm.geometries:
+            pm.transform_geometry(lbl, (dx or 0.0, dy or 0.0, dz or 0.0))
+        if lbl in pm.geometries:
+            return pm.geometry_figure(lbl)
+        return go.Figure()
+
+    @app.callback(
+        Output("circuit_view", "figure"),
+        Input("add_component", "n_clicks"),
+        State("node_a", "value"),
+        State("node_b", "value"),
+        State("component", "value"),
+        prevent_initial_call=True,
+    )
+    def _update_circuit(n_clicks, a, b, comp):
+        pm.add_component(comp or "comp", a or "A", b or "B")
+        return pm.circuit_figure()
 
     app.run_server(host=host, port=port)
 

--- a/src/dpf2/gui/project_manager.py
+++ b/src/dpf2/gui/project_manager.py
@@ -11,9 +11,13 @@ metrics from multiple sweeps which can then be overlaid or written to disk.
 from pathlib import Path
 import csv
 import json
-from typing import Callable, Dict, Iterable, List, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Tuple
 
 import numpy as np
+try:  # pragma: no cover - optional dependency for circuit visualisation
+    import networkx as nx
+except Exception:  # pragma: no cover
+    nx = None  # type: ignore
 
 from ..core.config import DPFConfig
 from ..optimization.param_sweep import (
@@ -46,6 +50,9 @@ class ProjectManager:
         self.project = project
         self.last_kpi_plot: Path | None = None
         self.last_convergence_plot: Path | None = None
+        # Geometry and circuit state
+        self.geometries: Dict[str, Any] = {}
+        self.circuit: nx.Graph | None = nx.Graph() if nx else None
 
     @staticmethod
     def _spot_size(t: Iterable[float], current: Iterable[float]) -> float:
@@ -374,6 +381,122 @@ class ProjectManager:
             metrics[label] = {float(k): v for k, v in vals.items()}
         self.metrics = metrics
         self.params = data.get("params", {})
+
+    # ------------------------------------------------------------------
+    # Geometry handling
+    def import_geometry(self, label: str, path: str | Path) -> None:
+        """Import a geometry file (STEP/STL/VTK) and store it under ``label``.
+
+        The geometry is kept in-memory for later visualisation or transformation.
+        Dependencies such as :mod:`trimesh` or :mod:`pyvista` are optional and
+        only required when the corresponding file format is used.
+        """
+
+        p = Path(path)
+        suffix = p.suffix.lower()
+        geom: Any
+        if suffix in {".stl", ".step", ".stp"}:
+            try:
+                import trimesh
+
+                geom = trimesh.load(p)
+            except Exception as exc:  # pragma: no cover - optional dependency
+                raise RuntimeError("trimesh is required for STEP/STL import") from exc
+        elif suffix in {".vtk", ".vtu", ".vtp"}:
+            try:
+                import pyvista as pv
+
+                geom = pv.read(p)
+            except Exception as exc:  # pragma: no cover - optional dependency
+                raise RuntimeError("pyvista is required for VTK import") from exc
+        else:
+            raise ValueError(f"Unsupported geometry format: {suffix}")
+
+        self.geometries[label] = geom
+
+    def transform_geometry(
+        self, label: str, translation: Tuple[float, float, float]
+    ) -> None:
+        """Apply a simple translation to a stored geometry."""
+
+        geom = self.geometries.get(label)
+        if geom is None:
+            raise KeyError(label)
+        try:
+            geom.apply_translation(translation)  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - fall back for pyvista
+            try:
+                geom.translate(translation)  # type: ignore[attr-defined]
+            except Exception as exc:  # pragma: no cover
+                raise RuntimeError("Geometry translation not supported") from exc
+
+    def geometry_figure(self, label: str):  # pragma: no cover - simple wrapper
+        """Return a Plotly figure visualising a stored geometry."""
+
+        geom = self.geometries.get(label)
+        if geom is None:
+            raise KeyError(label)
+        try:
+            import plotly.graph_objects as go
+            import numpy as np
+        except Exception as exc:
+            raise RuntimeError("plotly is required for geometry visualisation") from exc
+
+        if hasattr(geom, "faces") and hasattr(geom, "vertices"):
+            verts = np.asarray(geom.vertices)
+            faces = np.asarray(geom.faces)
+        elif hasattr(geom, "points") and hasattr(geom, "faces"):
+            verts = np.asarray(geom.points)
+            faces = np.asarray(geom.faces).reshape(-1, 4)[:, 1:]
+        else:  # pragma: no cover - unknown object type
+            raise RuntimeError("Unsupported geometry object")
+
+        mesh = go.Mesh3d(
+            x=verts[:, 0], y=verts[:, 1], z=verts[:, 2], i=faces[:, 0], j=faces[:, 1], k=faces[:, 2]
+        )
+        fig = go.Figure(data=[mesh])
+        fig.update_layout(scene_aspectmode="data")
+        return fig
+
+    # ------------------------------------------------------------------
+    # Circuit handling
+    def add_component(self, name: str, node_a: str, node_b: str) -> None:
+        """Add a circuit component between ``node_a`` and ``node_b``."""
+
+        if self.circuit is None:
+            raise RuntimeError("networkx is required for circuit wiring")
+        self.circuit.add_edge(node_a, node_b, component=name)
+
+    def circuit_figure(self):  # pragma: no cover - visual helper
+        """Return a Plotly figure of the current circuit wiring."""
+
+        if self.circuit is None:
+            raise RuntimeError("networkx is required for circuit visualisation")
+        try:
+            import plotly.graph_objects as go
+            import numpy as np
+        except Exception as exc:
+            raise RuntimeError("plotly is required for circuit visualisation") from exc
+
+        pos = nx.spring_layout(self.circuit)
+        x = []
+        y = []
+        for n in self.circuit.nodes:
+            px, py = pos[n]
+            x.append(px)
+            y.append(py)
+        edge_x = []
+        edge_y = []
+        for u, v in self.circuit.edges:
+            edge_x.extend([pos[u][0], pos[v][0], None])
+            edge_y.extend([pos[u][1], pos[v][1], None])
+        node_trace = go.Scatter(x=x, y=y, mode="markers+text", text=list(self.circuit.nodes))
+        edge_trace = go.Scatter(x=edge_x, y=edge_y, mode="lines")
+        fig = go.Figure(data=[edge_trace, node_trace])
+        fig.update_xaxes(visible=False)
+        fig.update_yaxes(visible=False)
+        fig.update_layout(showlegend=False)
+        return fig
 
 
 __all__ = ["ProjectManager"]

--- a/src/dpf2/gui/qt_sweep.py
+++ b/src/dpf2/gui/qt_sweep.py
@@ -24,6 +24,7 @@ from typing import Dict, Iterable, List
 import argparse
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 
 from .project_manager import ProjectManager
 from ..core.config import DPFConfig
@@ -43,6 +44,7 @@ try:  # pragma: no cover - optional GUI dependency
         QDoubleSpinBox,
         QSpinBox,
         QPushButton,
+        QLineEdit,
     )
 except Exception:  # pragma: no cover - allow import when PyQt missing
     QApplication = None  # type: ignore
@@ -152,6 +154,13 @@ class _SweepWindow(QWidget):
         p_row.addWidget(self.pressure)
         layout.addLayout(p_row)
 
+        # Project name input for multi-project overlays
+        self.project_edit = QLineEdit("qt")
+        proj_row = QHBoxLayout()
+        proj_row.addWidget(QLabel("Project"))
+        proj_row.addWidget(self.project_edit)
+        layout.addLayout(proj_row)
+
         # Voltage sweep range controls
         self.v_min = QDoubleSpinBox()
         self.v_min.setRange(5_000, 30_000)
@@ -212,7 +221,13 @@ class _SweepWindow(QWidget):
             btn_row.addWidget(b)
         layout.addLayout(btn_row)
 
-        self.pm = ProjectManager(project="qt")
+        # Managers for each project
+        self.managers: Dict[str, ProjectManager] = {}
+
+        # Embedded plotting canvas for overlays
+        self.fig, self.ax = plt.subplots()
+        self.canvas = FigureCanvas(self.fig)
+        layout.addWidget(self.canvas)
 
         # Connect callbacks
         self.btn_sweep_v.clicked.connect(self._sweep_voltage)
@@ -227,6 +242,10 @@ class _SweepWindow(QWidget):
         cfg.charging_voltage = float(self.voltage.value())
         cfg.initial_pressure = float(self.pressure.value())
         return cfg
+
+    def _pm(self) -> ProjectManager:
+        proj = self.project_edit.text() or "qt"
+        return self.managers.setdefault(proj, ProjectManager(project=proj))
 
     def _sweep_voltage(self) -> None:
         vals = np.linspace(
@@ -245,11 +264,12 @@ class _SweepWindow(QWidget):
         self._run_sweep("initial_pressure", vals)
 
     def _run_sweep(self, param: str, values: Iterable[float]) -> None:
+        pm = self._pm()
         cfg = self._config()
-        label = f"{param}_{len(self.pm.metrics)}"
-        metrics = self.pm.run_sweep(label, cfg, param, list(values))
-        if self.pm.last_kpi_plot:
-            img = plt.imread(self.pm.last_kpi_plot)
+        label = f"{param}_{len(pm.metrics)}"
+        metrics = pm.run_sweep(label, cfg, param, list(values))
+        if pm.last_kpi_plot:
+            img = plt.imread(pm.last_kpi_plot)
             plt.figure()
             plt.imshow(img)
             plt.axis("off")
@@ -258,8 +278,7 @@ class _SweepWindow(QWidget):
         y_path = plot_yield_vs_param(
             param,
             metrics,
-            Path("results")
-            / self.pm.project
+            Path("results") / pm.project
             / f"yield_vs_{param}"
             / f"{label}.png",
         )
@@ -272,10 +291,7 @@ class _SweepWindow(QWidget):
         if param == "initial_pressure":
             s_path = plot_yield_vs_S_gv(
                 metrics,
-                Path("results")
-                / self.pm.project
-                / "yield_vs_S"
-                / f"{label}.png",
+                Path("results") / pm.project / "yield_vs_S" / f"{label}.png",
             )
             img = plt.imread(s_path)
             plt.figure()
@@ -291,20 +307,29 @@ class _SweepWindow(QWidget):
             print(f"Optimal S = {opt_S:.2f} at P={best_val}")
             if abs(opt_S - gv) > 1e-6:
                 print(f"Deviation from GV ({gv}) = {opt_S - gv:+.2f}")
+        self._overlay_runs()
 
     def _overlay_runs(self) -> None:
-        path = self.pm.overlay_metrics()
-        img = plt.imread(path)
-        plt.figure()
-        plt.imshow(img)
-        plt.axis("off")
-        plt.tight_layout()
-        plt.show()
+        self.ax.clear()
+        x_label = "parameter"
+        for proj, pm in self.managers.items():
+            for label, metrics in pm.metrics.items():
+                vals = sorted(metrics.keys())
+                y = [metrics[v].get("yield", 0.0) for v in vals]
+                self.ax.plot(vals, y, label=f"{proj}:{label}")
+                if pm.params.get(label):
+                    x_label = pm.params[label]
+        self.ax.set_xlabel(x_label)
+        self.ax.set_ylabel("Yield")
+        self.ax.legend()
+        self.canvas.draw_idle()
 
     def _export_metrics(self) -> None:
-        self.pm.export_metrics(Path("metrics.csv"))
+        pm = self._pm()
+        pm.export_metrics(Path("metrics.csv"))
 
     def _pareto_search(self) -> None:
+        pm = self._pm()
         cfg = self._config()
         bounds = {
             "charging_voltage": (
@@ -316,7 +341,7 @@ class _SweepWindow(QWidget):
                 cfg.initial_pressure * 1.5,
             ),
         }
-        front = self.pm.pareto_search(cfg, bounds, n_samples=20)
+        front = pm.pareto_search(cfg, bounds, n_samples=20)
         plt.figure()
         plt.scatter(
             [p["spot_size"] for p in front],


### PR DESCRIPTION
## Summary
- support importing STEP/STL/VTK geometries and circuit wiring in ProjectManager
- add Dash controls for geometry visualization and circuit editing
- extend Qt sweep tool with project-aware overlay panel
- document geometry edits and sweep comparisons in new tutorials

## Testing
- `pytest -q` *(fails: attempted relative import with no known parent package; missing numerous simulation modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ee70ba54832ab95384471b1c9e75