### PR TITLE
feat: add neutron diagnostic utilities

### DIFF
--- a/src/dpf2/diagnostics/neutron/__init__.py
+++ b/src/dpf2/diagnostics/neutron/__init__.py
@@ -1,0 +1,46 @@
+"""High level neutron diagnostic utilities.
+
+This subpackage provides convenience wrappers around the existing neutron
+analysis helpers in :mod:`dpf2.diagnostics.neutron_spectra` and
+:mod:`dpf2.diagnostics.neutron_yield`.  The functions exposed here focus on
+common analysis tasks such as computing beam–target and thermonuclear yields,
+aggregating angular distributions and generating synthetic time-of-flight (ToF)
+signals correlated with circuit ``I``–``V`` traces.
+"""
+
+from .base import (
+    Detector,
+    DetectorLayout,
+    synthetic_tof_spectrum,
+    angular_spectrum,
+    anisotropy_metric,
+    forward_radial_backward_counts,
+    anisotropy_ratios,
+    load_detector_layout,
+    load_response,
+    apply_response,
+    anisotropy_report,
+)
+from .yield_calculators import thermonuclear_yield, beam_target_yield
+from .angular import angular_distribution
+from .tof import synthetic_tof_correlated
+from .benchmarks import compare_with_benchmark
+
+__all__ = [
+    "Detector",
+    "DetectorLayout",
+    "synthetic_tof_spectrum",
+    "angular_spectrum",
+    "anisotropy_metric",
+    "forward_radial_backward_counts",
+    "anisotropy_ratios",
+    "load_detector_layout",
+    "load_response",
+    "apply_response",
+    "anisotropy_report",
+    "thermonuclear_yield",
+    "beam_target_yield",
+    "angular_distribution",
+    "synthetic_tof_correlated",
+    "compare_with_benchmark",
+]

--- a/src/dpf2/diagnostics/neutron/angular.py
+++ b/src/dpf2/diagnostics/neutron/angular.py
@@ -1,0 +1,44 @@
+"""Angular aggregation helpers for neutron diagnostics."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Sequence, Tuple
+
+from ..neutron_spectra import (
+    angular_spectrum,
+    DetectorLayout,
+    forward_radial_backward_counts,
+)
+from .base import apply_response as _apply_response
+
+
+def _apply_optional_response(
+    times: Sequence[float], signal: Sequence[float], response: Dict[str, float] | None
+) -> List[float]:
+    """Apply :func:`dpf2.diagnostics.neutron.apply_response` if *response* given."""
+
+    if response:
+        return _apply_response(times, signal, response)
+    return [float(v) for v in signal]
+
+
+def angular_distribution(
+    angles: Sequence[float],
+    base_yield: float,
+    anisotropy: float = 0.0,
+    response: Dict[str, float] | None = None,
+) -> Tuple[List[float], Dict[str, float]]:
+    """Return per-angle yields and grouped forward/radial/backward counts."""
+
+    layout = DetectorLayout(angles=angles, distance_m=1.0)
+    spectrum = angular_spectrum(layout.angles_deg(), base_yield, anisotropy)
+    if response:
+        spectrum = [
+            _apply_optional_response([0.0], [s], response)[0] for s in spectrum
+        ]
+    spectra = {det.name: [s] for det, s in zip(layout.detectors, spectrum)}
+    counts = forward_radial_backward_counts(layout, spectra)
+    return spectrum, counts
+
+
+__all__ = ["angular_distribution"]

--- a/src/dpf2/diagnostics/neutron/base.py
+++ b/src/dpf2/diagnostics/neutron/base.py
@@ -7,7 +7,7 @@ from typing import Sequence, List, Dict, Any
 import json
 
 # Re-export core synthesis utilities from :mod:`neutron_spectra`
-from .neutron_spectra import (
+from ..neutron_spectra import (
     Detector,
     DetectorLayout,
     synthetic_tof_spectrum,

--- a/src/dpf2/diagnostics/neutron/benchmarks.py
+++ b/src/dpf2/diagnostics/neutron/benchmarks.py
@@ -1,0 +1,56 @@
+"""Benchmark comparison helpers for neutron diagnostics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+import json
+
+
+def _load_expected(benchmark: str) -> Tuple[float, float]:
+    """Return (expected_yield, tolerance) for *benchmark*."""
+
+    base = (
+        Path(__file__).resolve().parents[4]
+        / "benchmarks"
+        / benchmark
+        / "expected.json"
+    )
+    with base.open("r", encoding="utf8") as fh:
+        data = json.load(fh)
+    exp = float(data.get("neutron_yield", [0.0, 0.0])[-1])
+    tol = float(data.get("tolerance", {}).get("neutron_yield", 0.0))
+    return exp, tol
+
+
+def compare_with_benchmark(
+    yield_value: float, benchmark: str, pass_band: float | None = None
+) -> Tuple[bool, float]:
+    """Compare ``yield_value`` against reference data for *benchmark*.
+
+    Parameters
+    ----------
+    yield_value:
+        Simulated neutron yield to be compared.
+    benchmark:
+        Name of the benchmark directory under ``benchmarks/`` (e.g., ``pf_1000``
+        or ``mjolnir``).
+    pass_band:
+        Optional absolute tolerance overriding the value stored in the
+        benchmark file.
+
+    Returns
+    -------
+    ``(passed, difference)`` where ``passed`` indicates whether the simulated
+    yield lies within ``±pass_band`` of the reference value and ``difference`` is
+    the signed difference ``yield_value - reference``.
+    """
+
+    expected, tol = _load_expected(benchmark)
+    if pass_band is not None:
+        tol = float(pass_band)
+    diff = float(yield_value) - expected
+    return (abs(diff) <= tol, diff)
+
+
+__all__ = ["compare_with_benchmark"]

