### PR TITLE
Add LHDI resistivity model with diagnostics and safeguards

### DIFF
--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -42,6 +42,7 @@ from .diagnostics.quality_dashboard import QualityDashboard
 from .diagnostics.modes import azimuthal_mode_spectrum
 from .physics.anomalous_resistivity import SpectralResistivity
 from .physics.lower_hybrid_drift import LowerHybridDrift
+from .physics.lhdi_resistivity import LHDIResistivity
 
 logger = logging.getLogger(__name__)
 
@@ -353,8 +354,11 @@ class HallMHDSolver(PlasmaSolverBase):
     impedance_growth: list[float] = field(default_factory=list)
     last_voltage_spike: float = field(init=False, default=0.0)
     last_lh_power: float = field(init=False, default=0.0)
+    last_lh_spectrum: Any | None = field(init=False, default=None)
     last_eta_anom_mean: float = field(init=False, default=0.0)
     last_eta_total_mean: float = field(init=False, default=0.0)
+    last_Ez_surge: float = field(init=False, default=0.0)
+    last_spitzer_eta: float = field(init=False, default=0.0)
     last_pressure: np.ndarray | None = field(init=False, default=None)
     last_ionization: np.ndarray | None = field(init=False, default=None)
     last_rad_loss: np.ndarray | None = field(init=False, default=None)
@@ -412,6 +416,16 @@ class HallMHDSolver(PlasmaSolverBase):
 
         self.lower_hybrid_drift = SpectralResistivity(lhd, scale=scale, floor=floor)
 
+    def enable_lhdi_resistivity(
+        self,
+        lhd: LowerHybridDrift,
+        scale: float = 1.0,
+        floor: float = 0.0,
+    ) -> None:
+        """Enable power/phase based LHDI anomalous resistivity."""
+
+        self.lower_hybrid_drift = LHDIResistivity(lhd, scale=scale, floor=floor)
+
     def compute_anomalous_resistivity(self, J: np.ndarray) -> np.ndarray:
         """Evaluate anomalous resistivity models and record voltage spikes.
 
@@ -422,6 +436,13 @@ class HallMHDSolver(PlasmaSolverBase):
         :meth:`step` while the combined resistivity is returned.
         """
 
+        if (
+            self.anomalous_resistivity is None
+            and self.lower_hybrid_drift is None
+            and self.m0_instability is None
+        ):
+            raise RuntimeError("No anomalous resistivity mechanism configured")
+
         eta = np.zeros(J.shape[:-1])
         E = np.zeros_like(J)
         s_eta = np.zeros(J.shape[:-1])
@@ -431,6 +452,12 @@ class HallMHDSolver(PlasmaSolverBase):
             mag = np.abs(J[..., 0]) + np.abs(J[..., 1]) + np.abs(J[..., 2])
         else:  # pragma: no cover - very small stub fallback
             mag = [abs(j[0]) + abs(j[1]) + abs(j[2]) for j in J]
+
+        try:
+            J_mag = np.linalg.norm(J, axis=-1)
+            self.last_lh_spectrum = azimuthal_mode_spectrum(J_mag, axis=-1)
+        except Exception:  # pragma: no cover - tiny numpy stub
+            self.last_lh_spectrum = []
 
         def _process(result: np.ndarray | tuple[np.ndarray, np.ndarray]) -> tuple[np.ndarray, np.ndarray]:
             if isinstance(result, tuple):
@@ -487,11 +514,24 @@ class HallMHDSolver(PlasmaSolverBase):
         if spike != 0.0:
             self.voltage_spikes.append(spike)
         self.last_voltage_spike = spike
+        try:
+            self.last_Ez_surge = float(np.max(np.abs(s_E[..., 2])))
+        except Exception:
+            self.last_Ez_surge = 0.0
         self.last_E_anom = E
         try:
             self.last_eta_anom_mean = float(np.mean(eta))
         except Exception:
             self.last_eta_anom_mean = 0.0
