### PR TITLE
Add detector transfer functions and RLC cable dispersion models

### DIFF
--- a/data/detectors/iv_probe.json
+++ b/data/detectors/iv_probe.json
@@ -1,5 +1,5 @@
 {
   "gating": {"start": 0.0, "end": 10.0},
   "dead_time": 0.0,
-  "dispersion": [0.5, 0.5]
+  "rlc": {"R": 1.0, "L": 1.0, "C": 1.0}
 }

--- a/data/detectors/neutron_detector.json
+++ b/data/detectors/neutron_detector.json
@@ -1,5 +1,5 @@
 {
   "gating": {"start": 1.0, "end": 3.0},
   "dead_time": 0.0,
-  "dispersion": [1.0]
+  "transfer_function": [1.0]
 }

--- a/data/detectors/xray_detector.json
+++ b/data/detectors/xray_detector.json
@@ -1,5 +1,5 @@
 {
   "gating": {"start": 0.0, "end": 10.0},
   "dead_time": 0.25,
-  "dispersion": [1.0]
+  "transfer_function": [1.0]
 }

--- a/src/dpf2/diagnostics/iv_probes.py
+++ b/src/dpf2/diagnostics/iv_probes.py
@@ -1,17 +1,47 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Sequence, List, Dict, Any
+from typing import Sequence, List, Dict, Any, Mapping
 import json
+import math
 
 
-def load_response(path: str | Path) -> Dict[str, Any]:
+def load_response(path: str | Path, overrides: Mapping[str, Any] | None = None) -> Dict[str, Any]:
     """Load an I-V probe response description from *path*.
 
-    The file shares the same JSON structure as other detector responses.
+    Parameters
+    ----------
+    path:
+        Location of the JSON configuration file.
+    overrides:
+        Optional mapping of values that override those read from *path*.
     """
     with open(Path(path), "r", encoding="utf-8") as fh:
