### PR TITLE
Record dataset paths and enforce radiation metadata provenance

### DIFF
--- a/src/dpf2/io/manifest.py
+++ b/src/dpf2/io/manifest.py
@@ -40,11 +40,17 @@ def capture_dataset_metadata(
             raise ValueError(
                 "dataset metadata requires 'path', 'doi' and 'version'"
             )
-        h = _hash_file(Path(path))
+        p = Path(path)
+        h = _hash_file(p)
         logger.info(
             "dataset %s: hash=%s doi=%s version=%s", name, h, doi, version
         )
-        result[name] = {"hash": h, "doi": str(doi), "version": str(version)}
+        result[name] = {
+            "path": str(p),
+            "hash": h,
+            "doi": str(doi),
+            "version": str(version),
+        }
     return result
 
 

--- a/src/dpf2/radiation/metadata.py
+++ b/src/dpf2/radiation/metadata.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-"""Metadata loaders for radiation data sets."""
+"""Metadata loaders for radiation data sets.
+
+These helpers validate that required provenance information is present in
+sidecar JSON metadata files distributed with CHIANTI or other radiation
+tables.
+"""
 
 from dataclasses import dataclass
 import json
@@ -21,6 +26,8 @@ logger = logging.getLogger(__name__)
 
 
 def _require_metadata_fields(data: Mapping[str, object]) -> DatasetMetadata:
+    """Validate DOI and version fields and build :class:`DatasetMetadata`."""
+
     doi = data.get("doi")
     version = data.get("version")
     if not doi or not version:
@@ -28,15 +35,19 @@ def _require_metadata_fields(data: Mapping[str, object]) -> DatasetMetadata:
     return DatasetMetadata(doi=str(doi), version=str(version))
 
 
+def _load(path: Path | str) -> DatasetMetadata:
+    """Load and validate a metadata JSON file."""
+
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    meta = _require_metadata_fields(data)
+    logger.info("Loaded radiation metadata: doi=%s version=%s", meta.doi, meta.version)
+    return meta
+
+
 def load_chianti_metadata(meta_path: Path | str) -> DatasetMetadata:
     """Load metadata for a CHIANTI table."""
 
-    data = json.loads(Path(meta_path).read_text(encoding="utf-8"))
-    meta = _require_metadata_fields(data)
-    logger.info(
-        "Loaded CHIANTI metadata: doi=%s version=%s", meta.doi, meta.version
-    )
-    return meta
+    return _load(meta_path)
 
 
 __all__ = ["DatasetMetadata", "load_chianti_metadata"]

--- a/tests/io/test_manifest.py
+++ b/tests/io/test_manifest.py
@@ -27,6 +27,7 @@ def test_manifest_records_dataset_doi(tmp_path):
     assert meta["doi"] == "10.1234/example"
     assert meta["version"] == "1.0"
     assert len(meta["hash"]) == 64
+    assert Path(meta["path"]) == data_file
 
 
 def test_manifest_dataset_requires_doi_and_version(tmp_path):


### PR DESCRIPTION
## Summary
- Refactor radiation dataset metadata loader and helper to require DOI and version fields.
- Record dataset file paths alongside hashes, DOIs, and versions when capturing dataset metadata for manifests.
- Test manifest recording of dataset provenance, including dataset path.

## Testing
- `pytest tests/io/test_manifest.py tests/test_manifest_metadata.py tests/test_manifest_warnings.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9f86bfbb8832a8a608de006211f8a