+        try:
+            self.last_eta_total_mean = float(np.mean(eta))
+        except Exception:
+            self.last_eta_total_mean = 0.0
+
+        self.last_spitzer_eta = float(spitzer_resistivity(1e18, 1e5, 1.0))
+        if self.last_eta_total_mean < self.last_spitzer_eta:
+            raise RuntimeError("Impedance below Spitzer threshold")
+
         return eta
 
     # ------------------------------------------------------------------

--- a/src/dpf2/physics/__init__.py
+++ b/src/dpf2/physics/__init__.py
@@ -6,6 +6,7 @@ from .eos import TabulatedEOS, load_tabulated_eos, load_standard_eos
 from .radiation import RadiationTransport
 from .pic_driver import PicDriver, PhysicalPICDriver, WarpXPICDriver
 from .lower_hybrid_drift import LowerHybridDrift
+from .lhdi_resistivity import LHDIResistivity
 from .m0_instability import MZeroInstability
 
 
@@ -40,6 +41,7 @@ __all__ = [
     "load_standard_eos",
     "RadiationTransport",
     "LowerHybridDrift",
+    "LHDIResistivity",
     "MZeroInstability",
     "GVFront",
 ]

--- a/src/dpf2/physics/lhdi_resistivity.py
+++ b/src/dpf2/physics/lhdi_resistivity.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Lower-hybrid drift instability effective resistivity model.
+
+The implementation is intentionally compact and derives an effective
+resistivity from the wave power and phase velocity provided by a
+:class:`~dpf2.physics.lower_hybrid_drift.LowerHybridDrift` instance.
+The resulting model is compatible with
+:meth:`dpf2.hall_mhd_solver.HallMHDSolver.compute_anomalous_resistivity`
+returning both a spatial resistivity field and an optional axial electric
+field contribution.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Tuple
+import numpy as np
+
+from .lower_hybrid_drift import LowerHybridDrift
+
+
+@dataclass
+class LHDIResistivity:
+    """Map lower‑hybrid drift wave power to an anomalous resistivity.
+
+    Parameters
+    ----------
+    lhd:
+        Instability model supplying ``power`` and ``phase_velocity``.
+    scale:
+        Multiplicative factor applied to the power/velocity ratio.
+    floor:
+        Minimum resistivity returned by the model.
+    """
+
+    lhd: LowerHybridDrift
+    scale: float = 1.0
+    floor: float = 0.0
+
+    def __call__(self, J: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+        """Return effective resistivity and axial electric field for ``J``.
+
+        The resistivity is computed as ``scale * power / |v_phase|`` with
+        ``floor`` enforcing a lower bound.  The same quantity is used as an
+        axial electric‑field surge to mimic the impulsive response expected
+        from unresolved lower‑hybrid drift waves.
+        """
+
+        try:
+            power = self.lhd.power()
+            v_phase = np.abs(self.lhd.phase_velocity(1.0)) + 1e-12
+            eta = self.scale * power / v_phase + self.floor
+        except Exception:  # pragma: no cover - numpy stub fallback
+            eta = self.floor
+
+        try:  # pragma: no cover - broadcast for real NumPy
+            eta_field = np.broadcast_to(eta, J.shape[:-1])
+            Ez = np.broadcast_to(eta, J.shape[:-1])
+        except Exception:  # pragma: no cover - minimal stub fallback
+            eta_field = np.ones(J.shape[:-1]) * eta
+            Ez = np.ones(J.shape[:-1]) * eta
+        return eta_field, Ez
+
+
+__all__ = ["LHDIResistivity"]

--- a/src/dpf2/physics/pic.py
+++ b/src/dpf2/physics/pic.py
@@ -15,6 +15,7 @@ from typing import Any, List
 import numpy as np
 
 from ..core.bases import PlasmaSolverBase, CouplingState
+from .lhdi_resistivity import LHDIResistivity
 
 
 EPS0 = 1.0  # Permittivity used for the lightweight solvers
@@ -49,6 +50,10 @@ class SimplePIC(PlasmaSolverBase):
     divergence_error: float = field(init=False, default=0.0)
     energy_drift: float = field(init=False, default=0.0)
     _prev_energy: float = field(init=False, default=0.0)
+    lhdi: LHDIResistivity | None = None
+    last_lh_power: float = 0.0
+    last_Ez_surge: float = 0.0
+    lhdi_spectrum: Any | None = None
 
     def __post_init__(self) -> None:
         if self.field_solver != "circuit":
@@ -107,6 +112,14 @@ class SimplePIC(PlasmaSolverBase):
             self.circuit_feedback = CouplingState(
                 current=current, voltage=voltage, back_reaction=plasma_current
             )
+            self.last_Ez_surge = abs(E)
+            if self.lhdi is not None:
+                try:
+                    self.last_lh_power = float(np.max(self.lhdi.lhd.power()))
+                    self.lhdi_spectrum = np.abs(np.fft.rfft([E]))
+                except Exception:
+                    self.last_lh_power = 0.0
+                    self.lhdi_spectrum = []
             return state
 
         # Spectral/finite-difference solver
@@ -127,6 +140,14 @@ class SimplePIC(PlasmaSolverBase):
         self.circuit_feedback = CouplingState(
             current=current, voltage=voltage, back_reaction=plasma_current
         )
+        self.last_Ez_surge = float(np.max(np.abs(self.E))) if self.E.size else 0.0
+        if self.lhdi is not None:
+            try:
+                self.last_lh_power = float(np.max(self.lhdi.lhd.power()))
+                self.lhdi_spectrum = np.abs(np.fft.rfft(self.E)) if self.E.size else []
+            except Exception:
+                self.last_lh_power = 0.0
+                self.lhdi_spectrum = []
 
         # Diagnostics ------------------------------------------------------
         if self.E.size:

--- a/tests/physics/test_lhdi_resistivity.py
+++ b/tests/physics/test_lhdi_resistivity.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+
+from dpf2.hall_mhd_solver import HallMHDSolver
+from dpf2.physics.lower_hybrid_drift import LowerHybridDrift
+from dpf2.physics.lhdi_resistivity import LHDIResistivity
+
+
+def test_lhdi_resistivity_voltage_spike_scaling():
+    lhd = LowerHybridDrift(B=1.0, n_i=1e19, amplitude=0.1)
+    model = LHDIResistivity(lhd, scale=0.5)
+    solver = HallMHDSolver(lower_hybrid_drift=model)
+    J = np.ones((1, 3))
+    eta = solver.compute_anomalous_resistivity(J)
+    expected = 0.5 * lhd.power() / (abs(lhd.phase_velocity(1.0)) + 1e-12)
+    assert eta[0] == pytest.approx(expected)
+    assert solver.last_voltage_spike == pytest.approx(expected * 3)
+    assert solver.last_Ez_surge == pytest.approx(expected)
+
+
+def test_lhdi_resistivity_below_spitzer_fails():
+    lhd = LowerHybridDrift(B=1.0, n_i=1e19, amplitude=0.0)
+    model = LHDIResistivity(lhd)
+    solver = HallMHDSolver(lower_hybrid_drift=model)
+    J = np.ones((1, 3))
+    with pytest.raises(RuntimeError):
+        solver.compute_anomalous_resistivity(J)


### PR DESCRIPTION
## Summary
- implement `LHDIResistivity` converting lower-hybrid drift wave power and phase velocity to anomalous resistivity
- hook LHDI model into Hall-MHD and PIC engines, recording spectra and axial E-field surges
- enforce Spitzer impedance floor and add regression test for voltage spike scaling

## Testing
- `PYTHONPATH=src pytest tests/physics/test_lhdi_resistivity.py -vv`
- `PYTHONPATH=src pytest` *(fails: NameError: name 'types' is not defined, AttributeError: 'types.SimpleNamespace' object has no attribute 'use', and other missing dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fb88677c832a823af8acc383e66e