### PR TITLE
Add DSMC neutral solver and plasma coupling

### DIFF
--- a/src/dpf2/coupled_models.py
+++ b/src/dpf2/coupled_models.py
@@ -59,6 +59,19 @@ class NeutralPlasmaCoupler:
         self.plasma_solver = plasma_solver
 
     def run(self, dt: float) -> NeutralPlasmaResult:
+        """Run coupled neutral and plasma solvers for a single step.
+
+        Parameters
+        ----------
+        dt:
+            Time step forwarded to the DSMC neutral solver.
+
+        Returns
+        -------
+        NeutralPlasmaResult
+            Container bundling the neutral density with the plasma solver
+            payload.
+        """
         nd = self.dsmc.run(dt)
         plasma = self.plasma_solver.run(neutral_density=nd)
         return NeutralPlasmaResult(neutral_density=nd, plasma=plasma)

--- a/src/dpf2/neutral/dsmc.py
+++ b/src/dpf2/neutral/dsmc.py
@@ -51,8 +51,10 @@ def _validate_cross_sections(table: np.ndarray) -> None:
     # perform the checks using pure Python constructs.
     energies = [row[0] for row in table]
     sigmas = [row[1] for row in table]
+    if any(e < 0 for e in energies):
+        raise ValueError("energies must be non-negative")
     if any(s < 0 for s in sigmas):
-        raise ValueError("cross sections must be non‑negative")
+        raise ValueError("cross sections must be non-negative")
     if any(b <= a for a, b in zip(energies, energies[1:])):
         raise ValueError("energy grid must be strictly increasing")
 


### PR DESCRIPTION
## Summary
- validate tabulated cross-section energy grid in DSMC neutral solver
- document neutral/plasma coupling interface for DSMC-driven runs
- exercise DSMC–plasma density coupling in a dedicated unit test

## Testing
- `python -m pytest tests/neutral/test_dsmc_coupling.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9f86d1660832aa9a0825578650f1f