### PR TITLE
Add neutral gas fluid model and swarm parameter validation

### DIFF
--- a/src/dpf2/physics/hooks.py
+++ b/src/dpf2/physics/hooks.py
@@ -11,8 +11,23 @@ for neutral species and ablating walls within the simplified MHD framework.
 from ..ablation import ablation_mass_energy_source
 
 
-def neutral_density_source(rho_n: float, ionization_rate: float) -> float:
-    """Return the depletion rate of neutral mass density.
+def neutral_density_source(
+    rho_n: float,
+    ionization_rate: float,
+    *,
+    t: float = 0.0,
+    puff_start: float | None = None,
+    puff_end: float | None = None,
+    mass_flow_rate: float = 0.0,
+    volume: float = 1.0,
+) -> float:
+    """Rate of change of neutral density.
+
+    The source term combines ionisation losses with a simple
+    representation of a timed gas puff.  When ``puff_start <= t <=
+    puff_end`` a mass flow ``mass_flow_rate`` (kg/s) is injected through a
+    nozzle and converted into a density source by dividing by the system
+    volume.
 
     Parameters
     ----------
@@ -20,14 +35,31 @@ def neutral_density_source(rho_n: float, ionization_rate: float) -> float:
         Neutral mass density.
     ionization_rate:
         Effective ionisation rate coefficient ``[1/s]``.
+    t:
+        Simulation time ``[s]``.
+    puff_start, puff_end:
+        Start and end times of the gas puff ``[s]``.
+    mass_flow_rate:
+        Mass flow through the puff nozzle ``[kg/s]``.
+    volume:
+        Volume used to convert mass flow to density ``[m^3]``.
 
     Returns
     -------
     float
-        Time derivative of ``rho_n`` due to ionisation.
+        Time derivative of ``rho_n`` accounting for both sources and
+        sinks.
     """
 
-    return -ionization_rate * rho_n
+    injection = 0.0
+    if (
+        puff_start is not None
+        and puff_end is not None
+        and puff_start <= t <= puff_end
+        and mass_flow_rate > 0.0
+    ):
+        injection = mass_flow_rate / volume
+    return injection - ionization_rate * rho_n
 
 
 def wall_ablation_source(

--- a/src/dpf2/physics/neutral_gas/__init__.py
+++ b/src/dpf2/physics/neutral_gas/__init__.py
@@ -1,0 +1,15 @@
+"""Neutral gas physics models and utilities."""
+
+from .fluid import NeutralGasFluid
+from .swarm import (
+    SwarmParameters,
+    compute_swarm_parameters,
+    validate_swarm_parameters,
+)
+
+__all__ = [
+    "NeutralGasFluid",
+    "SwarmParameters",
+    "compute_swarm_parameters",
+    "validate_swarm_parameters",
+]

--- a/src/dpf2/physics/neutral_gas/fluid.py
+++ b/src/dpf2/physics/neutral_gas/fluid.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+"""Simple neutral gas fluid model with gas puff injection.
+
+This module provides a small 0D fluid model that evolves the neutral
+mass density.  It is intentionally lightweight and aims to exercise the
+coupling interfaces used throughout the code base rather than providing
+an exhaustive physical model.
+
+The model evolves the neutral density according to
+
+.. math::
+
+    \frac{d\rho_n}{dt} = S_{puff}(t) - \nu_i\rho_n
+
+where ``S_puff`` represents a mass source due to a gas puff and
+``nu_i`` is an effective ionisation rate.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class NeutralGasFluid:
+    """Zero‑dimensional neutral gas model.
+
+    Parameters
+    ----------
+    rho : float
+        Initial mass density ``[kg/m^3]``.
+    volume : float
+        Volume of the system ``[m^3]`` used to convert mass flow to
+        density injection.
+    mass_flow_rate : float, optional
+        Mass flow through the puff nozzle ``[kg/s]``.
+    puff_start : float, optional
+        Start time of the gas puff ``[s]``.
+    puff_end : float, optional
+        End time of the gas puff ``[s]``.
+    """
+
+    rho: float
+    volume: float
+    mass_flow_rate: float = 0.0
+    puff_start: float = 0.0
+    puff_end: float = 0.0
+
+    def puff_source(self, t: float) -> float:
+        """Return the density source due to the gas puff."""
+        if self.puff_start <= t <= self.puff_end and self.mass_flow_rate > 0:
+            return self.mass_flow_rate / self.volume
+        return 0.0
+
+    def source(self, t: float, ionization_rate: float) -> float:
+        """Combined source term from puff and ionisation."""
+        return self.puff_source(t) - ionization_rate * self.rho
+
+    def step(self, dt: float, t: float, ionization_rate: float) -> float:
+        """Advance the density by ``dt`` seconds."""
+        self.rho += dt * self.source(t, ionization_rate)
+        return self.rho
+
+
+__all__ = ["NeutralGasFluid"]

