### PR TITLE
Add modal decomposition and instability diagnostics

### DIFF
--- a/src/dpf2/diagnostics/modes.py
+++ b/src/dpf2/diagnostics/modes.py
@@ -19,6 +19,7 @@ from typing import Sequence
 
 __all__ = [
     "azimuthal_mode_spectrum",
+    "azimuthal_decomposition",
     "growth_rate",
     "lh_azimuthal_power",
     "log_impedance_ratio",
@@ -95,6 +96,63 @@ def azimuthal_mode_spectrum(field: np.ndarray, axis: int = -1) -> np.ndarray:
             count += 1
         spectrum.append(c_sum / count if count else 0.0)
     return np.array(spectrum)
+
+
+def azimuthal_decomposition(field: np.ndarray, axis: int = -1) -> np.ndarray:
+    """Return complex azimuthal Fourier coefficients of ``field``.
+
+    This is similar to :func:`azimuthal_mode_spectrum` but retains the
+    complex phase information of each mode.  The coefficients are scaled so
+    that a pure ``cos(m\theta)`` signal yields a real coefficient of one and
+    a vanishing imaginary part.
+    """
+
+    data = np.asarray(field)
+
+    if hasattr(np, "fft"):
+        data = np.moveaxis(data, axis, -1)
+        n = data.shape[-1]
+        if n == 0:
+            return np.array([])
+        coeff = np.fft.rfft(data, axis=-1) / float(n)
+        if n % 2 == 0:
+            if coeff.shape[-1] > 2:
+                coeff[..., 1:-1] *= 2.0
+        else:
+            if coeff.shape[-1] > 1:
+                coeff[..., 1:] *= 2.0
+        mean_axes = tuple(range(coeff.ndim - 1))
+        return np.mean(coeff, axis=mean_axes)
+
+    if axis not in (-1, data.ndim - 1):
+        raise ValueError("manual mode decomposition only supports the last axis")
+    n = data.shape[-1]
+    if n == 0:
+        return np.array([])
+    theta = [2.0 * math.pi * k / n for k in range(n)]
+    m_max = n // 2
+    coeff = []
+    cos_cache = [[math.cos(m * t) for t in theta] for m in range(m_max + 1)]
+    sin_cache = [[math.sin(m * t) for t in theta] for m in range(m_max + 1)]
+    for m in range(m_max + 1):
+        c_sum = 0.0 + 0.0j
+        count = 0
+        for idx in product(*(range(s) for s in data.shape[:-1])):
+            row = data[idx]
+            a = 0.0
+            b = 0.0
+            for j in range(n):
+                a += row[j] * cos_cache[m][j]
+                b += row[j] * sin_cache[m][j]
+            a /= n
+            b /= n
+            if m != 0:
+                a *= 2.0
+                b *= 2.0
+            c_sum += complex(a, -b)
+            count += 1
+        coeff.append(c_sum / count if count else 0.0)
+    return np.asarray(coeff)
 
 
 def growth_rate(previous: Sequence[float], current: Sequence[float], dt: float) -> np.ndarray:

--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -16,6 +16,8 @@ from typing import Any, Callable, Dict, Tuple
 from typing import Protocol
 
 import logging
+import math
+from pathlib import Path
 import numpy as np
 try:  # pragma: no cover - allow running without SciPy
     from scipy.constants import mu_0
@@ -349,6 +351,7 @@ class HallMHDSolver(PlasmaSolverBase):
     instability_thresholds: Dict[str, float] | None = None
     sausage_onset: bool = field(init=False, default=False)
     kink_onset: bool = field(init=False, default=False)
+    mode_history: list[np.ndarray] = field(init=False, default_factory=list)
     voltage_spikes: list[float] = field(default_factory=list)
     impedance_growth: list[float] = field(default_factory=list)
     last_voltage_spike: float = field(init=False, default=0.0)
@@ -501,10 +504,17 @@ class HallMHDSolver(PlasmaSolverBase):
         if not self.instability_thresholds:
             return
         try:
-            J_mag = np.linalg.norm(J, axis=-1)
+            if hasattr(np, "linalg") and hasattr(np.linalg, "norm"):
+                J_mag = np.linalg.norm(J, axis=-1)
+            else:  # pragma: no cover - manual magnitude for stubs
+                J_mag = np.array([
+                    math.sqrt(float(j[0]) ** 2 + float(j[1]) ** 2 + float(j[2]) ** 2)
+                    for j in J
+                ])
         except Exception:  # pragma: no cover - very small stub fallback
             return
         spectrum = azimuthal_mode_spectrum(J_mag, axis=-1)
+        self.mode_history.append(spectrum.copy())
         if (
             not self.sausage_onset
             and "sausage" in self.instability_thresholds
@@ -519,6 +529,23 @@ class HallMHDSolver(PlasmaSolverBase):
             and spectrum[1] >= self.instability_thresholds["kink"]
         ):
             self.kink_onset = True
+
+    def dump_mode_growth(self, outdir: Path | str = Path("synthetic_diagnostics/modes")) -> Path | None:
+        """Write recorded modal growth rates to ``outdir``.
+
+        The solver collects the azimuthal mode spectrum of the current density
+        during :meth:`compute_anomalous_resistivity`.  This helper computes the
+        exponential growth rate between successive spectra and stores them in
+        ``outdir`` using the :mod:`dpf2.synthetic_diagnostics.modes` helpers.
+        ``None`` is returned if fewer than two spectra have been recorded.
+        """
+
+        if len(self.mode_history) < 2:
+            return None
+        times = list(range(len(self.mode_history)))
+        from .synthetic_diagnostics.modes import write_growth_rates
+
+        return write_growth_rates(times, self.mode_history, outdir)
 
     def amr_refinement(self, state: MHDState) -> None:
         """Invoke the refinement callback if provided."""

--- a/src/dpf2/synthetic_diagnostics/__init__.py
+++ b/src/dpf2/synthetic_diagnostics/__init__.py
@@ -1,0 +1,22 @@
+"""Synthetic diagnostics package with compatibility shim.
+
+This package exposes the legacy :mod:`dpf2.synthetic_diagnostics` module
+API while also providing access to submodules such as
+``dpf2.synthetic_diagnostics.modes``.
+"""
+
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+# Load the legacy module residing alongside this package and re-export its
+# public API so that existing imports remain valid.
+_module_path = Path(__file__).resolve().parent.parent / "synthetic_diagnostics.py"
+_spec = spec_from_file_location("dpf2.synthetic_diagnostics_legacy", _module_path)
+_module = module_from_spec(_spec)
+_spec.loader.exec_module(_module)  # type: ignore[attr-defined]
+
+__all__ = getattr(_module, "__all__", [])
+for name in __all__:
+    globals()[name] = getattr(_module, name)

--- a/src/dpf2/synthetic_diagnostics/modes/__init__.py
+++ b/src/dpf2/synthetic_diagnostics/modes/__init__.py
@@ -14,7 +14,12 @@ except Exception:  # pragma: no cover
 
 from ...diagnostics.modes import azimuthal_mode_spectrum, growth_rate
 
-__all__ = ["azimuthal_mode_spectrum", "growth_rate", "plot_growth_rates"]
+__all__ = [
+    "azimuthal_mode_spectrum",
+    "growth_rate",
+    "plot_growth_rates",
+    "write_growth_rates",
+]
 
 
 def plot_growth_rates(times: Sequence[float], spectra: Sequence[Sequence[float]],
@@ -49,3 +54,32 @@ def plot_growth_rates(times: Sequence[float], spectra: Sequence[Sequence[float]]
     fig.savefig(fig_path)
     plt.close(fig)
     return fig_path
+
+
+def write_growth_rates(times: Sequence[float], spectra: Sequence[Sequence[float]],
+                       outdir: Path | str = Path("synthetic_diagnostics/modes")) -> Path:
+    """Compute growth rates and write them to ``outdir``.
+
+    The returned file contains one row per interval in ``times`` with the
+    exponential growth rate for each azimuthal mode.  ``times`` and
+    ``spectra`` must therefore contain at least two samples.
+    """
+
+    if len(times) < 2 or len(spectra) < 2:
+        raise ValueError("at least two time steps required to compute growth rates")
+
+    out_path = Path(outdir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    rates = []
+    for t0, t1, s0, s1 in zip(times[:-1], times[1:], spectra[:-1], spectra[1:]):
+        dt = float(t1) - float(t0)
+        rates.append(growth_rate(s0, s1, dt))
+    arr = np.asarray(rates)
+    file_path = out_path / "growth_rates.csv"
+    if hasattr(np, "savetxt"):
+        np.savetxt(file_path, arr, delimiter=",")
+    else:  # pragma: no cover - minimal stub fallback
+        with open(file_path, "w", encoding="utf-8") as fh:
+            for row in arr:
+                fh.write(",".join(str(float(x)) for x in row) + "\n")
+    return file_path

--- a/tests/diagnostics/test_mode_decomposition.py
+++ b/tests/diagnostics/test_mode_decomposition.py
@@ -1,7 +1,13 @@
 import math
 import numpy as np
 
-from dpf2.diagnostics.modes import azimuthal_mode_spectrum, growth_rate
+from dpf2.diagnostics.modes import (
+    azimuthal_mode_spectrum,
+    azimuthal_decomposition,
+    growth_rate,
+)
+from dpf2.synthetic_diagnostics.modes import write_growth_rates
+from dpf2.hall_mhd_solver import HallMHDSolver
 
 
 def test_mode_spectrum_simple_cosine():
@@ -26,3 +32,39 @@ def test_growth_rate():
     dt = 1.0
     rates = growth_rate(prev, curr, dt)
     assert np.allclose(rates, [0.0, 1.0, math.log(0.5)])
+
+
+def test_mode_decomposition_complex():
+    theta = np.linspace(0.0, 2 * np.pi, 33)[:-1]
+    cos = lambda x: np.sin(x + np.pi / 2)
+    field = cos(theta) + 0.5 * cos(2 * theta)
+    coeff = [complex(c) for c in azimuthal_decomposition(field)]
+    assert len(coeff) >= 3
+    assert abs(coeff[0].real - 0.0) < 1e-12
+    assert abs(coeff[1].real - 1.0) < 1e-12
+    assert abs(coeff[2].real - 0.5) < 1e-12
+    assert all(abs(c.imag) < 1e-12 for c in coeff)
+
+
+def test_write_growth_rates(tmp_path):
+    times = [0.0, 1.0, 2.0]
+    spectra = [np.array([1.0, 1.0]), np.array([1.0, math.e]), np.array([1.0, math.e**2])]
+    path = write_growth_rates(times, spectra, tmp_path)
+    assert path.exists()
+    if hasattr(np, "loadtxt"):
+        data = np.loadtxt(path, delimiter=",")
+        col = data[:, 1]
+        assert len(col) == 2
+        assert all(abs(float(v) - 1.0) < 1e-12 for v in col)
+
+
+def test_instability_thresholds_trigger():
+    solver = HallMHDSolver(instability_thresholds={"sausage": 0.9, "kink": 0.4})
+    theta = np.linspace(0.0, 2 * np.pi, 32)[:-1]
+    cos = lambda x: math.sin(x + math.pi / 2)
+    mag = np.array([1.0 + 0.5 * cos(float(t)) for t in theta])
+    zeros = np.zeros(len(mag))
+    J = np.stack((mag, zeros, zeros), axis=-1)
+    solver.compute_anomalous_resistivity(J)
+    assert solver.sausage_onset
+    assert solver.kink_onset


### PR DESCRIPTION
## Summary
- implement `azimuthal_decomposition` for complex Fourier mode analysis
- expose `write_growth_rates` synthetic diagnostic and support solver mode history
- track sausage/kink thresholds in `HallMHDSolver` with growth-rate dump capability

## Testing
- `pytest tests/diagnostics/test_mode_decomposition.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9f86f664c832a88146ff8b6510a8b