### PR TITLE
Track LHDI wave metrics and impedance in solver diagnostics

### DIFF
--- a/src/dpf2/diagnostics/quality_dashboard.py
+++ b/src/dpf2/diagnostics/quality_dashboard.py
@@ -40,6 +40,7 @@ class QualityDashboard:
         lambda_D: float,
         amr_level: int | None = None,
         lower_hybrid_power: float | None = None,
+        lower_hybrid_phase_velocity: float | None = None,
         plasma_impedance: float | None = None,
         divergence_error: float = 0.0,
         energy_drift: float = 0.0,
@@ -61,6 +62,8 @@ class QualityDashboard:
 
         if lower_hybrid_power is not None:
             entry["lower_hybrid_power"] = lower_hybrid_power
+        if lower_hybrid_phase_velocity is not None:
+            entry["lower_hybrid_phase_velocity"] = lower_hybrid_phase_velocity
         if plasma_impedance is not None:
             entry["plasma_impedance"] = plasma_impedance
 

--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -353,6 +353,7 @@ class HallMHDSolver(PlasmaSolverBase):
     impedance_growth: list[float] = field(default_factory=list)
     last_voltage_spike: float = field(init=False, default=0.0)
     last_lh_power: float = field(init=False, default=0.0)
+    last_lh_phase_velocity: float = field(init=False, default=0.0)
     last_eta_anom_mean: float = field(init=False, default=0.0)
     last_eta_total_mean: float = field(init=False, default=0.0)
     last_pressure: np.ndarray | None = field(init=False, default=None)
@@ -453,7 +454,14 @@ class HallMHDSolver(PlasmaSolverBase):
             _accumulate(e_eta, e_E)
 
         if self.lower_hybrid_drift is not None:
-            res = self.lower_hybrid_drift(J)
+            model = self.lower_hybrid_drift
+            source = getattr(model, "__self__", model)
+            if callable(model):
+                res = model(J)
+            elif hasattr(model, "anomalous_resistivity"):
+                res = model.anomalous_resistivity(J)
+            else:  # pragma: no cover - unexpected type
+                res = model(J)  # type: ignore[misc]
             e_eta, e_E = _process(res)
             _accumulate(e_eta, e_E, axial=True)
             s_eta += e_eta
@@ -461,13 +469,31 @@ class HallMHDSolver(PlasmaSolverBase):
                 s_E[..., 2] += e_E
             else:
                 s_E += e_E
-            if hasattr(self.lower_hybrid_drift, "power"):
+            if hasattr(source, "power"):
                 try:
-                    self.last_lh_power = float(np.max(self.lower_hybrid_drift.power()))
+                    self.last_lh_power = float(np.max(source.power()))
                 except Exception:  # pragma: no cover - power optional
                     self.last_lh_power = 0.0
+            else:
+                self.last_lh_power = 0.0
+            if hasattr(source, "last_phase_velocity"):
+                try:
+                    self.last_lh_phase_velocity = float(
+                        np.max(getattr(source, "last_phase_velocity"))
+                    )
+                except Exception:  # pragma: no cover - optional
+                    self.last_lh_phase_velocity = 0.0
+            elif hasattr(source, "phase_velocity"):
+                try:
+                    pv = source.phase_velocity()
+                    self.last_lh_phase_velocity = float(np.max(pv))
+                except Exception:  # pragma: no cover - optional
+                    self.last_lh_phase_velocity = 0.0
+            else:
+                self.last_lh_phase_velocity = 0.0
         else:
             self.last_lh_power = 0.0
+            self.last_lh_phase_velocity = 0.0
 
 
         if self.instability_thresholds:
@@ -906,6 +932,7 @@ class HallMHDSolver(PlasmaSolverBase):
             lambda_D = np.sqrt(epsilon_0 * k * T / (ne * e**2))
             ppc = float(np.mean(ne) * cell_volume)
             lh_power = self.last_lh_power
