### PR TITLE
Record container hash in manifest

### DIFF
--- a/docs/hpc_deployment.md
+++ b/docs/hpc_deployment.md
@@ -19,8 +19,10 @@ information before executing the `dpf2` CLI.
 ## Submitting jobs
 
 Use the :class:`dpf2.hpc.JobManager` helper to launch batch jobs on the
-cluster.  Each submission creates an `run_manifest.h5` file containing the
-code version, run configuration and container hash for reproducibility.
+cluster.  Each submission creates a `run_manifest.h5` file capturing the git
+commit, run configuration and container image hash.  When no hash is supplied
+explicitly, the manager looks for a `SINGULARITY_CONTAINER` environment variable
+and records the SHA256 digest of that image for later auditing.
 
 ```python
 from dpf2.hpc import JobManager
@@ -29,10 +31,11 @@ jm = JobManager("slurm")
 jm.submit(
     "run.sh",
     config={"shot": 1},
-    container_hash="sha256:1234...",
+    # container_hash="sha256:1234...",  # optional
 )
 ```
 
-The manifest is staged with other outputs and may be used to audit or reproduce
+The manifest is staged with other outputs and may be inspected with tools like
+`h5dump run_manifest.h5` or from Python using `h5py` to reproduce and audit
 simulation runs on the cluster.
 

--- a/infrastructure/Singularity.def
+++ b/infrastructure/Singularity.def
@@ -26,4 +26,9 @@ EOF
     .. /app
 
 %runscript
+    # ``JobManager`` generates a ``run_manifest.h5`` capturing the git commit
+    # and a hash of this container image.  Singularity exposes the currently
+    # running image via ``SINGULARITY_CONTAINER`` which is hashed at runtime.
+    # The manifest may later be inspected with tools like ``h5dump`` to audit a
+    # job's execution environment.
     exec /entrypoint.sh "$@"

--- a/src/dpf2/hpc/manager.py
+++ b/src/dpf2/hpc/manager.py
@@ -28,7 +28,13 @@ class JobManager:
         config: Mapping[str, Any] | None,
         container_hash: str | None,
     ) -> None:
-        """Write a minimal HDF5 manifest capturing run metadata."""
+        """Write a minimal HDF5 manifest capturing run metadata.
+
+        ``container_hash`` may be ``None`` in which case the runtime
+        environment is inspected for a container image to hash.  The Singularity
+        runtime exposes the ``SINGULARITY_CONTAINER`` variable pointing at the
+        active ``.sif`` image which is used when available.
+        """
 
         try:
             import h5py  # type: ignore
@@ -40,12 +46,29 @@ class JobManager:
             ).strip()
         except Exception:  # pragma: no cover - git may be unavailable
             commit = "unknown"
+
+        config = config or {}
+        if not container_hash:
+            # Singularity exposes the path to the running image via the
+            # ``SINGULARITY_CONTAINER`` variable.  Hash the file to obtain a
+            # reproducible identifier for the runtime environment.
+            img = os.environ.get("SINGULARITY_CONTAINER")
+            if img:
+                try:
+                    container_hash = (
+                        subprocess.check_output(["sha256sum", img], text=True)
+                        .split()[0]
+                        .strip()
+                    )
+                except Exception:  # pragma: no cover - hashing may fail
+                    container_hash = None
+
         with h5py.File(path, "w") as h5:
             manifest = h5.require_group("manifest")
             manifest.attrs["git_commit"] = commit
-            if config is not None:
+            if config:
                 manifest.attrs["config"] = json.dumps(config)
-            if container_hash is not None:
+            if container_hash:
                 manifest.attrs["container_hash"] = container_hash
 
     def _extend_cmd(self, cmd: list[str], opts: Dict[str, Any], flag_map: Dict[str, Iterable[str]]) -> None:
@@ -159,9 +182,14 @@ class JobManager:
 
         manifest_path = manifest or "run_manifest.json"
         manifest_h5_path = manifest_h5 or "run_manifest.h5"
-
-        if config is not None or container_hash is not None:
-            self._write_hdf5_manifest(manifest_h5_path, config, container_hash)
+        # Always write an HDF5 manifest.  ``_write_hdf5_manifest`` will fill in
+        # empty defaults and attempt to derive the container hash from the
+        # runtime environment when not supplied.
+        self._write_hdf5_manifest(
+            manifest_h5_path,
+            config or {},
+            container_hash or None,
+        )
 
         stage_out = dict(stage_out or {})
         stage_out[manifest_path] = manifest_path


### PR DESCRIPTION
## Summary
- Always generate `run_manifest.h5` and populate it with run config and container hash
- Derive container hash from `SINGULARITY_CONTAINER` when not provided
- Document manifest creation and inspection in container definition and HPC guide

## Testing
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f853d560832aa63ae91bf9c8fc76