### PR TITLE
Add FFT-based m-mode instability diagnostics with benchmark

### DIFF
--- a/benchmarks/m1_evolution/README.md
+++ b/benchmarks/m1_evolution/README.md
@@ -1,0 +1,7 @@
+# Reduced m=1 instability benchmark
+
+This benchmark creates a small three-dimensional synthetic data set to
+illustrate the evolution of an $m=1$ kink mode.  Running
+`python -m benchmarks.m1_evolution.demo` will compute FFT-based azimuthal
+mode amplitudes, report growth rates for $m=0$ and $m=1$, and issue an
+alert when the kink threshold is exceeded.

--- a/benchmarks/m1_evolution/demo.py
+++ b/benchmarks/m1_evolution/demo.py
@@ -1,0 +1,35 @@
+"""Reduced 3D benchmark demonstrating m=1 mode evolution.
+
+This script generates a small synthetic data set where an m=1 kink mode
+grows exponentially. The :mod:`diagnostics.instabilities` module is used
+to extract growth rates and trigger instability alerts.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from diagnostics.instabilities import analyze_instabilities
+
+
+def main() -> None:
+    n_theta = 32
+    n_z = 4
+    n_r = 4
+    dt = 1.0
+    times = np.arange(10)
+    series = []
+    for ti in times:
+        theta = np.linspace(0.0, 2 * np.pi, n_theta, endpoint=False)
+        base = np.ones((n_z, n_r, n_theta))
+        m1 = np.cos(theta)[None, None, :] * np.exp(0.3 * ti)
+        series.append(base + m1)
+    ez_series = np.sin(0.1 * times) + 0.5 * times
+    result = analyze_instabilities(series, dt, ez_series)
+    print("Growth rates:", result["growth_rates"])
+    print("Alerts:", result["alerts"])
+    if "beam_onset_time" in result:
+        print("Beam onset time:", result["beam_onset_time"])
+
+
+if __name__ == "__main__":
+    main()

--- a/diagnostics/__init__.py
+++ b/diagnostics/__init__.py
@@ -1,0 +1,1 @@
+"""Diagnostic utilities for DPF simulations."""

--- a/diagnostics/instabilities/__init__.py
+++ b/diagnostics/instabilities/__init__.py
@@ -1,0 +1,17 @@
+"""Instability diagnostics based on azimuthal mode analysis."""
+
+from .m_mode_analysis import (
+    analyze_instabilities,
+    fft_m_modes,
+    growth_rate,
+    SAUSAGE_GROWTH_THRESHOLD,
+    KINK_GROWTH_THRESHOLD,
+)
+
+__all__ = [
+    "analyze_instabilities",
+    "fft_m_modes",
+    "growth_rate",
+    "SAUSAGE_GROWTH_THRESHOLD",
+    "KINK_GROWTH_THRESHOLD",
+]

--- a/diagnostics/instabilities/m_mode_analysis.py
+++ b/diagnostics/instabilities/m_mode_analysis.py
@@ -1,0 +1,115 @@
+import logging
+from typing import Iterable, Dict, Any
+
+import numpy as np
+
+SAUSAGE_GROWTH_THRESHOLD = 0.05
+KINK_GROWTH_THRESHOLD = 0.05
+
+
+def fft_m_modes(field: np.ndarray, theta_axis: int = -1) -> np.ndarray:
+    """Return absolute FFT amplitudes of azimuthal modes.
+
+    Parameters
+    ----------
+    field: np.ndarray
+        Field sampled on uniform azimuthal grid. The azimuthal axis is
+        specified by ``theta_axis``.
+    theta_axis: int
+        Axis corresponding to the azimuthal direction.
+
+    Returns
+    -------
+    np.ndarray
+        Absolute value of Fourier coefficients along ``theta_axis``
+        normalised by the number of azimuthal samples.
+    """
+    field = np.asarray(field)
+    n_theta = field.shape[theta_axis]
+    fft = np.fft.fft(field, axis=theta_axis)
+    return np.abs(fft) / n_theta
+
+
+def growth_rate(time_series: Iterable[np.ndarray], dt: float, m: int,
+                theta_axis: int = -1) -> float:
+    """Estimate exponential growth rate for mode ``m``.
+
+    Parameters
+    ----------
+    time_series: iterable of np.ndarray
+        Sequence of field snapshots ordered in time.
+    dt: float
+        Time separation between consecutive snapshots.
+    m: int
+        Mode number whose growth rate is requested.
+    theta_axis: int
+        Axis corresponding to the azimuthal direction.
+    """
+    amplitudes = []
+    for snap in time_series:
+        modes = fft_m_modes(snap, theta_axis)
+        amplitudes.append(np.mean(modes[..., m]))
+    amplitudes = np.asarray(amplitudes)
+    amplitudes = np.where(amplitudes <= 0, 1e-12, amplitudes)
+    times = np.arange(len(amplitudes)) * dt
+    slope, _ = np.polyfit(times, np.log(amplitudes), 1)
+    return float(slope)
+
+
+def analyze_instabilities(time_series: Iterable[np.ndarray], dt: float,
+                          ez_series: Iterable[float] | None = None,
+                          thresholds: Dict[str, float] | None = None,
+                          theta_axis: int = -1) -> Dict[str, Any]:
+    """Analyse m=0 and m=1 modes and detect instability onsets.
+
+    Parameters
+    ----------
+    time_series: iterable of np.ndarray
+        Field snapshots ordered in time.
+    dt: float
+        Time step between snapshots.
+    ez_series: iterable of float, optional
+        On-axis electric field evolution used to relate mode growth to
+        axial surges and beam formation.
+    thresholds: dict, optional
+        Mapping of ``{"sausage": value, "kink": value}`` representing
+        growth-rate thresholds that trigger alerts.
+    theta_axis: int
+        Axis corresponding to azimuthal direction.
+
+    Returns
+    -------
+    dict
+        Dictionary with growth rates, optional Ez surge information and
+        list of instabilities whose thresholds were exceeded.
+    """
+    if thresholds is None:
+        thresholds = {
+            "sausage": SAUSAGE_GROWTH_THRESHOLD,
+            "kink": KINK_GROWTH_THRESHOLD,
+        }
+
+    gr0 = growth_rate(time_series, dt, 0, theta_axis)
+    gr1 = growth_rate(time_series, dt, 1, theta_axis)
+
+    alerts = []
+    if gr0 > thresholds.get("sausage", float("inf")):
+        alerts.append("sausage")
+        logging.warning("Sausage instability threshold exceeded")
+    if gr1 > thresholds.get("kink", float("inf")):
+        alerts.append("kink")
+        logging.warning("Kink instability threshold exceeded")
+
+    result: Dict[str, Any] = {
+        "growth_rates": {"m0": gr0, "m1": gr1},
+        "alerts": alerts,
+    }
+
+    if ez_series is not None:
+        ez_series = np.asarray(ez_series)
+        derivative = np.gradient(ez_series) / dt
+        surge_index = int(np.argmax(derivative))
+        result["ez_surge_time"] = surge_index * dt
+        if "kink" in alerts:
+            result["beam_onset_time"] = surge_index * dt
+    return result

--- a/tests/test_instabilities_analysis.py
+++ b/tests/test_instabilities_analysis.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from diagnostics.instabilities import analyze_instabilities, fft_m_modes
+
+
+def test_m_mode_growth_and_alert():
+    n_theta = 32
+    dt = 1.0
+    times = np.arange(8)
+    series = []
+    for ti in times:
+        theta = np.linspace(0, 2 * np.pi, n_theta, endpoint=False)
+        field = 1.0 + np.exp(0.2 * ti) * np.cos(theta)
+        series.append(field)
+    ez_series = times ** 2
+    result = analyze_instabilities(
+        series,
+        dt,
+        ez_series=ez_series,
+        thresholds={"sausage": 0.1, "kink": 0.1},
+    )
+    assert result["growth_rates"]["m1"] == pytest.approx(0.2, rel=0.1)
+    assert abs(result["growth_rates"]["m0"]) < 1e-3
+    assert "kink" in result["alerts"]
+    assert "beam_onset_time" in result
+
+
+def test_fft_m_mode_amplitudes():
+    n_theta = 8
+    theta = np.linspace(0, 2 * np.pi, n_theta, endpoint=False)
+    field = 2 + 3 * np.cos(theta)
+    modes = fft_m_modes(field)
+    # m=0 mode amplitude should be 2
+    assert modes[0] == pytest.approx(2.0, rel=1e-6)
+    # m=1 mode amplitude should be 3/2 due to FFT normalisation
+    assert modes[1] == pytest.approx(1.5, rel=1e-6)


### PR DESCRIPTION
## Summary
- Implement FFT-based azimuthal mode analysis and growth-rate estimation for m=0 and m=1
- Trigger alerts when sausage/kink growth exceeds thresholds and relate to axial Ez surges
- Add reduced 3D benchmark and tests demonstrating kink-mode evolution

## Testing
- `pytest tests/test_instabilities_analysis.py -q`
- `python -m benchmarks.m1_evolution.demo`


------
https://chatgpt.com/codex/tasks/task_e_68b9fb8f29c8832a92c1182fa7fc10b6