-        return json.load(fh)
+        data = json.load(fh)
+    if overrides:
+        data.update(overrides)
+    return data
+
+
+def _rlc_kernel(length: int, dt: float, R: float, L: float, C: float) -> List[float]:
+    """Generate an impulse response for a simple series RLC circuit."""
+    kernel: List[float] = []
+    alpha = R / (2.0 * L) if L else 0.0
+    w0 = 1.0 / math.sqrt(L * C) if L and C else 0.0
+    for i in range(length):
+        t = i * dt
+        if alpha < w0:
+            wd = math.sqrt(w0 * w0 - alpha * alpha)
+            val = (1.0 / (L * wd)) * math.exp(-alpha * t) * math.sin(wd * t)
+        elif alpha == w0:
+            val = (t / L) * math.exp(-alpha * t) if L else 0.0
+        else:
+            sq = math.sqrt(alpha * alpha - w0 * w0)
+            r1 = -alpha + sq
+            r2 = -alpha - sq
+            val = (1.0 / (L * (r2 - r1))) * (math.exp(r1 * t) - math.exp(r2 * t)) if L else 0.0
+        kernel.append(val)
+    return kernel
 
 
 def apply_response(
@@ -46,9 +76,24 @@ def apply_response(
                     last = ti
         vals = processed
 
-    dispersion = response.get("dispersion")
-    if dispersion:
-        kernel = [float(k) for k in dispersion]
+    kernel = response.get("transfer_function") or response.get("dispersion")
+    if kernel:
+        kernel = [float(k) for k in kernel]
+        conv = [0.0 for _ in vals]
+        for i, v in enumerate(vals):
+            for j, k in enumerate(kernel):
+                idx = i + j
+                if idx < len(conv):
+                    conv[idx] += v * k
+        vals = conv
+
+    rlc = response.get("rlc")
+    if rlc:
+        R = float(rlc.get("R", 0.0))
+        L = float(rlc.get("L", 0.0))
+        C = float(rlc.get("C", 0.0))
+        dt = t[1] - t[0] if len(t) > 1 else 1.0
+        kernel = _rlc_kernel(len(vals), dt, R, L, C)
         conv = [0.0 for _ in vals]
         for i, v in enumerate(vals):
             for j, k in enumerate(kernel):

--- a/src/dpf2/diagnostics/neutron.py
+++ b/src/dpf2/diagnostics/neutron.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Sequence, List, Dict, Any
+from typing import Sequence, List, Dict, Any, Mapping
 import json
 
 # Re-export core synthesis utilities from :mod:`neutron_spectra`
@@ -19,16 +19,31 @@ from .neutron_spectra import (
 )
 
 
-def load_response(path: str | Path) -> Dict[str, Any]:
+def load_response(path: str | Path, overrides: Mapping[str, Any] | None = None) -> Dict[str, Any]:
     """Load a neutron detector response description from *path*.
 
+    Parameters
+    ----------
+    path:
+        Location of the JSON configuration file.
+    overrides:
+        Optional mapping of values that override those read from *path*.  This
+        provides a lightweight mechanism for user customisation of the detector
+        description without having to modify the distributed parameter files.
+
+    Notes
+    -----
     The file is expected to contain JSON with optional keys ``gating``,
-    ``dead_time`` and ``dispersion``. ``gating`` should be a mapping with
-    ``start`` and ``end`` times.  ``dispersion`` is interpreted as a kernel for
-    a simple discrete convolution applied after gating and dead time.
+    ``dead_time`` and ``transfer_function``. ``gating`` should be a mapping with
+    ``start`` and ``end`` times.  ``transfer_function`` is interpreted as a
+    kernel for a simple discrete convolution applied after gating and dead
+    time.
     """
     with open(Path(path), "r", encoding="utf-8") as fh:
-        return json.load(fh)
+        data = json.load(fh)
+    if overrides:
+        data.update(overrides)
+    return data
 
 
 def apply_response(
@@ -69,10 +84,9 @@ def apply_response(
                     last = ti
         vals = processed
 
-    dispersion = response.get("dispersion")
-    if dispersion:
-        kernel = [float(k) for k in dispersion]
-        klen = len(kernel)
+    kernel = response.get("transfer_function") or response.get("dispersion")
+    if kernel:
+        kernel = [float(k) for k in kernel]
         conv = [0.0 for _ in vals]
         for i, v in enumerate(vals):
             for j, k in enumerate(kernel):

--- a/src/dpf2/diagnostics/xray.py
+++ b/src/dpf2/diagnostics/xray.py
@@ -1,17 +1,25 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Sequence, List, Dict, Any
+from typing import Sequence, List, Dict, Any, Mapping
 import json
 
 
-def load_response(path: str | Path) -> Dict[str, Any]:
+def load_response(path: str | Path, overrides: Mapping[str, Any] | None = None) -> Dict[str, Any]:
     """Load an X-ray detector response description from *path*.
 
-    The JSON format mirrors that used for neutron detectors.
+    Parameters
+    ----------
+    path:
+        Location of the JSON configuration file.
+    overrides:
+        Optional mapping of values that override those read from *path*.
     """
     with open(Path(path), "r", encoding="utf-8") as fh:
-        return json.load(fh)
+        data = json.load(fh)
+    if overrides:
+        data.update(overrides)
+    return data
 
 
 def apply_response(
@@ -49,9 +57,9 @@ def apply_response(
                     last = ti
         vals = processed
 
-    dispersion = response.get("dispersion")
-    if dispersion:
-        kernel = [float(k) for k in dispersion]
+    kernel = response.get("transfer_function") or response.get("dispersion")
+    if kernel:
+        kernel = [float(k) for k in kernel]
         conv = [0.0 for _ in vals]
         for i, v in enumerate(vals):
             for j, k in enumerate(kernel):

--- a/tests/diagnostics/test_detector_responses.py
+++ b/tests/diagnostics/test_detector_responses.py
@@ -13,6 +13,16 @@ def test_neutron_gating_only():
     assert processed == [0.0, 1.0, 1.0, 1.0, 0.0]
 
 
+def test_neutron_transfer_function():
+    resp = neutron.load_response(
+        DATA_DIR / "neutron_detector.json", overrides={"gating": None, "transfer_function": [0.5, 0.5]}
+    )
+    times = [0, 1, 2, 3]
+    signal = [1, 0, 0, 0]
+    processed = neutron.apply_response(times, signal, resp)
+    assert processed == [0.5, 0.5, 0.0, 0.0]
+
+
 def test_xray_dead_time():
     resp = xray.load_response(DATA_DIR / "xray_detector.json")
     times = [0.0, 0.1, 0.2, 0.5]
@@ -21,9 +31,11 @@ def test_xray_dead_time():
     assert processed == [1.0, 0.0, 0.0, 1.0]
 
 
-def test_iv_probe_dispersion():
+def test_iv_probe_rlc():
     resp = iv_probes.load_response(DATA_DIR / "iv_probe.json")
     times = [0.0, 1.0, 2.0, 3.0]
-    signal = [1.0, 0.0, 0.0, 1.0]
+    signal = [1.0, 0.0, 0.0, 0.0]
     processed = iv_probes.apply_response(times, signal, resp)
-    assert processed == [0.5, 0.5, 0.0, 0.5]
+    expected = [0.0, 0.5335071951, 0.4192796297, 0.1332426440]
+    for p, e in zip(processed, expected):
+        assert abs(p - e) < 1e-6


### PR DESCRIPTION
## Summary
- extend neutron and X-ray diagnostics with configurable transfer functions and user overrides
- support cable dispersion for I/V probes via simple RLC convolution
- provide default response files and tests covering gating, dead time, transfer functions and RLC effects

## Testing
- `pytest tests/diagnostics/test_detector_responses.py`
- `pytest` *(fails: ImportError: attempted relative import with no known parent package; cannot import name 'HallMHD', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fb93f9b0832a9f272f6a07182f16