### PR TITLE
Add snapshot sharing and vector-field phase overlays

### DIFF
--- a/examples/labs/instability_lab.md
+++ b/examples/labs/instability_lab.md
@@ -1,0 +1,12 @@
+# Instability Growth Lab
+
+This exercise guides you through interpreting the Instability Visualizer.
+
+1. Open the **Instability Growth** panel and watch the waveform and green motion
+   vectors.
+2. Note how phase annotations divide the timeline into breakdown, rundown,
+   pinch, and afterglow segments.
+3. Capture a snapshot via **Save & Share** and reload it from the shared link or
+   by uploading the snapshot JSON file.
+4. Discuss how the vector field evolves between phases and how it relates to the
+   amplitude trace.

--- a/examples/labs/sheath_beam_lab.md
+++ b/examples/labs/sheath_beam_lab.md
@@ -1,0 +1,10 @@
+# Sheath & Beam Sandbox Lab
+
+Explore the interactive sheath and J×B overlay from the web sandbox.
+
+1. Launch the web frontend and open the **Sheath & J×B** panel.
+2. Vary the voltage and pressure sliders to see the sheath radius and drift
+   arrows respond. Green arrows show the phase‐dependent vector field.
+3. Use **Save & Share** to export the current state. Share the returned URL with
+   a partner and reload it to resume the scene.
+4. Record observations on how phase transitions modify the vector field.

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -7,7 +7,16 @@ from pathlib import Path
 import asyncio
 from typing import Any, Dict, List
 
-from fastapi import Depends, FastAPI, HTTPException, WebSocket, WebSocketDisconnect, status
+from fastapi import (
+    Depends,
+    FastAPI,
+    File,
+    HTTPException,
+    UploadFile,
+    WebSocket,
+    WebSocketDisconnect,
+    status,
+)
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from pydantic import BaseModel
 
@@ -18,6 +27,7 @@ from dpf2.diagnostics import RegimePanel
 BASE_DIR = Path(__file__).resolve().parent.parent
 AUDIT_LOG = BASE_DIR / "audit.log"
 UPLOAD_DIR = BASE_DIR / "uploads"
+SNAPSHOT_DIR = BASE_DIR / "snapshots"
 logging.basicConfig(level=logging.INFO, filename=str(AUDIT_LOG), format="%(asctime)s %(message)s")
 logger = logging.getLogger("dpf-web")
 
@@ -76,6 +86,10 @@ class SweepRequest(BaseModel):
     config: Dict[str, Any]
     parameter: str
     values: List[float]
+
+
+class SnapshotRequest(BaseModel):
+    state: Dict[str, Any]
 
 
 async def broadcast_progress(run_id: str, progress: float) -> None:
@@ -194,6 +208,33 @@ def get_results(run_id: str, user=Depends(require_role("admin"))):
 @app.get("/sweep/{run_id}")
 async def get_sweep(run_id: str, user=Depends(get_current_user)):
     return sweep_results.get(run_id, {})
+
+
+@app.post("/snapshot/save")
+async def save_snapshot(req: SnapshotRequest, user=Depends(get_current_user)):
+    """Persist a sandbox state and return a shareable reference."""
+    SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+    snap_id = f"snap-{datetime.utcnow().timestamp():.0f}-{len(req.state)}"
+    path = SNAPSHOT_DIR / f"{snap_id}.json"
+    path.write_text(json.dumps(req.state))
+    logger.info("action=save_snapshot user=%s id=%s", user["username"], snap_id)
+    return {"id": snap_id, "url": f"/snapshot/{snap_id}"}
+
+
+@app.get("/snapshot/{snap_id}")
+async def get_snapshot(snap_id: str):
+    path = SNAPSHOT_DIR / f"{snap_id}.json"
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Snapshot not found")
+    logger.info("action=get_snapshot id=%s", snap_id)
+    return json.loads(path.read_text())
+
+
+@app.post("/snapshot/upload")
+async def upload_snapshot(file: UploadFile = File(...)):
+    """Load a snapshot from a user-uploaded JSON file."""
+    data = json.loads(await file.read())
+    return data
 
 
 @app.websocket("/ws/progress/{run_id}")

