### PR TITLE
Add reproducible container build and run manifest logging

### DIFF
--- a/docs/hpc_deployment.md
+++ b/docs/hpc_deployment.md
@@ -1,0 +1,38 @@
+# HPC Deployment
+
+This guide outlines how to build the Singularity container used for DPF2
+simulations and how to submit jobs to a cluster using the bundled utilities.
+
+## Building the container
+
+The project ships with a `Singularity.def` definition that pins all runtime
+dependencies and installs an entrypoint script which records the current git
+commit and environment details.  Build the image with:
+
+```bash
+singularity build -F dpf2.sif infrastructure/Singularity.def
+```
+
+Running the resulting `dpf2.sif` image will print the code hash and platform
+information before executing the `dpf2` CLI.
+
+## Submitting jobs
+
+Use the :class:`dpf2.hpc.JobManager` helper to launch batch jobs on the
+cluster.  Each submission creates an `run_manifest.h5` file containing the
+code version, run configuration and container hash for reproducibility.
+
+```python
+from dpf2.hpc import JobManager
+
+jm = JobManager("slurm")
+jm.submit(
+    "run.sh",
+    config={"shot": 1},
+    container_hash="sha256:1234...",
+)
+```
+
+The manifest is staged with other outputs and may be used to audit or reproduce
+simulation runs on the cluster.
+

--- a/infrastructure/Singularity.def
+++ b/infrastructure/Singularity.def
@@ -2,11 +2,28 @@ Bootstrap: docker
 From: python:3.12-slim
 
 %post
