### PR TITLE
Use Pydantic validator for neutron yield rules

### DIFF
--- a/src/dpf2/neutron_yield_model.py
+++ b/src/dpf2/neutron_yield_model.py
@@ -19,7 +19,7 @@ from typing import (
 import math
 import numpy as np
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
 from .utils.pydantic_compat import model_validator as _model_validator
 
 
@@ -27,17 +27,6 @@ from .utils.pydantic_compat import model_validator as _model_validator
 
 
 from .core_schema import ConfigSectionBase, to_camel_case
-
-
-def from_camel_case(string: str) -> str:
-    out = []
-    for ch in string:
-        if ch.isupper():
-            out.append("_")
-            out.append(ch.lower())
-        else:
-            out.append(ch)
-    return "".join(out)
 
 from .units_settings import UnitsSettings
 
@@ -87,8 +76,12 @@ class NeutronYieldModel(ConfigSectionBase):
     # Thermonuclear fusion configuration
     reactivity_source: Literal["look-up", "analytic", "FLYCHK"] = "look-up"
     maxwellian_assumed: bool = True
-    average_ion_temperature_keV: Optional[float] = None
-    average_ion_density_cm3: Optional[float] = None
+    average_ion_temperature_keV: Optional[float] = Field(
+        None, alias="averageIonTemperatureKeV"
+    )
+    average_ion_density_cm3: Optional[float] = Field(
+        None, alias="averageIonDensityCm3"
+    )
     dd_branching_ratio: Optional[float] = Field(0.5, ge=0.0, le=1.0)
     reactivity_table_path: Optional[Path] = None
     reactivity_table_units: Optional[Dict[str, str]] = {"Ti": "keV", "reactivity": "cm^3/s"}
@@ -96,7 +89,9 @@ class NeutronYieldModel(ConfigSectionBase):
     # ------------------------------------------------------------------
     # Spectrum output and detector modeling
     neutron_spectrum_output_enabled: bool = True
-    spectrum_energy_bins_MeV: Optional[List[float]] = None
+    spectrum_energy_bins_MeV: Optional[List[float]] = Field(
+        None, alias="spectrumEnergyBinsMeV"
+    )
     anisotropic_spectrum: bool = False
     spectrum_output_format: Optional[Literal["csv", "OpenPMD", "plot", "hdf5"]] = "csv"
     apply_detector_response_function: bool = False
@@ -174,19 +169,7 @@ class NeutronYieldModel(ConfigSectionBase):
         return hashlib.sha256(serialized.encode()).hexdigest()
 
     # ------------------------------------------------------------------
-    @classmethod
-    def model_validate(cls, data: Dict[str, Any]) -> "NeutronYieldModel":
-        alias_map = {to_camel_case(n): n for n in cls.__annotations__}
-        for n in list(alias_map):
-            if n.endswith("Mev"):
-                alias_map[n[:-3] + "MeV"] = alias_map[n]
-        cleaned = {
-            alias_map.get(k, from_camel_case(k)): v for k, v in data.items()
-        }
-        inst = cls(**cleaned)
-        return cls.check_rules(inst)
-
-    @classmethod
+    @_model_validator(mode="after")
     def check_rules(cls, values: "NeutronYieldModel") -> "NeutronYieldModel":
         if (
             values.thermonuclear_model_enabled

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,14 @@
 import sys
 from pathlib import Path
 
-# Provide a minimal ``numpy`` implementation for environments where the
+# Preload real pydantic if available before adding the local ``src`` path
+# which contains lightweight stubs used for optional dependencies.
+try:  # pragma: no cover - prefer real pydantic when installed
+    import pydantic  # noqa: F401
+except Exception:  # pragma: no cover - fall back to stub later if missing
+    pass
 
+# Provide a minimal ``numpy`` implementation for environments where the
 # dependency is unavailable.  If the real ``numpy`` package is installed the
 # stub is skipped and the genuine implementation is used.
 try:  # pragma: no cover - prefer real numpy

--- a/tests/test_neutron_yield_model.py
+++ b/tests/test_neutron_yield_model.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from pydantic import ValidationError
 
 from dpf2.neutron_yield_model import NeutronYieldModel
 
@@ -19,7 +20,17 @@ def test_requires_temp_density_for_analytic_thermal_model():
     data["reactivitySource"] = "analytic"
     data.pop("averageIonTemperatureKeV", None)
     data.pop("averageIonDensityCm3", None)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
+        NeutronYieldModel.model_validate(data)
+
+
+def test_requires_temperature_for_analytic_thermal_model():
+    data = {
+        "beamIonSpecies": "D+",
+        "reactivitySource": "analytic",
+        "averageIonDensityCm3": 1e21,
+    }
+    with pytest.raises(ValidationError):
         NeutronYieldModel.model_validate(data)
 
 
@@ -27,17 +38,17 @@ def test_missing_response_file_when_enabled():
     data = base_data()
     data["applyDetectorResponseFunction"] = True
     data["detectorResponseFile"] = None
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         NeutronYieldModel.model_validate(data)
 
 
 def test_branching_ratio_bounds():
     data = base_data()
     data["ddBranchingRatio"] = 1.5
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         NeutronYieldModel.model_validate(data)
     data["ddBranchingRatio"] = -0.1
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         NeutronYieldModel.model_validate(data)
 
 
@@ -103,7 +114,7 @@ def test_missing_reactivity_table_path_for_lookup():
     data = base_data()
     data["reactivitySource"] = "look-up"
     data["reactivityTablePath"] = None
-    with pytest.raises(ValueError, match="reactivity_table_path required"):
+    with pytest.raises(ValidationError, match="reactivity_table_path required"):
         NeutronYieldModel.model_validate(data)
 
 
@@ -111,21 +122,21 @@ def test_cross_section_table_required_for_tabulated():
     data = base_data()
     data["fusionCrossSectionModel"] = "tabulated"
     data["crossSectionTablePath"] = None
-    with pytest.raises(ValueError, match="cross_section_table_path required"):
+    with pytest.raises(ValidationError, match="cross_section_table_path required"):
         NeutronYieldModel.model_validate(data)
 
 
 def test_invalid_spectrum_bin_order():
     data = base_data()
     data["spectrumEnergyBinsMeV"] = [2.0, 1.0]
-    with pytest.raises(ValueError, match="monotonically increasing"):
+    with pytest.raises(ValidationError, match="monotonically increasing"):
         NeutronYieldModel.model_validate(data)
 
 
 def test_invalid_integration_window():
     data = base_data()
     data["yieldIntegrationWindowUs"] = [1.0, 0.5]
-    with pytest.raises(ValueError, match="start < end"):
+    with pytest.raises(ValidationError, match="start < end"):
         NeutronYieldModel.model_validate(data)
 
 
@@ -133,5 +144,5 @@ def test_anisotropic_requires_hdf5():
     data = base_data()
     data["anisotropicSpectrum"] = True
     data["spectrumOutputFormat"] = "csv"
-    with pytest.raises(ValueError, match="anisotropic_spectrum requires"):
+    with pytest.raises(ValidationError, match="anisotropic_spectrum requires"):
         NeutronYieldModel.model_validate(data)


### PR DESCRIPTION
## Summary
- validate neutron yield model with `@_model_validator` instead of manual hook
- support camelCase unit aliases like `averageIonTemperatureKeV` and `spectrumEnergyBinsMeV`
- ensure tests load real pydantic and cover missing-temperature error case

## Testing
- `pytest tests/test_neutron_yield_model.py::test_requires_temp_density_for_analytic_thermal_model tests/test_neutron_yield_model.py::test_requires_temperature_for_analytic_thermal_model -q`
- `pytest -q` *(fails: attempted relative import; missing dependencies such as flask_sock, PicDriver, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b9f8526b24832a851ec755b6723c82