+            lh_phase = self.last_lh_phase_velocity
             impedance = self.last_eta_total_mean
             self.quality.log(
                 self.step_count,
@@ -916,6 +943,7 @@ class HallMHDSolver(PlasmaSolverBase):
                 float(np.mean(lambda_D)),
                 amr_level=getattr(self, "amr_level", None),
                 lower_hybrid_power=lh_power,
+                lower_hybrid_phase_velocity=lh_phase,
                 plasma_impedance=impedance,
                 divergence_error=getattr(self, "divergence_error", 0.0),
                 energy_drift=getattr(self, "energy_drift", 0.0),

--- a/src/dpf2/physics/lower_hybrid_drift.py
+++ b/src/dpf2/physics/lower_hybrid_drift.py
@@ -31,9 +31,11 @@ class LowerHybridDrift:
 
     The model evolves a perturbation amplitude representing the strength of
     lower‑hybrid waves and exposes an ``anomalous_resistivity`` callback
-    compatible with :class:`~dpf2.hall_mhd_solver.HallMHDSolver`.  When the
-    solver requests a resistivity field the stored amplitude is returned along
-    with an optional electric‑field contribution.
+    compatible with :class:`~dpf2.hall_mhd_solver.HallMHDSolver`.  Alongside
+    the raw amplitude, derived quantities such as the wave energy, phase
+    velocity and a simple power estimate are cached for diagnostic use.  When
+    the solver requests a resistivity field the stored amplitude is returned
+    along with an optional electric‑field contribution.
     """
 
     B: float  # Magnetic field strength [T]

--- a/tests/physics/test_anomalous_resistivity.py
+++ b/tests/physics/test_anomalous_resistivity.py
@@ -3,6 +3,7 @@ import pytest
 
 from dpf2.hall_mhd_solver import HallMHDSolver
 from dpf2.physics.lower_hybrid_drift import LowerHybridDrift
+from dpf2.diagnostics.quality_dashboard import QualityDashboard
 
 
 def test_impedance_spike_from_lhdi_not_fixed():
@@ -10,16 +11,36 @@ def test_impedance_spike_from_lhdi_not_fixed():
         return np.full(J.shape[:-1], 0.05)
 
     lhd = LowerHybridDrift(B=1.0, n_i=1e19, amplitude=0.2)
-    solver = HallMHDSolver(
-        anomalous_resistivity=fixed, lower_hybrid_drift=lhd.anomalous_resistivity
-    )
+    lhd.phase_velocity(1.0)
+    solver = HallMHDSolver(anomalous_resistivity=fixed, lower_hybrid_drift=lhd)
     J = np.ones((1, 3))
     eta = solver.compute_anomalous_resistivity(J)
     assert solver.last_voltage_spike == pytest.approx(0.6)
     assert eta[0] == pytest.approx(0.25)
+    assert solver.last_lh_power > 0.0
+    assert solver.last_lh_phase_velocity > 0.0
 
     solver.impedance_growth.append(solver.last_voltage_spike / 1.0)
     assert solver.impedance_growth[-1] == pytest.approx(0.6)
+
+
+def test_quality_dashboard_logs_lh_metrics(tmp_path):
+    dash = QualityDashboard(output_dir=tmp_path)
+    dash.log(
+        step=1,
+        dt=1.0,
+        cell_size=1.0,
+        ppc=1.0,
+        cfl=0.1,
+        lambda_D=0.2,
+        lower_hybrid_power=2.0,
+        lower_hybrid_phase_velocity=3.0,
+        plasma_impedance=0.5,
+    )
+    entry = dash.history[-1]
+    assert entry["plasma_impedance"] == pytest.approx(0.5)
+    assert entry["lower_hybrid_power"] == pytest.approx(2.0)
+    assert entry["lower_hybrid_phase_velocity"] == pytest.approx(3.0)
 
 
 def test_fixed_resistivity_does_not_trigger_spike():


### PR DESCRIPTION
## Summary
- Cache lower-hybrid drift wave energy, phase velocity and power for diagnostics
- Expose LHDI power and phase velocity through `HallMHDSolver` and log plasma impedance
- Record LHDI metrics and impedance in the quality dashboard

## Testing
- `pytest tests/physics/test_anomalous_resistivity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9f86569e8832ab3c87a33d56c2c96