### PR TITLE
Add SEEA flashover model with conditioning and jitter tests

### DIFF
--- a/src/dpf2/geometry/__init__.py
+++ b/src/dpf2/geometry/__init__.py
@@ -15,6 +15,7 @@ from .parameterized import (
 from .triple_junction import (
     triple_junction_field,
     set_triple_junction_field_map,
+    triple_junction_enhancement,
 )
 
 __all__ = [
@@ -29,4 +30,5 @@ __all__ = [
     "ReentrantGeometry",
     "triple_junction_field",
     "set_triple_junction_field_map",
+    "triple_junction_enhancement",
 ]

--- a/src/dpf2/geometry/triple_junction.py
+++ b/src/dpf2/geometry/triple_junction.py
@@ -36,4 +36,35 @@ def set_triple_junction_field_map(geometry: str, field: float) -> None:
     _TRIPLE_JUNCTION_FIELD_MAP[geometry] = field
 
 
-__all__ = ["triple_junction_field", "set_triple_junction_field_map"]
+def triple_junction_enhancement(
+    geometry: str, anode_radius: float, cathode_radius: float, default: float = 1.0
+) -> float:
+    """Return a geometry-dependent triple-junction field enhancement.
+
+    The enhancement scales the preset field factor returned by
+    :func:`triple_junction_field` using the cathode to anode radius ratio.
+    This simple relationship captures the intuition that larger cathode
+    structures enhance the local electric field near the triple junction.
+
+    Parameters
+    ----------
+    geometry:
+        Name of the geometry preset.
+    anode_radius, cathode_radius:
+        Characteristic radii in centimetres.
+    default:
+        Baseline value used when ``geometry`` is unknown.
+    """
+
+    if anode_radius <= 0 or cathode_radius <= 0:
+        raise ValueError("radii must be positive")
+    base = triple_junction_field(geometry, default)
+    ratio = cathode_radius / anode_radius
+    return base * (1.0 + 0.1 * ratio)
+
+
+__all__ = [
+    "triple_junction_field",
+    "set_triple_junction_field_map",
+    "triple_junction_enhancement",
+]

--- a/src/dpf2/gui/dashboard.py
+++ b/src/dpf2/gui/dashboard.py
@@ -12,6 +12,7 @@ except Exception:  # pragma: no cover - fallback when matplotlib missing
 
 from ..web.app import create_app
 from ..uq import sampling, analysis, calibration
+from ..physics.flashover import FlashoverModel, FlashoverParameters
 
 Bounds = Mapping[str, Tuple[float, float]]
 
@@ -244,6 +245,36 @@ def plot_kpi_with_domain(
     return ax
 
 
+def flashover_delay_distribution(
+    field: float,
+    threshold: float,
+    geometry: str,
+    shots: int,
+    *,
+    sigma: float = 0.1,
+    conditioning: float = 0.0,
+    seed: int | None = None,
+) -> Sequence[float]:
+    """Return stochastic flashover delays for GUI consumption."""
+
+    params = FlashoverParameters(
+        field_threshold=threshold,
+        sigma=sigma,
+        conditioning=conditioning,
+        seed=seed,
+    )
+    model = FlashoverModel(geometry, params)
+    return model.delay_distribution(field, shots)
+
+
+def flashover_conditioning_curve(shots: int, alpha: float) -> Sequence[float]:
+    """Return conditioning multipliers suitable for plotting."""
+
+    params = FlashoverParameters(field_threshold=1.0, conditioning=alpha)
+    model = FlashoverModel("mather", params)
+    return model.conditioning_curve(shots)
+
+
 __all__ = [
     "launch",
     "run_sampling",
@@ -251,4 +282,6 @@ __all__ = [
     "calibrate_from_file",
     "plot_posterior_distributions",
     "plot_kpi_with_domain",
+    "flashover_delay_distribution",
+    "flashover_conditioning_curve",
 ]

--- a/src/dpf2/physics/__init__.py
+++ b/src/dpf2/physics/__init__.py
@@ -7,6 +7,7 @@ from .radiation import RadiationTransport
 from .pic_driver import PicDriver, PhysicalPICDriver, WarpXPICDriver
 from .lower_hybrid_drift import LowerHybridDrift
 from .m0_instability import MZeroInstability
+from .flashover import FlashoverModel, FlashoverParameters
 
 
 # Import optional modules individually so that a failure in one does not
@@ -42,6 +43,8 @@ __all__ = [
     "LowerHybridDrift",
     "MZeroInstability",
     "GVFront",
+    "FlashoverModel",
+    "FlashoverParameters",
 ]
 
 

--- a/src/dpf2/physics/flashover.py
+++ b/src/dpf2/physics/flashover.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""SEEA-based flashover model with conditioning history."""
+
+from dataclasses import dataclass, field
+from typing import List, Sequence
+
+from ..breakdown.flashover import (
+    FlashoverParameters,
+    conditioning_curve,
+    seea_stochastic_delay,
+    holdoff_voltage,
+)
+
+
+@dataclass
+class FlashoverModel:
+    """Track flashover delays and hold-off with conditioning history.
+
+    Parameters
+    ----------
+    geometry:
+        Name of the electrode geometry preset used for triple-junction
+        field enhancement.
+    params:
+        Configuration parameters controlling the stochastic delay model.
+    """
+
+    geometry: str
+    params: FlashoverParameters
+    shot: int = 0
+    delay_history: List[float] = field(default_factory=list)
+    holdoff_history: List[float] = field(default_factory=list)
+
+    def sample_delay(self, field: float) -> float:
+        """Sample a stochastic flashover delay for ``field``.
+
+        The internal ``shot`` counter is incremented after sampling so that
+        successive calls represent consecutive conditioning shots.
+        """
+
+        p = FlashoverParameters(
+            field_threshold=self.params.field_threshold,
+            sigma=self.params.sigma,
+            conditioning=self.params.conditioning,
+            seed=None if self.params.seed is None else self.params.seed + self.shot,
+        )
+        delay = seea_stochastic_delay(field, p, shot=self.shot)
+        self.delay_history.append(delay)
+        self.shot += 1
+        return delay
+
+    def delay_distribution(self, field: float, shots: int) -> Sequence[float]:
+        """Return a series of stochastic delays over ``shots`` shots."""
+
+        return [self.sample_delay(field) for _ in range(shots)]
+
+    def sample_holdoff(self) -> float:
+        """Sample a hold-off voltage for the configured geometry."""
+
+        p = FlashoverParameters(
+            field_threshold=self.params.field_threshold,
+            sigma=self.params.sigma,
+            conditioning=self.params.conditioning,
+            seed=None if self.params.seed is None else self.params.seed + self.shot,
+        )
+        value = holdoff_voltage(self.geometry, p, shot=self.shot)
+        self.holdoff_history.append(value)
+        self.shot += 1
+        return value
+
+    def holdoff_series(self, shots: int) -> Sequence[float]:
+        """Return a series of hold-off voltages over ``shots`` shots."""
+
+        return [self.sample_holdoff() for _ in range(shots)]
+
+    def conditioning_curve(self, shots: int) -> Sequence[float]:
+        """Return the conditioning multipliers for the first ``shots`` shots."""
+
+        return [conditioning_curve(n, self.params.conditioning) for n in range(shots)]
+
+
+__all__ = ["FlashoverModel", "FlashoverParameters", "conditioning_curve"]

--- a/tests/breakdown/test_flashover.py
+++ b/tests/breakdown/test_flashover.py
@@ -8,6 +8,7 @@ from dpf2.breakdown.flashover import (
 from dpf2.geometry import (
     triple_junction_field,
     set_triple_junction_field_map,
+    triple_junction_enhancement,
 )
 from dpf2.dpf_config import BreakdownModel
 from dpf2.synthetic_diagnostics import flashover_delay_stats, flashover_jitter_stats
@@ -30,6 +31,12 @@ def test_triple_junction_field_map():
     set_triple_junction_field_map("custom", 42.0)
     assert triple_junction_field("custom") == 42.0
     assert base == 1.0
+
+
+def test_triple_junction_enhancement_geometry_ratio():
+    base = triple_junction_field("mather")
+    enhanced = triple_junction_enhancement("mather", anode_radius=1.0, cathode_radius=2.0)
+    assert enhanced > base
 
 def test_breakdown_model_exposes_parameters():
     bm = BreakdownModel(type="flashover", seea_sigma=0.2, conditioning_alpha=0.1)

--- a/tests/physics/test_flashover_history.py
+++ b/tests/physics/test_flashover_history.py
@@ -1,0 +1,18 @@
+from dpf2.physics.flashover import FlashoverModel, FlashoverParameters
+from dpf2.synthetic_diagnostics import flashover_jitter_stats
+
+
+def test_flashover_model_conditioning_history():
+    params = FlashoverParameters(field_threshold=10.0, sigma=0.0, conditioning=0.1, seed=1)
+    model = FlashoverModel("mather", params)
+    d0 = model.sample_delay(5.0)
+    d1 = model.sample_delay(5.0)
+    assert d1 < d0
+
+
+def test_flashover_jitter_matches_reference():
+    params = FlashoverParameters(field_threshold=10.0, sigma=0.2, conditioning=0.0, seed=123)
+    model = FlashoverModel("mather", params)
+    series = model.holdoff_series(20)
+    stats = flashover_jitter_stats(series)
+    assert abs(stats["stddev"] - 2.0) < 0.5


### PR DESCRIPTION
## Summary
- implement SEEA-based `FlashoverModel` tracking conditioning history
- compute geometry-dependent triple-junction field enhancement
- expose flashover delay distribution and conditioning curve helpers in GUI
- add acceptance test comparing simulated flashover jitter to reference data

## Testing
- `pytest tests/breakdown/test_flashover.py tests/physics/test_flashover_history.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9fb8b1104832abfa02dd0daaa307c