### PR TITLE
feat: add plasma-triggered AMR refinement

### DIFF
--- a/src/dpf2/diagnostics/quality_dashboard.py
+++ b/src/dpf2/diagnostics/quality_dashboard.py
@@ -45,7 +45,16 @@ class QualityDashboard:
         energy_drift: float = 0.0,
 
     ) -> None:
-        """Record a step's metrics and emit warnings if thresholds violated."""
+        """Record a step's metrics and emit warnings if thresholds violated.
+
+        Parameters
+        ----------
+        amr_level:
+            Current refinement level, if adaptive mesh refinement is enabled.
+            When provided the level is stored and visualised in the stability
+            plot, allowing users to correlate mesh changes with other quality
+            metrics.
+        """
         entry = {
             "step": step,
             "dt": dt,

--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -523,7 +523,9 @@ class HallMHDSolver(PlasmaSolverBase):
     def amr_refinement(self, state: MHDState) -> None:
         """Invoke the refinement callback if provided."""
         if self.refine is not None:
-            self.refine(state)
+            stats = self.refine(state)
+            if stats:
+                logger.info("AMR callback stats: %s", stats)
 
     def _exchange_array(self, arr: np.ndarray) -> None:
         """Exchange ghost cells of ``arr`` with neighbouring MPI ranks."""

--- a/src/dpf2/mesh/amr.py
+++ b/src/dpf2/mesh/amr.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Any, Optional
 
+import logging
 import numpy as np
 
 try:  # pragma: no cover - optional dependency
     import pyamrex  # type: ignore
 except Exception:  # pragma: no cover - gracefully degrade if backend missing
     pyamrex = None  # type: ignore
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -45,22 +48,14 @@ def plasma_gradient_refinement(field: np.ndarray, threshold: float) -> np.ndarra
 
 def debye_length_refinement(lambda_D: np.ndarray, threshold: float) -> np.ndarray:
     """Return mask where the Debye length ``lambda_D`` falls below ``threshold``."""
-    arr = lambda_D.data if hasattr(lambda_D, "data") else lambda_D
-    def _walk(a):
-        if isinstance(a, list):
-            return [_walk(x) for x in a]
-        return bool(a < threshold)
-    return np.array(_walk(arr))
+    arr = np.asarray(lambda_D)
+    return arr < threshold
 
 
 def ion_inertial_length_refinement(d_i: np.ndarray, threshold: float) -> np.ndarray:
     """Return mask where the ion inertial length ``d_i`` falls below ``threshold``."""
-    arr = d_i.data if hasattr(d_i, "data") else d_i
-    def _walk(a):
-        if isinstance(a, list):
-            return [_walk(x) for x in a]
-        return bool(a < threshold)
-    return np.array(_walk(arr))
+    arr = np.asarray(d_i)
+    return arr < threshold
 
 
 def pressure_gradient_refinement(pressure: np.ndarray, threshold: float) -> np.ndarray:
@@ -70,17 +65,11 @@ def pressure_gradient_refinement(pressure: np.ndarray, threshold: float) -> np.n
 
 def current_density_refinement(current: np.ndarray, threshold: float) -> np.ndarray:
     """Return mask where the current density magnitude exceeds ``threshold``."""
-    arr = current.data if hasattr(current, "data") else current
-    def _walk(a):
-        if isinstance(a, list) and a and not isinstance(a[0], list):
-            if len(a) != 3:
-                raise ValueError("current vectors must have three components")
-            mag = (a[0]**2 + a[1]**2 + a[2]**2) ** 0.5
-            return mag > threshold
-        if isinstance(a, list):
-            return [_walk(x) for x in a]
-        raise ValueError("current must be an array of vectors")
-    return np.array(_walk(arr))
+    arr = np.asarray(current)
+    if arr.shape[-1] != 3:
+        raise ValueError("current vectors must have three components")
+    mag = np.sqrt(np.sum(arr**2, axis=-1))
+    return mag > threshold
 
 
 def wavefront_refinement(field: np.ndarray, prev_field: np.ndarray, threshold: float) -> np.ndarray:
@@ -120,10 +109,26 @@ class AMRMesh:
         self,
         plasma_state: Optional[Dict[str, Any]] = None,
         prev_field: Optional[np.ndarray] = None,
-    ) -> None:
-        """Apply refinement criteria and notify the backend."""
+    ) -> Dict[str, int]:
+        """Apply refinement criteria and notify the backend.
+
+        Parameters
+        ----------
+        plasma_state:
+            Mapping of field names to arrays.  Recognised keys include
+            ``density``, ``field``, ``lambda_D``, ``d_i``, ``pressure`` and
+            ``current``.
+        prev_field:
+            Optional previous field for wavefront detection.
+
+        Returns
+        -------
+        dict
+            Statistics about tagged cells for each criterion along with the
+            total number of tagged cells.
+        """
         if plasma_state is None:
-            return
+            return {}
 
         density = plasma_state.get("density")
         field = plasma_state.get("field")
@@ -132,50 +137,70 @@ class AMRMesh:
         pressure = plasma_state.get("pressure")
         current = plasma_state.get("current")
 
-        def _init_mask(shape):
-            if isinstance(shape, int):
-                return [False] * shape
-            if isinstance(shape, tuple):
-                return [_init_mask(s) for s in shape]
-            raise TypeError("shape must be int or tuple")
-
-        def _or(a, b):
-            if isinstance(a, list):
-                return [_or(x, y) for x, y in zip(a, b)]
-            return bool(a) or bool(b)
-
-        mask = _init_mask(self.shape)
+        mask = np.zeros(self.shape, dtype=bool)
+        stats: Dict[str, int] = {}
 
         grad_thresh = self.criteria.get("gradient_threshold")
         if density is not None and grad_thresh is not None:
-            mask = _or(mask, plasma_gradient_refinement(density, grad_thresh).data)
+            gmask = plasma_gradient_refinement(density, grad_thresh)
+            stats["gradient"] = int(np.sum(gmask))
+            mask |= gmask
+            if stats["gradient"]:
+                logger.info("AMR gradient trigger tagged %d cells", stats["gradient"])
 
         wave_thresh = self.criteria.get("wavefront_threshold")
         if field is not None and prev_field is not None and wave_thresh is not None:
-            mask = _or(mask, wavefront_refinement(field, prev_field, wave_thresh).data)
+            wmask = wavefront_refinement(field, prev_field, wave_thresh)
+            stats["wavefront"] = int(np.sum(wmask))
+            mask |= wmask
+            if stats["wavefront"]:
+                logger.info("AMR wavefront trigger tagged %d cells", stats["wavefront"])
 
         ld_thresh = self.criteria.get("lambda_D_threshold")
         if lambda_D is not None and ld_thresh is not None:
-            mask = _or(mask, debye_length_refinement(lambda_D, ld_thresh).data)
+            ldmask = debye_length_refinement(lambda_D, ld_thresh)
+            stats["lambda_D"] = int(np.sum(ldmask))
+            mask |= ldmask
+            if stats["lambda_D"]:
+                logger.info("AMR λ_D trigger tagged %d cells", stats["lambda_D"])
 
         di_thresh = self.criteria.get("d_i_threshold")
         if d_i is not None and di_thresh is not None:
-            mask = _or(mask, ion_inertial_length_refinement(d_i, di_thresh).data)
+            dimask = ion_inertial_length_refinement(d_i, di_thresh)
+            stats["d_i"] = int(np.sum(dimask))
+            mask |= dimask
+            if stats["d_i"]:
+                logger.info("AMR d_i trigger tagged %d cells", stats["d_i"])
 
         gradp_thresh = self.criteria.get("pressure_gradient_threshold")
         if pressure is not None and gradp_thresh is not None:
-            mask = _or(mask, pressure_gradient_refinement(pressure, gradp_thresh).data)
+            pmask = pressure_gradient_refinement(pressure, gradp_thresh)
+            stats["pressure_gradient"] = int(np.sum(pmask))
+            mask |= pmask
+            if stats["pressure_gradient"]:
+                logger.info(
+                    "AMR |∇p| trigger tagged %d cells", stats["pressure_gradient"]
+                )
 
         J_thresh = self.criteria.get("current_density_threshold")
         if current is not None and J_thresh is not None:
-            mask = _or(mask, current_density_refinement(current, J_thresh).data)
+            jmask = current_density_refinement(current, J_thresh)
+            stats["current_density"] = int(np.sum(jmask))
+            mask |= jmask
+            if stats["current_density"]:
+                logger.info(
+                    "AMR |J| trigger tagged %d cells", stats["current_density"]
+                )
 
         self._last_mask = np.array(mask)
+        stats["tagged_cells"] = int(np.sum(self._last_mask))
 
         if self._backend and hasattr(self._backend, "amr"):
-            self._backend.amr.tag_cells(mask.astype(np.int8))
+            self._backend.amr.tag_cells(self._last_mask.astype(np.int8))
             if hasattr(self._backend, "warpx"):
                 self._backend.warpx.regrid()
+
+        return stats
 
     # ------------------------------------------------------------------
     def tagging_stats(self) -> Dict[str, int]:

--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -437,8 +437,10 @@ class SimulationEngine:
                 for diag in diag_list:
                     diag.record(updated, circuit.time[-1])
 
-            if self._mesh is not None:
-                self._mesh.refine()
+            if self._mesh is not None and plasma_state is not None:
+                stats = self._mesh.refine(plasma_state)
+                if stats:
+                    logger.info("AMR mesh stats: %s", stats)
 
             current, voltage = updated.current, updated.voltage
             step += 1

--- a/tests/mesh/test_amr_triggers.py
+++ b/tests/mesh/test_amr_triggers.py
@@ -23,8 +23,7 @@ def test_ion_inertial_length_trigger():
 def test_pressure_gradient_trigger():
     p = np.array([[1.0, 1.0], [2.0, 4.0]])
     mask = pressure_gradient_refinement(p, 1.0)
-    data = mask.data if hasattr(mask, "data") else mask
-    assert any(any(row) for row in data)
+    assert np.any(mask)
 
 
 def test_current_density_trigger():
@@ -39,5 +38,6 @@ def test_amrmesh_combines_triggers():
     ld = np.array([[0.1, 0.6], [0.4, 0.2]])
     J = np.array([[[0.0, 0.0, 0.0], [3.0, 4.0, 0.0]],
                   [[0.0, 0.0, 0.0], [0.0, 0.0, 6.0]]])
-    mesh.refine({"lambda_D": ld, "current": J})
+    stats = mesh.refine({"lambda_D": ld, "current": J})
+    assert stats["tagged_cells"] == 4
     assert mesh.tagging_stats()["tagged_cells"] == 4


### PR DESCRIPTION
## Summary
- implement Debye length, inertial length, pressure gradient and current density AMR triggers
- propagate refinement stats to solvers and simulation engine
- document AMR level plotting in quality dashboard

## Testing
- `pytest tests/mesh/test_amr_triggers.py`
- `pytest tests/test_quality_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_68b9f8726f0c832aaaad2ff5e067cf05