--- a/src/dpf2/diagnostics/neutron/tof.py
+++ b/src/dpf2/diagnostics/neutron/tof.py
@@ -1,0 +1,36 @@
+"""Synthetic time-of-flight utilities."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Sequence, Tuple
+
+from ..neutron_spectra import (
+    synthetic_tof_spectrum,
+    correlate_tof_peaks_with_circuit_iv,
+)
+from .angular import _apply_optional_response
+
+
+def synthetic_tof_correlated(
+    energies: Sequence[float],
+    flux: Sequence[float],
+    distance: float,
+    time_bins: Sequence[float],
+    circuit_time: Sequence[float],
+    current: Sequence[float],
+    voltage: Sequence[float],
+    response: Dict[str, float] | None = None,
+) -> Tuple[List[float], List[Tuple[float, float]], float]:
+    """Return ToF histogram and correlation with circuit ``I``–``V`` traces."""
+
+    hist = synthetic_tof_spectrum(energies, flux, distance, time_bins)
+    mid = [0.5 * (time_bins[i] + time_bins[i + 1]) for i in range(len(time_bins) - 1)]
+    if response:
+        hist = _apply_optional_response(mid, hist, response)
+    peaks, _lags, _corr, max_lag = correlate_tof_peaks_with_circuit_iv(
+        time_bins, hist, circuit_time, current, voltage
+    )
+    return hist, peaks, max_lag
+
+
+__all__ = ["synthetic_tof_correlated"]

--- a/src/dpf2/diagnostics/neutron/yield_calculators.py
+++ b/src/dpf2/diagnostics/neutron/yield_calculators.py
@@ -1,0 +1,65 @@
+"""Yield calculation helpers for neutron diagnostics."""
+
+from __future__ import annotations
+
+from typing import Callable, Sequence, Tuple
+
+from ..neutron_yield import (
+    compute_beam_target_yield as _compute_beam_target_yield,
+    compute_thermonuclear_yield as _compute_thermonuclear_yield,
+    IonBeamEDF,
+)
+from .angular import _apply_optional_response
+
+
+def thermonuclear_yield(
+    reactivity: Sequence[float], ion_density: Sequence[float], dt: float
+) -> float:
+    """Return thermonuclear yield integrated over time.
+
+    This is a thin wrapper over :func:`dpf2.diagnostics.neutron_yield.compute_thermonuclear_yield`
+    provided here for completeness of the subpackage API.
+    """
+
+    return _compute_thermonuclear_yield(reactivity, ion_density, dt)
+
+
+def beam_target_yield(
+    ion_edf: IonBeamEDF,
+    cross_section: Callable[[float], float],
+    angles: Sequence[float],
+    distance: float,
+    time_bins: Sequence[float],
+    response: dict | None = None,
+) -> Tuple[list[float], list[list[float]]]:
+    """Return ``dN/dΩ`` and ToF histograms for each detector angle.
+
+    Parameters
+    ----------
+    ion_edf, cross_section, angles, distance, time_bins:
+        Forwarded to :func:`dpf2.diagnostics.neutron_yield.compute_beam_target_yield`.
+    response:
+        Optional instrument response dictionary understood by
+        :func:`dpf2.diagnostics.neutron.apply_response`.  When provided the
+        response is applied to each time-of-flight histogram and integrated yield.
+
+    Returns
+    -------
+    (yields, tofs): ``yields`` gives ``dN/dΩ`` for each angle and ``tofs`` the
+    corresponding time-of-flight histograms.
+    """
+
+    yields, tofs = _compute_beam_target_yield(
+        ion_edf, cross_section, angles, distance, time_bins
+    )
+    if response:
+        processed_yields: list[float] = []
+        processed_tofs: list[list[float]] = []
+        mid = [0.5 * (time_bins[i] + time_bins[i + 1]) for i in range(len(time_bins) - 1)]
+        for y, hist in zip(yields, tofs):
+            hist = _apply_optional_response(mid, hist, response)
+            y_resp = _apply_optional_response([0.0], [y], response)[0]
+            processed_yields.append(y_resp)
+            processed_tofs.append(hist)
+        yields, tofs = processed_yields, processed_tofs
+    return yields, tofs

--- a/tests/test_neutron_package.py
+++ b/tests/test_neutron_package.py
@@ -1,0 +1,62 @@
+from dpf2.diagnostics.neutron import (
+    thermonuclear_yield,
+    beam_target_yield,
+    angular_distribution,
+    synthetic_tof_correlated,
+    compare_with_benchmark,
+)
+
+
+class _ConstEDF:
+    def energy_distribution(self, angle_deg):
+        return [1.0, 2.0], [1.0, 1.0]
+
+
+def _unit_sigma(e):
+    return 1.0
+
+
+def test_thermonuclear_yield():
+    y = thermonuclear_yield([1.0, 1.0], [1.0, 2.0], 1.0)
+    assert y == 5.0
+
+
+def test_beam_target_yield_basic():
+    angles = [0.0]
+    time_bins = [0.0, 1.0e-12]
+    yields, tofs = beam_target_yield(_ConstEDF(), _unit_sigma, angles, 1.0, time_bins)
+    assert yields == [1.0]
+    assert len(tofs) == 1 and len(tofs[0]) == 1
+
+
+def test_angular_distribution_counts():
+    spectrum, counts = angular_distribution([0.0, 90.0, 180.0], 1.0, anisotropy=1.0)
+    assert spectrum == [2.0, 1.0, 0.0]
+    assert counts["forward"] == 2.0
+    assert counts["radial"] == 1.0
+    assert counts["backward"] == 0.0
+
+
+def test_synthetic_tof_correlated():
+    energies = [3e-22, 4e-22]
+    flux = [1.0e22, 1.0e22]
+    distance = 1.0
+    time_bins = [0.0, 0.001, 0.002, 0.003]
+    circuit_time = [0.0, 0.001, 0.002, 0.003]
+    current = [0.0, 1.0, 0.0, 0.0]
+    voltage = [0.0, 2.0, 0.0, 0.0]
+    hist, peaks, max_lag = synthetic_tof_correlated(
+        energies, flux, distance, time_bins, circuit_time, current, voltage
+    )
+    expected = [0.0, 1.0, 0.0]
+    for a, b in zip(hist, expected):
+        assert abs(a - b) < 1e-12
+    assert peaks == [(0.0015, 1.0)]
+    assert max_lag == 0.0
+
+
+def test_compare_with_benchmarks():
+    passed, diff = compare_with_benchmark(0.0, "pf_1000")
+    assert passed and diff == 0.0
+    passed, _ = compare_with_benchmark(1.0, "mjolnir", pass_band=2.0)
+    assert passed


### PR DESCRIPTION
## Summary
- add thermonuclear and beam–target yield helpers
- support angular distributions, directional counts and instrument response
- generate synthetic ToF signals correlated with I–V traces
- compare yields to PF-1000 or MJOLNIR benchmarks

## Testing
- `pytest tests/test_neutron_package.py tests/test_neutron_spectra.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9fb88e8f4832abf5bccbe4090cadb