### PR TITLE
Add Hall MHD transport diagnostics and checks

### DIFF
--- a/docs/physics/hall_mhd.md
+++ b/docs/physics/hall_mhd.md
@@ -15,7 +15,12 @@ metrics evaluated every time step:
 The most recent values of these quantities together with boolean flags
 indicating whether the corrections were applied are exposed through the solver
 attributes `last_wce_tau_e`, `last_di_over_L`, `hall_active` and
-`electron_inertia_active`.
+`electron_inertia_active`.  When a
+`~dpf2.diagnostics.quality_dashboard.QualityDashboard` instance is attached via
+``HallMHDSolver(quality=...)`` these values along with the activation
+thresholds `hall_threshold` and `ei_threshold` are written to the diagnostic
+history so that post‑processing scripts can examine which terms were active at
+each time step.
 
 A Braginskii transport closure may be provided via the ``braginskii``
 callable.  The helper :func:`dpf2.physics.hall_mhd.nrl_braginskii` implements a

--- a/src/dpf2/diagnostics/quality_dashboard.py
+++ b/src/dpf2/diagnostics/quality_dashboard.py
@@ -43,6 +43,12 @@ class QualityDashboard:
         plasma_impedance: float | None = None,
         divergence_error: float = 0.0,
         energy_drift: float = 0.0,
+        hall_active: bool | None = None,
+        electron_inertia_active: bool | None = None,
+        wce_tau_e: float | None = None,
+        di_over_L: float | None = None,
+        hall_threshold: float | None = None,
+        ei_threshold: float | None = None,
 
     ) -> None:
         """Record a step's metrics and emit warnings if thresholds violated."""
@@ -63,6 +69,18 @@ class QualityDashboard:
             entry["lower_hybrid_power"] = lower_hybrid_power
         if plasma_impedance is not None:
             entry["plasma_impedance"] = plasma_impedance
+        if hall_active is not None:
+            entry["hall_active"] = hall_active
+        if electron_inertia_active is not None:
+            entry["electron_inertia_active"] = electron_inertia_active
+        if wce_tau_e is not None:
+            entry["wce_tau_e"] = wce_tau_e
+        if di_over_L is not None:
+            entry["di_over_L"] = di_over_L
+        if hall_threshold is not None:
+            entry["hall_threshold"] = hall_threshold
+        if ei_threshold is not None:
+            entry["ei_threshold"] = ei_threshold
 
         dt_violation = self.max_dt is not None and dt > self.max_dt
         lambda_violation = lambda_D < cell_size

--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -868,9 +868,10 @@ class HallMHDSolver(PlasmaSolverBase):
             self.last_voltage_spike / (abs(self.current) + 1e-30)
         )
 
+        v_final = mom / rho[..., None]
+        B2_final = np.sum(B ** 2, axis=-1)
+
         if energy_tracker is not None:
-            v_final = mom / rho[..., None]
-            B2_final = np.sum(B ** 2, axis=-1)
             kinetic_final = 0.5 * rho * np.sum(v_final**2, axis=-1)
             magnetic_final = 0.5 * B2_final
             thermal_final = energy - kinetic_final - magnetic_final
@@ -919,6 +920,12 @@ class HallMHDSolver(PlasmaSolverBase):
                 plasma_impedance=impedance,
                 divergence_error=getattr(self, "divergence_error", 0.0),
                 energy_drift=getattr(self, "energy_drift", 0.0),
+                hall_active=self.hall_active,
+                electron_inertia_active=self.electron_inertia_active,
+                wce_tau_e=self.last_wce_tau_e,
+                di_over_L=self.last_di_over_L,
+                hall_threshold=self.hall_threshold,
+                ei_threshold=self.ei_threshold,
 
             )
 

--- a/tests/numpy_stub.py
+++ b/tests/numpy_stub.py
@@ -395,6 +395,17 @@ def clip(vals, lo, hi):
     return Array(min(max(arr.data, lo), hi))
 
 
+def sign(vals):
+    arr = array(vals)
+    if isinstance(arr.data, list):
+        return Array([sign(v) for v in arr.data])
+    if arr.data > 0:
+        return Array(1.0)
+    if arr.data < 0:
+        return Array(-1.0)
+    return Array(0.0)
+
+
 def gradient(vals, dx, edge_order=2):
     arr = array(vals).data
     n = len(arr)
@@ -407,6 +418,15 @@ def gradient(vals, dx, edge_order=2):
         else:
             grad.append((arr[i + 1] - arr[i - 1]) / (2 * dx))
     return Array(grad)
+
+
+def roll(arr, shift, axis=0):
+    data = array(arr).data
+    if axis > 0:
+        return Array([roll(sub, shift, axis - 1).data for sub in data])
+    n = len(data)
+    s = shift % n
+    return Array(data[-s:] + data[:-s])
 
 
 def isclose(a, b, rtol=1.0e-8, atol=1.0e-8):
@@ -460,8 +480,10 @@ np = types.SimpleNamespace(
     mean=mean,
     cross=cross,
     clip=clip,
+    sign=sign,
     sqrt=sqrt,
     gradient=gradient,
+    roll=roll,
     isclose=isclose,
     allclose=allclose,
     array_equal=array_equal,

--- a/tests/physics/test_hall_mhd.py
+++ b/tests/physics/test_hall_mhd.py
@@ -1,10 +1,12 @@
 import numpy as np
+import pytest
 
 from dpf2.physics import HallMHD
 from dpf2.core.circuit import RLCCircuitSolver
 from dpf2.mesh import Mesh3D
 from dpf2.hall_mhd_solver import HallMHDSolver, MHDState
 from dpf2.physics.hall_mhd import nrl_braginskii
+from dpf2.diagnostics.quality_dashboard import QualityDashboard
 
 
 def _shock_setup():
@@ -106,3 +108,29 @@ def test_activation_gates_and_closure():
     nu, kappa = nrl_braginskii(np.array([1.0]), np.array([1.0]), np.array([1.0]))
     assert nu.shape == (1,)
     assert kappa.shape == (1,)
+
+
+def test_quality_diagnostics(tmp_path):
+    B = np.zeros((2, 1, 3)) + np.array([5.0, 0.0, 0.0])
+    state = MHDState(
+        rho=np.ones((2, 1)) * 1e-6,
+        mom=np.zeros((2, 1, 3)),
+        energy=np.ones((2, 1)) * 20.0,
+        B=B,
+        eta=np.ones((2, 1)) * 1e-3,
+    )
+    q = QualityDashboard(output_dir=tmp_path)
+    solver = HallMHDSolver(
+        hall_threshold=0.1,
+        ei_threshold=0.01,
+        scale_length=1e-3,
+        quality=q,
+    )
+    solver.step(state, 0.0)
+    entry = q.history[-1]
+    assert entry["hall_active"] is True
+    assert entry["electron_inertia_active"] is True
+    assert entry["hall_threshold"] == pytest.approx(0.1)
+    assert entry["ei_threshold"] == pytest.approx(0.01)
+    assert entry["wce_tau_e"] == pytest.approx(solver.last_wce_tau_e)
+    assert entry["di_over_L"] == pytest.approx(solver.last_di_over_L)


### PR DESCRIPTION
## Summary
- log Hall and electron-inertia activation metrics to QualityDashboard
- surface new transport thresholds and runtime checks in solver diagnostics
- document Hall MHD diagnostic outputs and add regression coverage

## Testing
- `pytest tests/physics/test_hall_mhd.py tests/test_quality_dashboard.py`

------
https://chatgpt.com/codex/tasks/task_e_68b9f864b024832aba5baafc35c17980