### PR TITLE
Add DPF KPI calculator and web overlay

### DIFF
--- a/src/dpf2/diagnostics/performance_metrics.py
+++ b/src/dpf2/diagnostics/performance_metrics.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+"""Utilities for computing simple key performance indicators.
+
+The production code only needs a very small subset of KPIs in order to feed
+other parts of the UI.  The implementation here intentionally keeps the
+interface extremely small and returns a dictionary so that the front-end can
+consume it without having to understand any additional classes.
+"""
+
 from typing import Dict
 
 
@@ -38,12 +46,26 @@ def compute_performance_metrics(
     """
     if rep_rate_hz < 0:
         raise ValueError("rep_rate_hz must be non-negative")
+    if energy_in_j < 0 or energy_out_j < 0:
+        raise ValueError("energies must be non-negative")
+    if electrode_mass_g < 0:
+        raise ValueError("electrode_mass_g must be non-negative")
+    if erosion_per_shot_g < 0:
+        raise ValueError("erosion_per_shot_g must be non-negative")
 
+    # How many neutrons are produced per hour.  ``rep_rate_hz`` is the firing
+    # rate, so we convert to hours by multiplying by ``3600``.
     yield_hour = yield_per_shot * rep_rate_hz * 3600.0
 
+    # The wall plug efficiency is defined as the ratio of output to input
+    # energy.  If the input energy is zero the efficiency is defined to be zero
+    # rather than raising an error in order to keep the API convenient for the
+    # front end.
     wall = energy_out_j / energy_in_j if energy_in_j > 0 else 0.0
 
-    if erosion_per_shot_g <= 0 or rep_rate_hz == 0:
+    # ``erosion_per_shot_g`` can be zero when erosion has not been measured.
+    # In such cases the lifetime is effectively unbounded.
+    if erosion_per_shot_g == 0 or rep_rate_hz == 0:
         lifetime = float("inf")
     else:
         shots = electrode_mass_g / erosion_per_shot_g

--- a/tests/diagnostics/test_performance_metrics.py
+++ b/tests/diagnostics/test_performance_metrics.py
@@ -32,3 +32,24 @@ def test_zero_and_infinite_cases():
     )
     assert metrics["wall_plug_efficiency"] == 0.0
     assert math.isinf(metrics["lifetime_hours"])
+
+
+def test_invalid_inputs():
+    with pytest.raises(ValueError):
+        compute_performance_metrics(
+            1.0,
+            rep_rate_hz=-1.0,
+            energy_out_j=1.0,
+            energy_in_j=1.0,
+            electrode_mass_g=1.0,
+            erosion_per_shot_g=1.0,
+        )
+    with pytest.raises(ValueError):
+        compute_performance_metrics(
+            1.0,
+            rep_rate_hz=1.0,
+            energy_out_j=-1.0,
+            energy_in_j=1.0,
+            electrode_mass_g=1.0,
+            erosion_per_shot_g=1.0,
+        )

--- a/web/frontend/src/EfficiencyCurveOverlay.jsx
+++ b/web/frontend/src/EfficiencyCurveOverlay.jsx
@@ -1,12 +1,18 @@
 import React, { useMemo, useRef } from 'react';
 
+// ``datasets`` is an array of objects describing a parameter sweep.  Each
+// dataset has a ``data`` object whose keys are the sweep parameter values and
+// whose values are the metrics computed on the Python side.  This component
+// renders a simple polyline plot of the wall plug efficiency and also exposes
+// a small text summary of the best performing shot.
 export default function EfficiencyCurveOverlay({ datasets = [] }) {
   const svgRef = useRef(null);
 
   const summary = useMemo(() => {
-    if (datasets.length === 0) return null;
-    const first = datasets[0].data || {};
-    const metrics = Object.values(first);
+    // Flatten all metric objects into a single list and pick the one with the
+    // highest wall-plug efficiency.  ``datasets`` can be empty or have missing
+    // ``data`` dictionaries, so we guard for that as well.
+    const metrics = datasets.flatMap((d) => Object.values(d.data || {}));
     if (metrics.length === 0) return null;
     const best = metrics.reduce((a, b) => {
       const aEff = a.wall_plug_efficiency ?? a.efficiency ?? 0;


### PR DESCRIPTION
## Summary
- implement compute_performance_metrics utility for DPF KPI calculations
- show best performance metrics on efficiency curve overlay component
- test KPI calculator including error handling

## Testing
- `pytest tests/diagnostics/test_performance_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9f879ea94832aa8de63cd965763bd