### PR TITLE
Refactor synthetic diagnostics into package and add import tests

### DIFF
--- a/src/dpf2/synthetic_diagnostics/__init__.py
+++ b/src/dpf2/synthetic_diagnostics/__init__.py
@@ -1,0 +1,6 @@
+"""Synthetic diagnostics package exposing public API and modes submodule."""
+
+from . import core, modes
+from .core import *  # noqa: F401,F403
+
+__all__ = [*core.__all__, "modes"]

--- a/src/dpf2/synthetic_diagnostics/core.py
+++ b/src/dpf2/synthetic_diagnostics/core.py
@@ -16,14 +16,14 @@ except Exception:  # pragma: no cover
 
 import numpy as np
 from pydantic import BaseModel, ConfigDict, Field
-from .utils.pydantic_compat import model_validator
+from ..utils.pydantic_compat import model_validator
 
 
 
-from .core_schema import ConfigSectionBase, to_camel_case
-from .units_settings import UnitsSettings
-from .core.bases import CouplingState
-from .diagnostics.synthetic_signals import (
+from ..core_schema import ConfigSectionBase, to_camel_case
+from ..units_settings import UnitsSettings
+from ..core.bases import CouplingState
+from ..diagnostics.synthetic_signals import (
     current_waveform,
     voltage_waveform,
     coupled_current_waveform,
@@ -723,4 +723,6 @@ __all__ = [
     "export_directional_yields",
     "autocorrelated_tof_iv_report",
     "anisotropy_report",
+    "flashover_delay_stats",
+    "flashover_jitter_stats",
 ]

--- a/tests/test_synthetic_diagnostics_imports.py
+++ b/tests/test_synthetic_diagnostics_imports.py
@@ -1,0 +1,11 @@
+
+def test_package_import():
+    # The package should be importable via the top-level namespace
+    from dpf2 import synthetic_diagnostics as sd
+    assert sd is not None
+
+
+def test_modes_submodule_import():
+    # The modes submodule should still be accessible
+    from dpf2.synthetic_diagnostics import modes
+    assert hasattr(modes, "plot_growth_rates")


### PR DESCRIPTION
## Summary
- move synthetic_diagnostics module into a package and expose its API from `__init__`
- re-export modes submodule and include flashover helpers in public API
- add regression tests for importing the package and modes submodule

## Testing
- `pytest -q tests/test_synthetic_diagnostics_imports.py && echo done`
- `pytest -q tests/test_synthetic_diagnostics.py tests/test_synthetic_tof_trace.py tests/test_anisotropy_report.py tests/test_directional_yields.py tests/breakdown/test_flashover.py && echo done`

------
https://chatgpt.com/codex/tasks/task_e_68b9f8500a80832a93f93e1960971952