### PR TITLE
Add UQ calibration and analysis utilities

### DIFF
--- a/src/dpf2/cli/uq_run.py
+++ b/src/dpf2/cli/uq_run.py
@@ -1,0 +1,65 @@
+"""Command line interface for running UQ calibration routines."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+from ..uq import calibrate_waveform
+
+
+def _load_waveform(path: str | Path) -> tuple[np.ndarray, np.ndarray]:
+    """Load two-column ``time,current`` waveform data."""
+    arr = np.loadtxt(path, dtype=float)
+    if arr.ndim != 2 or arr.shape[1] < 2:
+        raise ValueError(f"waveform file {path!s} must have at least two columns")
+    return arr[:, 0], arr[:, 1]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the ``uq_run`` CLI."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sim", help="CSV file with simulated time,current waveform")
+    parser.add_argument("data", help="CSV file with measured time,current waveform")
+    parser.add_argument(
+        "--method",
+        choices=["emcee", "dynesty"],
+        default="emcee",
+        help="Calibration backend to use",
+    )
+    parser.add_argument(
+        "--output",
+        default="uq_results.npz",
+        help="Path to store or read calibration samples",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Summarise an existing results file instead of running calibration",
+    )
+
+    args = parser.parse_args(argv)
+    out_path = Path(args.output)
+
+    if args.summary:
+        if not out_path.exists():
+            raise SystemExit(f"results file {out_path} does not exist")
+        data = np.load(out_path)
+        for name in data.files:
+            arr = data[name]
+            print(f"{name}: mean={arr.mean():.3f} std={arr.std():.3f}")
+        return 0
+
+    t_sim, i_sim = _load_waveform(args.sim)
+    t_data, i_data = _load_waveform(args.data)
+    samples = calibrate_waveform(t_sim, i_sim, t_data, i_data, method=args.method)
+    np.savez(out_path, **samples)
+    print(f"Saved results to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    raise SystemExit(main())

--- a/src/dpf2/uq/__init__.py
+++ b/src/dpf2/uq/__init__.py
@@ -7,8 +7,17 @@ from .calibration import (
     emcee_calibrate,
     dynesty_calibrate,
     emcee_calibrate_mass_current,
+    dynesty_calibrate_mass_current,
+    emcee_calibrate_waveform,
+    dynesty_calibrate_waveform,
+    calibrate_waveform,
 )
-from .inference import emcee_infer, dynesty_infer
+from .inference import (
+    emcee_infer,
+    dynesty_infer,
+    emcee_infer_waveform,
+    dynesty_infer_waveform,
+)
 
 __all__ = [
     "latin_hypercube",
@@ -18,6 +27,12 @@ __all__ = [
     "emcee_calibrate",
     "dynesty_calibrate",
     "emcee_calibrate_mass_current",
+    "dynesty_calibrate_mass_current",
+    "emcee_calibrate_waveform",
+    "dynesty_calibrate_waveform",
+    "calibrate_waveform",
     "emcee_infer",
     "dynesty_infer",
+    "emcee_infer_waveform",
+    "dynesty_infer_waveform",
 ]

--- a/src/dpf2/uq/analysis.py
+++ b/src/dpf2/uq/analysis.py
@@ -1,9 +1,12 @@
 """Post-processing helpers for uncertainty quantification."""
 from __future__ import annotations
 
-from typing import Dict, Sequence
+from typing import Callable, Dict, Sequence
 
 import statistics
+from pathlib import Path
+
+import numpy as np
 
 
 def _to_matrix(samples: Sequence[Sequence[float]]) -> list[list[float]]:
@@ -68,4 +71,80 @@ def uncertainty_band(values: Sequence[float], alpha: float = 0.95) -> Dict[str, 
     return {"mean": mean, "std": std, "lower": lower, "upper": upper}
 
 
-__all__ = ["sobol_indices", "uncertainty_band"]
+def propagate_yield_pinch(
+    samples: Sequence[Sequence[float]] | Dict[str, Sequence[float]],
+    model: Callable[[np.ndarray], tuple[float, float]],
+    outdir: str | Path = "validation",
+    alpha: float = 0.95,
+) -> Dict[str, Dict[str, float]]:
+    """Propagate parameter samples to yield and pinch-time uncertainties.
+
+    Parameters
+    ----------
+    samples:
+        Either an iterable of parameter vectors or a mapping of parameter
+        names to sequences of values representing posterior samples.
+    model:
+        Callable returning ``(yield, pinch_time)`` for a given parameter
+        vector.
+    outdir:
+        Directory where summary plots will be written.  Created if it does
+        not yet exist.
+    alpha:
+        Confidence level used when computing uncertainty bands.
+
+    Returns
+    -------
+    Dict[str, Dict[str, float]]
+        Mapping with ``"neutron_yield"`` and ``"pinch_time"`` entries each
+        containing statistics from :func:`uncertainty_band`.
+    """
+
+    if isinstance(samples, dict):
+        names = list(samples)
+        rows = zip(*(samples[n] for n in names))
+    else:
+        rows = samples
+
+    yields: list[float] = []
+    pinches: list[float] = []
+    for row in rows:
+        yld, pinch = model(np.asarray(row, dtype=float))
+        yields.append(float(yld))
+        pinches.append(float(pinch))
+
+    stats = {
+        "neutron_yield": uncertainty_band(yields, alpha),
+        "pinch_time": uncertainty_band(pinches, alpha),
+    }
+
+    try:  # pragma: no cover - plotting is optional
+        import matplotlib.pyplot as plt  # type: ignore
+
+        out = Path(outdir)
+        out.mkdir(parents=True, exist_ok=True)
+
+        plt.figure()
+        plt.hist(yields, bins=30, color="C0", alpha=0.7)
+        plt.xlabel("Neutron yield")
+        plt.ylabel("Frequency")
+        plt.title("Neutron yield distribution")
+        plt.tight_layout()
+        plt.savefig(out / "neutron_yield.png")
+        plt.close()
+
+        plt.figure()
+        plt.hist(pinches, bins=30, color="C1", alpha=0.7)
+        plt.xlabel("Pinch time")
+        plt.ylabel("Frequency")
+        plt.title("Pinch timing distribution")
+        plt.tight_layout()
+        plt.savefig(out / "pinch_time.png")
+        plt.close()
+    except Exception:
+        pass
+
+    return stats
+
+
+__all__ = ["sobol_indices", "uncertainty_band", "propagate_yield_pinch"]

--- a/src/dpf2/uq/calibration.py
+++ b/src/dpf2/uq/calibration.py
@@ -480,6 +480,34 @@ def dynesty_calibrate_waveform(
     return {name: res.samples[:, idx] for idx, name in enumerate(names)}
 
 
+def calibrate_waveform(
+    time_sim: np.ndarray,
+    current_sim: np.ndarray,
+    time_data: np.ndarray,
+    current_data: np.ndarray,
+    method: str = "emcee",
+    **kwargs,
+) -> Dict[str, np.ndarray]:
+    """Calibrate waveform scaling factors using the chosen sampler.
+
+    Parameters mirror :func:`emcee_calibrate_waveform` and
+    :func:`dynesty_calibrate_waveform` with an additional ``method``
+    argument selecting the backend sampler.  ``method`` may be ``"emcee"``
+    for ensemble MCMC or ``"dynesty"`` for nested sampling.
+    """
+
+    method = method.lower()
+    if method == "emcee":
+        return emcee_calibrate_waveform(
+            time_sim, current_sim, time_data, current_data, **kwargs
+        )
+    if method == "dynesty":
+        return dynesty_calibrate_waveform(
+            time_sim, current_sim, time_data, current_data, **kwargs
+        )
+    raise ValueError(f"Unknown calibration method: {method}")
+
+
 __all__ = [
     "bayesian_calibration",
     "nested_calibration",
@@ -489,5 +517,6 @@ __all__ = [
     "dynesty_calibrate_mass_current",
     "emcee_calibrate_waveform",
     "dynesty_calibrate_waveform",
+    "calibrate_waveform",
 ]
 

--- a/src/dpf2/uq/inference.py
+++ b/src/dpf2/uq/inference.py
@@ -107,4 +107,116 @@ def dynesty_infer(
     return {name: res.samples[:, idx] for idx, name in enumerate(names)}
 
 
-__all__ = ["emcee_infer", "dynesty_infer"]
+def emcee_infer_waveform(
+    time_sim: np.ndarray,
+    current_sim: np.ndarray,
+    time_data: np.ndarray,
+    current_data: np.ndarray,
+    bounds: Bounds | None = None,
+    n_walkers: int = 32,
+    n_steps: int = 1000,
+    sigma: float = 1.0,
+    seed: int | None = None,
+) -> Dict[str, np.ndarray]:
+    """Infer mass and current scaling from waveform data using MCMC.
+
+    The routine fits ``mass_factor`` and ``current_factor`` such that a
+    simulated current waveform best matches experimental measurements.
+    ``mass_factor`` scales the simulation time axis while
+    ``current_factor`` scales the amplitude.
+    """
+
+    try:  # pragma: no cover - dependency may be optional
+        import emcee  # type: ignore
+    except Exception as exc:  # pragma: no cover - import error path
+        raise RuntimeError("emcee is required for emcee_infer_waveform") from exc
+
+    if bounds is None:
+        bounds = {"mass_factor": (0.5, 1.5), "current_factor": (0.5, 1.5)}
+
+    names = ["mass_factor", "current_factor"]
+    lower = np.array([bounds[n][0] for n in names])
+    upper = np.array([bounds[n][1] for n in names])
+
+    time_sim = np.asarray(time_sim, dtype=float)
+    current_sim = np.asarray(current_sim, dtype=float)
+    time_data = np.asarray(time_data, dtype=float)
+    current_data = np.asarray(current_data, dtype=float)
+
+    def log_prob(theta: np.ndarray) -> float:
+        if np.any(theta < lower) or np.any(theta > upper):
+            return -np.inf
+        mass_factor, current_factor = theta
+        scaled_time = mass_factor * time_sim
+        sim_interp = np.interp(
+            time_data, scaled_time, current_sim, left=0.0, right=0.0
+        )
+        pred = current_factor * sim_interp
+        resid = (current_data - pred) / sigma
+        return -0.5 * np.dot(resid, resid)
+
+    rng = np.random.default_rng(seed)
+    p0 = lower + (upper - lower) * rng.random((n_walkers, len(names)))
+    sampler = emcee.EnsembleSampler(n_walkers, len(names), log_prob)
+    sampler.run_mcmc(p0, n_steps, progress=False)
+    chain = sampler.get_chain(discard=n_steps // 2, flat=True)
+    return {name: chain[:, idx] for idx, name in enumerate(names)}
+
+
+def dynesty_infer_waveform(
+    time_sim: np.ndarray,
+    current_sim: np.ndarray,
+    time_data: np.ndarray,
+    current_data: np.ndarray,
+    bounds: Bounds | None = None,
+    n_live: int = 50,
+    n_iter: int = 500,
+    sigma: float = 1.0,
+    seed: int | None = None,
+) -> Dict[str, np.ndarray]:
+    """Infer waveform scaling factors using :mod:`dynesty` nested sampling."""
+
+    try:  # pragma: no cover - dependency may be optional
+        import dynesty  # type: ignore
+    except Exception as exc:  # pragma: no cover - import error path
+        raise RuntimeError("dynesty is required for dynesty_infer_waveform") from exc
+
+    if bounds is None:
+        bounds = {"mass_factor": (0.5, 1.5), "current_factor": (0.5, 1.5)}
+
+    names = ["mass_factor", "current_factor"]
+    lower = np.array([bounds[n][0] for n in names])
+    upper = np.array([bounds[n][1] for n in names])
+
+    time_sim = np.asarray(time_sim, dtype=float)
+    current_sim = np.asarray(current_sim, dtype=float)
+    time_data = np.asarray(time_data, dtype=float)
+    current_data = np.asarray(current_data, dtype=float)
+
+    def prior_transform(u: np.ndarray) -> np.ndarray:
+        return lower + u * (upper - lower)
+
+    def log_like(theta: np.ndarray) -> float:
+        mass_factor, current_factor = theta
+        scaled_time = mass_factor * time_sim
+        sim_interp = np.interp(
+            time_data, scaled_time, current_sim, left=0.0, right=0.0
+        )
+        pred = current_factor * sim_interp
+        resid = (current_data - pred) / sigma
+        return -0.5 * np.dot(resid, resid)
+
+    sampler = dynesty.NestedSampler(
+        log_like, prior_transform, len(names), nlive=n_live, seed=seed
+    )
+    sampler.run_nested(maxiter=n_iter, print_progress=False)
+    res = sampler.results
+    return {name: res.samples[:, idx] for idx, name in enumerate(names)}
+
+
+__all__ = [
+    "emcee_infer",
+    "dynesty_infer",
+    "emcee_infer_waveform",
+    "dynesty_infer_waveform",
+]


### PR DESCRIPTION
## Summary
- expand inference module with waveform-focused MCMC and nested-sampling routines
- add wrapper calibration helper and CLI for launching and summarising UQ runs
- provide uncertainty propagation to neutron yield and pinch timing with optional plots

## Testing
- `pytest tests/uq/test_calibration.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9ee7622c8832a829f1372f1dd312a