### PR TITLE
Add numerical panel diagnostics and quality checks

### DIFF
--- a/src/dpf2/diagnostics/quality_dashboard.py
+++ b/src/dpf2/diagnostics/quality_dashboard.py
@@ -29,6 +29,11 @@ class QualityDashboard:
     min_omega_ce_tau_e: float | None = None
     regime_history: list[dict[str, float]] = field(default_factory=list)
 
+    max_l1_error: float | None = None
+    max_divB_norm: float | None = None
+    max_energy_drift: float | None = None
+    numerics_history: list[dict[str, float]] = field(default_factory=list)
+
 
     def log(
         self,


### PR DESCRIPTION
## Summary
- Expose thresholds for numerical diagnostics (L1 error, divergence, energy drift) in `QualityDashboard`
- Persist numerical metrics and evaluate them against new thresholds

## Testing
- `pytest tests/validation/test_numerics_panel.py -q`
- `pre-commit run --files src/dpf2/diagnostics/quality_dashboard.py tests/validation/test_numerics_panel.py src/dpf2/validation/numerics_panel.py` *(fails: `.pre-commit-config.yaml` is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f867f468832a8bd4a3269116a5f3