### PR TITLE
feat: expose regime parameter violations in dashboard

### DIFF
--- a/src/dpf2/diagnostics/quality_dashboard.py
+++ b/src/dpf2/diagnostics/quality_dashboard.py
@@ -122,30 +122,56 @@ class QualityDashboard:
             "omega_ce_tau_e": omega_ce_tau_e,
         }
 
-        self.regime_history.append(entry)
-        self.output_dir.mkdir(parents=True, exist_ok=True)
-        with open(self.output_dir / "regime.json", "w", encoding="utf-8") as fh:
-            json.dump(self.regime_history, fh, indent=2)
-
         def _warn_or_abort(msg: str) -> None:
             logger.warning(msg)
             if self.abort_on_violation:
                 raise RuntimeError(msg)
 
-        if self.min_S is not None and S < self.min_S:
-            _warn_or_abort(f"Lundquist number below threshold: {S:g} < {self.min_S:g}")
-        if self.max_beta is not None and beta > self.max_beta:
-            _warn_or_abort(f"Plasma beta above threshold: {beta:g} > {self.max_beta:g}")
-        if self.max_M_A is not None and M_A > self.max_M_A:
-            _warn_or_abort(f"Alfvén Mach number above threshold: {M_A:g} > {self.max_M_A:g}")
-        if self.min_R_m is not None and R_m < self.min_R_m:
-            _warn_or_abort(f"Magnetic Reynolds number below threshold: {R_m:g} < {self.min_R_m:g}")
-        if self.max_K_n is not None and K_n > self.max_K_n:
-            _warn_or_abort(f"Knudsen number above threshold: {K_n:g} > {self.max_K_n:g}")
-        if self.min_omega_ce_tau_e is not None and omega_ce_tau_e < self.min_omega_ce_tau_e:
-            _warn_or_abort(
-                f"Cyclotron frequency–collision time below threshold: {omega_ce_tau_e:g} < {self.min_omega_ce_tau_e:g}"
-            )
+        violations = {
+            "S": self.min_S is not None and S < self.min_S,
+            "beta": self.max_beta is not None and beta > self.max_beta,
+            "M_A": self.max_M_A is not None and M_A > self.max_M_A,
+            "R_m": self.min_R_m is not None and R_m < self.min_R_m,
+            "K_n": self.max_K_n is not None and K_n > self.max_K_n,
+            "omega_ce_tau_e": self.min_omega_ce_tau_e is not None
+            and omega_ce_tau_e < self.min_omega_ce_tau_e,
+        }
+
+        for key, violated in violations.items():
+            if not violated:
+                continue
+            if key == "S":
+                _warn_or_abort(
+                    f"Lundquist number below threshold: {S:g} < {self.min_S:g}"
+                )
+            elif key == "beta":
+                _warn_or_abort(
+                    f"Plasma beta above threshold: {beta:g} > {self.max_beta:g}"
+                )
+            elif key == "M_A":
+                _warn_or_abort(
+                    f"Alfvén Mach number above threshold: {M_A:g} > {self.max_M_A:g}"
+                )
+            elif key == "R_m":
+                _warn_or_abort(
+                    f"Magnetic Reynolds number below threshold: {R_m:g} < {self.min_R_m:g}"
+                )
+            elif key == "K_n":
+                _warn_or_abort(
+                    f"Knudsen number above threshold: {K_n:g} > {self.max_K_n:g}"
+                )
+            elif key == "omega_ce_tau_e":
+                _warn_or_abort(
+                    "Cyclotron frequency–collision time below threshold: "
+                    f"{omega_ce_tau_e:g} < {self.min_omega_ce_tau_e:g}"
+                )
+
+        entry["violations"] = violations
+
+        self.regime_history.append(entry)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        with open(self.output_dir / "regime.json", "w", encoding="utf-8") as fh:
+            json.dump(self.regime_history, fh, indent=2)
 
         self._update_regime_plot()
 

--- a/tests/gui/test_regime_dashboard.py
+++ b/tests/gui/test_regime_dashboard.py
@@ -7,4 +7,5 @@ def test_regime_dashboard_websocket_subscription():
     assert "/ws/regime" in content
     for key in ["S", "beta", "M_A", "R_m", "K_n", "omega_ce_tau_e"]:
         assert key in content
+    assert "violations" in content
 

--- a/web/frontend/src/RegimeDashboard.jsx
+++ b/web/frontend/src/RegimeDashboard.jsx
@@ -18,31 +18,17 @@ export default function RegimeDashboard() {
     return () => ws.close();
   }, []);
 
-  const limits = {
-    S: 1,
-    beta: 1,
-    M_A: 1,
-    R_m: 1,
-    K_n: 0.1,
-    omega_ce_tau_e: 1,
-  };
-
+  const params = ['S', 'beta', 'M_A', 'R_m', 'K_n', 'omega_ce_tau_e'];
   const latest = data[data.length - 1] || {};
-  const check = (key) => {
-    const val = latest[key];
-    if (val === undefined) return '';
-    if (['beta', 'M_A', 'K_n'].includes(key)) {
-      return val > limits[key] ? 'violation' : '';
-    }
-    return val < limits[key] ? 'violation' : '';
-  };
+  const check = (key) =>
+    latest.violations && latest.violations[key] ? 'violation' : '';
 
   return (
     <div className="overlay" title="Tracks plasma regime parameters">
       <h4>Regime Dashboard</h4>
       <table>
         <tbody>
-          {Object.keys(limits).map((k) => (
+          {params.map((k) => (
             <tr key={k} className={check(k)}>
               <td>{k}</td>
               <td>{latest[k] !== undefined ? latest[k].toFixed(3) : '-'}</td>


### PR DESCRIPTION
## Summary
- include detailed regime parameter violation flags in `QualityDashboard` entries
- rely on back-end violations in `RegimeDashboard` UI to mark out-of-bounds values
- cover dashboard with a small UI test

## Testing
- `pytest tests/gui/test_regime_dashboard.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9f8769a98832a8cf3d42167b13198