-    pip install -r /app/requirements.txt
+    apt-get update && \
+        apt-get install -y --no-install-recommends git libhdf5-dev && \
+        rm -rf /var/lib/apt/lists/*
+    pip install numpy==1.26.4 scipy==1.11.4 pydantic==2.6.2 \
+        matplotlib==3.8.2 flask==3.0.0 h5py==3.10.0 \
+        numba==0.58.1 sympy==1.12 werkzeug==3.0.1 \
+        tqdm==4.66.1 fastapi==0.109.0 uvicorn==0.25.0 \
+        python-multipart==0.0.6
     pip install /app
+    cat <<'EOF' >/entrypoint.sh
+#!/bin/bash
+set -e
+CODE_HASH=$(cd /app && git rev-parse HEAD 2>/dev/null || echo unknown)
+echo "Code hash: $CODE_HASH"
+echo "Python: $(python --version)"
+echo "Platform: $(uname -a)"
+exec dpf2 "$@"
+EOF
+    chmod +x /entrypoint.sh
 
 %files
     .. /app
 
 %runscript
-    exec dpf2 "$@"
+    exec /entrypoint.sh "$@"

--- a/src/dpf2/hpc/manager.py
+++ b/src/dpf2/hpc/manager.py
@@ -9,6 +9,7 @@ underlying schedulers.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 import os
 import subprocess
 import tempfile
@@ -20,6 +21,32 @@ class JobManager:
     """Dispatch simulation jobs to different backends."""
 
     scheduler: str = "slurm"
+
+    def _write_hdf5_manifest(
+        self,
+        path: str,
+        config: Mapping[str, Any] | None,
+        container_hash: str | None,
+    ) -> None:
+        """Write a minimal HDF5 manifest capturing run metadata."""
+
+        try:
+            import h5py  # type: ignore
+        except Exception:  # pragma: no cover - optional dependency
+            return
+        try:
+            commit = subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], text=True
+            ).strip()
+        except Exception:  # pragma: no cover - git may be unavailable
+            commit = "unknown"
+        with h5py.File(path, "w") as h5:
+            manifest = h5.require_group("manifest")
+            manifest.attrs["git_commit"] = commit
+            if config is not None:
+                manifest.attrs["config"] = json.dumps(config)
+            if container_hash is not None:
+                manifest.attrs["container_hash"] = container_hash
 
     def _extend_cmd(self, cmd: list[str], opts: Dict[str, Any], flag_map: Dict[str, Iterable[str]]) -> None:
         """Append CLI options from ``opts`` to ``cmd`` using ``flag_map``.
@@ -87,7 +114,16 @@ class JobManager:
         os.chmod(path, 0o755)
         return path
 
-    def submit(self, job_script: str, *, manifest: str | None = None, **kwargs: Any) -> Any:
+    def submit(
+        self,
+        job_script: str,
+        *,
+        manifest: str | None = None,
+        manifest_h5: str | None = None,
+        config: Mapping[str, Any] | None = None,
+        container_hash: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
         """Submit ``job_script`` to the configured scheduler.
 
         Parameters
@@ -98,6 +134,15 @@ class JobManager:
             Optional path to a ``run_manifest.json`` that should be staged with
             other outputs. If omitted, ``"run_manifest.json"`` is used and will
             always be copied alongside job results.
+        manifest_h5:
+            Path to the ``run_manifest.h5`` file to generate. Defaults to
+            ``"run_manifest.h5"``.
+        config:
+            Configuration dictionary describing the run. When provided along
+            with ``container_hash`` an HDF5 manifest capturing this metadata is
+            written before submission.
+        container_hash:
+            Digest of the container image used for the run.
         **kwargs:
             Additional scheduler specific keyword arguments. ``restart`` may
             reference a manifest path to resume a previous run.
@@ -112,16 +157,19 @@ class JobManager:
         stage_out: Mapping[str, str] | None = kwargs.pop("stage_out", None)
         restart = kwargs.get("restart")
 
-        # Always copy the run manifest with other outputs so metadata is
-        # preserved. When ``manifest`` is not supplied we fall back to the
-        # conventional ``run_manifest.json`` name.
         manifest_path = manifest or "run_manifest.json"
+        manifest_h5_path = manifest_h5 or "run_manifest.h5"
+
+        if config is not None or container_hash is not None:
+            self._write_hdf5_manifest(manifest_h5_path, config, container_hash)
+
         stage_out = dict(stage_out or {})
         stage_out[manifest_path] = manifest_path
+        stage_out[manifest_h5_path] = manifest_h5_path
 
         # ``--restart`` may reference a previously generated manifest. Stage it
         # in so the job can resume using the recorded metadata.
-        if restart is not None and str(restart).endswith(".json"):
+        if restart is not None and (str(restart).endswith(".json") or str(restart).endswith(".h5")):
             stage_in = dict(stage_in or {})
             stage_in[str(restart)] = str(restart)
 

--- a/tests/performance/test_hpc_manager.py
+++ b/tests/performance/test_hpc_manager.py
@@ -146,3 +146,32 @@ def test_default_manifest_staged(tmp_path, monkeypatch):
     jm.submit(str(script))
     assert called["stage_out"]["run_manifest.json"] == "run_manifest.json"
 
+
+def test_hdf5_manifest_written(tmp_path, monkeypatch):
+    script = tmp_path / "job.sh"
+    script.write_text("#!/bin/bash\n")
+    jm = JobManager("slurm")
+
+    monkeypatch.setattr(JobManager, "_wrap_staging", lambda self, js, si, so: js)
+    monkeypatch.setattr(
+        "subprocess.run", lambda *a, **kw: type("R", (), {})()
+    )
+
+    manifest_h5 = tmp_path / "run_manifest.h5"
+    cfg = {"x": 1}
+
+    import h5py_stub as h5py, json
+
+    jm.submit(
+        str(script),
+        manifest_h5=str(manifest_h5),
+        config=cfg,
+        container_hash="abc123",
+    )
+
+    with h5py.File(manifest_h5, "r") as h5:
+        grp = h5["manifest"]
+        assert grp.attrs["container_hash"] == "abc123"
+        assert json.loads(grp.attrs["config"]) == cfg
+        assert "git_commit" in grp.attrs
+


### PR DESCRIPTION
## Summary
- pin runtime dependencies in Singularity container and add entrypoint that logs commit and environment details
- write an HDF5 manifest per run with code version, config, and container hash
- document container build process and cluster submission workflow

## Testing
- `pytest` *(fails: tests require additional dependencies, see log)*
- `pytest tests/performance/test_hpc_manager.py::test_hdf5_manifest_written -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9ee77ae0c832a9d5e9ddb67fc8d43