--- a/web/frontend/src/InstabilityVisualizer.jsx
+++ b/web/frontend/src/InstabilityVisualizer.jsx
@@ -81,6 +81,24 @@ export default function InstabilityVisualizer() {
       />
       <svg ref={svgRef} width="200" height="100">
         <polyline points={pts} stroke="red" fill="none" />
+        {phaseNames.map((name, i) => {
+          const x = (i / phaseNames.length) * 200;
+          return (
+            <g key={name}>
+              <line
+                x1={x}
+                y1={0}
+                x2={x}
+                y2={100}
+                stroke="lightgray"
+                strokeDasharray="4 2"
+              />
+              <text x={x + 2} y={12} fontSize="10" fill="white">
+                {name}
+              </text>
+            </g>
+          );
+        })}
       </svg>
       <div>Phase: {phaseNames[phase]}</div>
       <button

--- a/web/frontend/src/SheathBeamOverlay.jsx
+++ b/web/frontend/src/SheathBeamOverlay.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 /**
  * Renders sheath evolution and J×B vectors using WebGL.
@@ -9,6 +9,9 @@ export default function SheathBeamOverlay({ voltage, pressure }) {
   const canvasRef = useRef(null);
   const voltageRef = useRef(voltage);
   const pressureRef = useRef(pressure);
+  const [phase, setPhase] = useState(0);
+  const phaseRef = useRef(0);
+  const phaseNames = ['Breakdown', 'Rundown', 'Pinch', 'Afterglow'];
 
   useEffect(() => {
     voltageRef.current = voltage;
@@ -17,6 +20,16 @@ export default function SheathBeamOverlay({ voltage, pressure }) {
   useEffect(() => {
     pressureRef.current = pressure;
   }, [pressure]);
+
+  useEffect(() => {
+    phaseRef.current = phase;
+  }, [phase]);
+
+  // Cycle through synthetic phases to demonstrate annotations
+  useEffect(() => {
+    const timer = setInterval(() => setPhase((p) => (p + 1) % 4), 1000);
+    return () => clearInterval(timer);
+  }, []);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -99,6 +112,39 @@ export default function SheathBeamOverlay({ voltage, pressure }) {
       }
       drawShape(arrows, gl.LINES, [1, 0.5, 0, 1]);
 
+      // Vector field overlay depending on phase
+      const field = [];
+      const grid = 5;
+      const spacing = 2 / (grid - 1); // normalized device coords
+      for (let i = 0; i < grid; i++) {
+        for (let j = 0; j < grid; j++) {
+          const x = -1 + i * spacing;
+          const y = -1 + j * spacing;
+          let u = 0;
+          let v = 0;
+          switch (phaseRef.current) {
+            case 0:
+              u = x;
+              v = y;
+              break; // Breakdown: radial outward
+            case 1:
+              u = -y;
+              v = x;
+              break; // Rundown: azimuthal
+            case 2:
+              u = -x;
+              v = -y;
+              break; // Pinch: radial inward
+            default:
+              u = 0;
+              v = 0;
+          }
+          const len = 0.1;
+          field.push(x, y, x + u * len, y + v * len);
+        }
+      }
+      drawShape(field, gl.LINES, [0, 1, 0, 1]);
+
       requestAnimationFrame(render);
     };
     render();
@@ -108,10 +154,13 @@ export default function SheathBeamOverlay({ voltage, pressure }) {
     <div className="overlay" title="Shows sheath edge and J×B drift using WebGL">
       <h4>Sheath &amp; J×B</h4>
       <canvas ref={canvasRef} width="200" height="200" title="Live WebGL canvas" />
+      <div>Phase: {phaseNames[phase]}</div>
       <details>
         <summary>What is this?</summary>
         The cyan disc approximates the sheath boundary and orange lines depict
         J×B drift. Radius follows voltage; arrow length scales with pressure.
+        Green arrows overlay a synthetic vector field that changes with the
+        annotated phase.
       </details>
     </div>
   );


### PR DESCRIPTION
## Summary
- overlay phase-dependent vector fields and annotations in web sandbox components
- enable Save & Share snapshot endpoints for sandbox states
- add guided lab exercises referencing Sheath & Beam and Instability Growth scenes

## Testing
- `npm run build`
- `pytest web/backend`


------
https://chatgpt.com/codex/tasks/task_e_68b9ee79f61c832a91d54462680451cd