--- a/src/dpf2/physics/neutral_gas/swarm.py
+++ b/src/dpf2/physics/neutral_gas/swarm.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+"""Utilities for validating swarm parameters against reference data."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+
+from dpf2.neutral.dsmc import load_lxcat_table
+
+
+@dataclass
+class SwarmParameters:
+    mobility: float
+    diffusion: float
+
+
+def compute_swarm_parameters(table: np.ndarray) -> SwarmParameters:
+    """Compute simple swarm parameters from a cross‑section table.
+
+    The implementation is intentionally simplistic: mobility and diffusion
+    are taken to scale inversely with the mean cross section of the table.
+    This is sufficient for validating that LXCat/Bolsig+ style reference
+    data can be ingested correctly.
+    """
+
+    sigma = float(np.mean(table[:, 1]))
+    if sigma <= 0:  # pragma: no cover - defensive programming
+        raise ValueError("mean cross section must be positive")
+    mobility = 1.0 / sigma
+    diffusion = 1.0 / (3.0 * sigma)
+    return SwarmParameters(mobility=mobility, diffusion=diffusion)
+
+
+def validate_swarm_parameters(path: Path, reference: Dict[str, float]) -> SwarmParameters:
+    """Validate swarm parameters against reference values.
+
+    Parameters
+    ----------
+    path:
+        Path to an LXCat style cross‑section table.
+    reference:
+        Mapping of parameter names to reference values.  Supported keys are
+        ``"mobility"`` and ``"diffusion"``.
+    """
+
+    table = load_lxcat_table(Path(path))
+    params = compute_swarm_parameters(table)
+    for key, ref in reference.items():
+        val = getattr(params, key)
+        if not np.isclose(val, ref, rtol=0.05, atol=0.0):
+            raise ValueError(f"{key} {val} disagrees with reference {ref}")
+    return params
+
+
+__all__ = ["SwarmParameters", "compute_swarm_parameters", "validate_swarm_parameters"]

--- a/tests/neutral/test_fluid_gas_puff.py
+++ b/tests/neutral/test_fluid_gas_puff.py
@@ -1,0 +1,30 @@
+import pytest
+
+from dpf2.physics.neutral_gas import NeutralGasFluid
+from dpf2.physics.hooks import neutral_density_source
+
+
+def test_gas_puff_increases_density_then_ionizes():
+    fluid = NeutralGasFluid(rho=0.0, volume=1.0, mass_flow_rate=1e-6, puff_start=0.0, puff_end=1.0)
+    # During puff, density rises linearly
+    rho1 = fluid.step(1.0, t=0.5, ionization_rate=0.0)
+    assert rho1 == pytest.approx(1e-6)
+
+    # After puff ends, only ionisation acts and density decays
+    rho2 = fluid.step(1.0, t=1.5, ionization_rate=1.0)
+    assert rho2 < rho1
+    assert rho2 == pytest.approx(rho1 - rho1)
+
+
+def test_neutral_density_source_with_puff():
+    # With a puff active the source should be positive even with ionisation
+    src = neutral_density_source(
+        rho_n=1e-6,
+        ionization_rate=0.1,
+        t=0.5,
+        puff_start=0.0,
+        puff_end=1.0,
+        mass_flow_rate=1e-6,
+        volume=1.0,
+    )
+    assert src > 0

--- a/tests/neutral/test_neutral_transport_benchmark.py
+++ b/tests/neutral/test_neutral_transport_benchmark.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+pytest.importorskip("pytest_benchmark")
+
+from dpf2.physics.neutral_gas import NeutralGasFluid
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("steps", [100])
+def test_neutral_transport_benchmark(benchmark, steps):
+    fluid = NeutralGasFluid(rho=0.0, volume=1.0, mass_flow_rate=1e-6, puff_start=0.0, puff_end=1e-3)
+
+    def run():
+        t = 0.0
+        for _ in range(steps):
+            fluid.step(1e-5, t, ionization_rate=0.0)
+            t += 1e-5
+        return fluid.rho
+
+    result = benchmark(run)
+    assert result > 0.0

--- a/tests/neutral/test_swarm_parameters.py
+++ b/tests/neutral/test_swarm_parameters.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from dpf2.physics.neutral_gas import validate_swarm_parameters, compute_swarm_parameters
+from dpf2.neutral.dsmc import load_lxcat_table
+
+
+def test_swarm_parameter_validation():
+    table = load_lxcat_table(Path("tests/neutral/lxcat_dummy.csv"))
+    params = compute_swarm_parameters(table)
+    # validate against the computed values to ensure routine works
+    validated = validate_swarm_parameters(Path("tests/neutral/lxcat_dummy.csv"), {
+        "mobility": params.mobility,
+        "diffusion": params.diffusion,
+    })
+    assert validated == params


### PR DESCRIPTION
## Summary
- add lightweight 0D neutral gas fluid model with gas puff injection support
- provide LXCat-based swarm parameter validation utilities
- extend neutral density hook for gas puff timing and couple to ionisation
- add neutral transport tests and benchmark

## Testing
- `pytest tests/neutral -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9fb8eba94832a8ba660d4b9a72eb5