### PR TITLE
Add metadata-driven domain checks for surrogate models

### DIFF
--- a/src/dpf2/ai/__init__.py
+++ b/src/dpf2/ai/__init__.py
@@ -1,6 +1,7 @@
 """Surrogate model interfaces for AI integration."""
 
 from .surrogate import SurrogateModel, TorchSurrogateModel, ONNXSurrogateModel
+from ..exceptions import OutOfDomainError
 from .training import load_numpy_dataset, train_torch_model
 from .simple_surrogates import (
     LinearSurrogate,
@@ -13,6 +14,7 @@ __all__ = [
     "SurrogateModel",
     "TorchSurrogateModel",
     "ONNXSurrogateModel",
+    "OutOfDomainError",
     "load_numpy_dataset",
     "train_torch_model",
     "LinearSurrogate",

--- a/src/dpf2/ai/surrogate.py
+++ b/src/dpf2/ai/surrogate.py
@@ -6,8 +6,11 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
+import json
 import numpy as np
 import pickle
+
+from ..exceptions import OutOfDomainError
 
 
 class SurrogateModel(ABC):
@@ -23,11 +26,65 @@ class SurrogateModel(ABC):
 
     def __init__(self, model_path: str | Path) -> None:
         self.model_path = Path(model_path)
+        metadata_path = self.model_path.with_name("metadata.json")
+        self._feature_mean: list[float] | None = None
+        self._inv_cov: list[list[float]] | None = None
+        self._mahalanobis_threshold: float | None = None
+        if metadata_path.exists():
+            with metadata_path.open() as fh:
+                metadata = json.load(fh)
+            mean = metadata.get("feature_mean")
+            cov_inv = metadata.get("feature_cov_inv")
+            cov = metadata.get("feature_cov")
+            threshold = metadata.get("mahalanobis_threshold")
+            if mean is not None and threshold is not None:
+                self._feature_mean = list(mean)
+                inv = None
+                if cov_inv is not None:
+                    inv = [list(row) for row in cov_inv]
+                elif cov is not None:
+                    try:
+                        import numpy as _np  # type: ignore
+                        inv = _np.linalg.inv(_np.asarray(cov)).tolist()
+                    except Exception:
+                        inv = None
+                if inv is not None:
+                    self._inv_cov = inv
+                    self._mahalanobis_threshold = float(threshold)
+                else:
+                    self._feature_mean = None
 
     @abstractmethod
-    def predict(self, inputs: np.ndarray) -> np.ndarray:
-        """Return model prediction for ``inputs``."""
+    def _predict(self, inputs: np.ndarray) -> np.ndarray:
         raise NotImplementedError
+
+    def predict(self, inputs: np.ndarray) -> np.ndarray:
+        """Return model prediction for ``inputs`` with domain validation."""
+        inputs_iter = [inputs] if getattr(inputs, "ndim", 1) == 1 else inputs
+        self._check_domain(inputs_iter)
+        return self._predict(inputs)
+
+    def _mahalanobis_distance(self, x: Any) -> float:
+        if self._feature_mean is None or self._inv_cov is None:
+            return 0.0
+        vec = x.data if hasattr(x, "data") else x
+        diff = [v - m for v, m in zip(vec, self._feature_mean)]
+        tmp = [sum(row[j] * diff[j] for j in range(len(diff))) for row in self._inv_cov]
+        return float(sum(diff[i] * tmp[i] for i in range(len(diff))))
+
+    def _check_domain(self, inputs: Any) -> None:
+        if (
+            self._feature_mean is None
+            or self._inv_cov is None
+            or self._mahalanobis_threshold is None
+        ):
+            return
+        distances = [self._mahalanobis_distance(x) for x in inputs]
+        if any(d > self._mahalanobis_threshold for d in distances):
+            raise OutOfDomainError(
+                f"Mahalanobis distance {max(distances):.3f} exceeds "
+                f"threshold {self._mahalanobis_threshold:.3f}"
+            )
 
     # ------------------------------------------------------------------
     # Optional lifecycle helpers
@@ -93,7 +150,7 @@ class TorchSurrogateModel(SurrogateModel):
         self.model.to(self.device)
         self.model.eval()
 
-    def predict(self, inputs: np.ndarray) -> np.ndarray:
+    def _predict(self, inputs: np.ndarray) -> np.ndarray:
         tensor = self._torch.as_tensor(inputs, device=self.device)
         with self._torch.no_grad():
             out = self.model(tensor).cpu().numpy()
@@ -153,7 +210,7 @@ class ONNXSurrogateModel(SurrogateModel):
             raise ImportError("onnxruntime is required for ONNXSurrogateModel") from exc
         self.session = ort.InferenceSession(str(self.model_path))
 
-    def predict(self, inputs: np.ndarray) -> np.ndarray:
+    def _predict(self, inputs: np.ndarray) -> np.ndarray:
         input_name = self.session.get_inputs()[0].name
         outputs = self.session.run(None, {input_name: inputs})
         return outputs[0]
@@ -175,4 +232,9 @@ class ONNXSurrogateModel(SurrogateModel):
         return cls(path)
 
 
-__all__ = ["SurrogateModel", "TorchSurrogateModel", "ONNXSurrogateModel"]
+__all__ = [
+    "SurrogateModel",
+    "TorchSurrogateModel",
+    "ONNXSurrogateModel",
+    "OutOfDomainError",
+]

--- a/src/dpf2/exceptions.py
+++ b/src/dpf2/exceptions.py
@@ -33,6 +33,9 @@ class ConfigurationError(DPFError):
 class SimulationRuntimeError(DPFError):
     """Raised for runtime errors occurring during simulation execution."""
 
+class OutOfDomainError(DPFError):
+    """Raised when model inputs are outside the training domain."""
+
 class ServerError(DPFError):
     """Base class for server-related errors."""
 

--- a/tests/test_ai_surrogate.py
+++ b/tests/test_ai_surrogate.py
@@ -1,8 +1,14 @@
+import json
 import numpy as np
 import pytest
 from typing import Any
 
-from dpf2.ai import SurrogateModel, TorchSurrogateModel, ONNXSurrogateModel
+from dpf2.ai import (
+    OutOfDomainError,
+    SurrogateModel,
+    TorchSurrogateModel,
+    ONNXSurrogateModel,
+)
 
 
 class SimpleSurrogate(SurrogateModel):
@@ -10,7 +16,7 @@ class SimpleSurrogate(SurrogateModel):
         super().__init__(model_path)
         self.scale = scale
 
-    def predict(self, inputs: Any) -> Any:
+    def _predict(self, inputs: Any) -> Any:
         return inputs * self.scale
 
 
@@ -34,6 +40,23 @@ def test_training_optional(tmp_path):
     metrics = model.train()
     assert metrics == {}
     assert model.scale == 5.0
+
+
+def test_out_of_domain(tmp_path):
+    model_path = tmp_path / "model.pkl"
+    meta = {
+        "feature_mean": [0.0, 0.0],
+        "feature_cov": [[1.0, 0.0], [0.0, 1.0]],
+        "feature_cov_inv": [[1.0, 0.0], [0.0, 1.0]],
+        "mahalanobis_threshold": 1.0,
+    }
+    (tmp_path / "metadata.json").write_text(json.dumps(meta))
+    model = SimpleSurrogate(model_path, scale=1.0)
+    inside = np.array([[0.5, 0.5]])
+    outside = np.array([[2.0, 2.0]])
+    np.testing.assert_allclose(model.predict(inside), inside)
+    with pytest.raises(OutOfDomainError):
+        model.predict(outside)
 
 
 def test_torch_surrogate_import_error(tmp_path):


### PR DESCRIPTION
## Summary
- load feature statistics from `metadata.json` during surrogate init
- validate inputs via Mahalanobis distance and raise `OutOfDomainError`
- expose `OutOfDomainError` and add regression tests

## Testing
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*
- `pytest tests/test_ai_surrogate.py -q`
- `pytest tests/test_ai_training.py -q` *(skipped: torch not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f201cd14832aaeff7a46649095de