### PR TITLE
Add KPI export and electrode erosion model

### DIFF
--- a/scripts/export_performance_metrics.py
+++ b/scripts/export_performance_metrics.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Compute simple KPIs and export them for the web UI.
+
+This command line utility wraps :func:`dpf2.diagnostics.compute_performance_metrics`
+and writes summary tables, plots and data files into the specified output
+directory.  The default location matches the layout expected by the web UI
+(``ui/performance_metrics``).
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from dpf2.diagnostics import (
+    compute_performance_metrics,
+    export_performance_metrics,
+)
+
+
+def main() -> None:  # pragma: no cover - CLI wrapper
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("yield_per_shot", type=float, help="Neutron yield per shot")
+    parser.add_argument("rep_rate_hz", type=float, help="Repetition rate in Hz")
+    parser.add_argument("energy_out_j", type=float, help="Output energy per shot (J)")
+    parser.add_argument("energy_in_j", type=float, help="Input energy per shot (J)")
+    parser.add_argument(
+        "electrode_mass_g", type=float, help="Available electrode mass before replacement (g)"
+    )
+    parser.add_argument(
+        "erosion_per_shot_g", type=float, help="Electrode mass lost per shot (g)"
+    )
+    parser.add_argument(
+        "--output",
+        default="ui/performance_metrics",
+        type=Path,
+        help="Directory where output files will be written",
+    )
+    args = parser.parse_args()
+
+    metrics = compute_performance_metrics(
+        args.yield_per_shot,
+        rep_rate_hz=args.rep_rate_hz,
+        energy_out_j=args.energy_out_j,
+        energy_in_j=args.energy_in_j,
+        electrode_mass_g=args.electrode_mass_g,
+        erosion_per_shot_g=args.erosion_per_shot_g,
+    )
+    export_performance_metrics(metrics, args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -58,7 +58,11 @@ from .neutron_spectra import (
     angular_spectrum,
     anisotropy_metric,
 )
-from .performance_metrics import compute_performance_metrics
+from .performance_metrics import (
+    compute_performance_metrics,
+    estimate_lifetime_sputtering,
+    export_performance_metrics,
+)
 
 
 def apply_noise(
@@ -95,6 +99,8 @@ __all__ = [
     "angular_yield_map",
     "save_angular_yield_map_hdf5",
     "compute_performance_metrics",
+    "estimate_lifetime_sputtering",
+    "export_performance_metrics",
     "compute_xray_spectrum",
     "compute_scope_trace",
     "current_waveform",

--- a/src/dpf2/diagnostics/performance_metrics.py
+++ b/src/dpf2/diagnostics/performance_metrics.py
@@ -9,6 +9,20 @@ consume it without having to understand any additional classes.
 """
 
 from typing import Dict
+from pathlib import Path
+import csv
+
+try:  # pragma: no cover - matplotlib optional
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+except Exception:  # pragma: no cover - matplotlib may be absent
+    plt = None
+
+import h5py
+
+
+AVOGADRO = 6.022_140_76e23  # mol^-1
 
 
 def compute_performance_metrics(
@@ -77,3 +91,119 @@ def compute_performance_metrics(
         "wall_plug_efficiency": float(wall),
         "lifetime_hours": float(lifetime),
     }
+
+
+def estimate_lifetime_sputtering(
+    sputtering_rate_atoms_per_cm2: float,
+    *,
+    electrode_area_cm2: float,
+    electrode_thickness_cm: float,
+    material_density_g_cm3: float,
+    atomic_mass_g_mol: float,
+    rep_rate_hz: float,
+) -> float:
+    """Estimate electrode lifetime from a simple sputtering model.
+
+    Parameters
+    ----------
+    sputtering_rate_atoms_per_cm2:
+        Number of atoms ejected per square centimetre for each shot.
+    electrode_area_cm2:
+        Exposed surface area of the electrode.
+    electrode_thickness_cm:
+        Thickness of material available before replacement is required.
+    material_density_g_cm3:
+        Density of the electrode material.
+    atomic_mass_g_mol:
+        Atomic mass of the electrode material in grams per mole.
+    rep_rate_hz:
+        Shot repetition rate.
+
+    Returns
+    -------
+    float
+        Estimated lifetime in hours.  ``inf`` is returned when no erosion occurs
+        or the repetition rate is zero.
+    """
+
+    if sputtering_rate_atoms_per_cm2 < 0:
+        raise ValueError("sputtering_rate_atoms_per_cm2 must be non-negative")
+    if electrode_area_cm2 < 0:
+        raise ValueError("electrode_area_cm2 must be non-negative")
+    if electrode_thickness_cm < 0:
+        raise ValueError("electrode_thickness_cm must be non-negative")
+    if material_density_g_cm3 < 0:
+        raise ValueError("material_density_g_cm3 must be non-negative")
+    if atomic_mass_g_mol <= 0:
+        raise ValueError("atomic_mass_g_mol must be positive")
+    if rep_rate_hz < 0:
+        raise ValueError("rep_rate_hz must be non-negative")
+
+    mass_per_shot = (
+        sputtering_rate_atoms_per_cm2
+        * electrode_area_cm2
+        * atomic_mass_g_mol
+        / AVOGADRO
+    )
+    total_mass = electrode_area_cm2 * electrode_thickness_cm * material_density_g_cm3
+
+    if mass_per_shot == 0 or rep_rate_hz == 0:
+        return float("inf")
+
+    shots = total_mass / mass_per_shot
+    return shots / rep_rate_hz / 3600.0
+
+
+def export_performance_metrics(metrics: Dict[str, float], output_dir: Path) -> None:
+    """Save KPI data to CSV, HDF5 and generate basic visualisations.
+
+    The following files are created inside ``output_dir``:
+
+    ``performance_metrics.csv``
+        Table of key/value pairs.
+    ``performance_metrics.h5``
+        HDF5 file with one dataset per KPI.
+    ``summary.md``
+        Markdown table summarising the metrics.
+    ``performance_metrics.png``
+        Bar chart of the KPI values (if :mod:`matplotlib` is available).
+    """
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    csv_path = output_dir / "performance_metrics.csv"
+    with csv_path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["metric", "value"])
+        for key, val in metrics.items():
+            writer.writerow([key, float(val)])
+
+    h5_path = output_dir / "performance_metrics.h5"
+    with h5py.File(h5_path, "w") as h5:
+        for key, val in metrics.items():
+            ds = h5.create_dataset(key, data=[float(val)])
+            # ``h5py_stub`` stores raw memoryviews which are not picklable. Replace
+            # them with plain lists when possible so that the file can be closed
+            # without error.
+            try:  # pragma: no cover - defensive for real h5py
+                ds.data = [float(val)]  # type: ignore[attr-defined]
+            except Exception:
+                pass
+
+    md_lines = ["| KPI | Value |", "| --- | --- |"]
+    for key, val in metrics.items():
+        md_lines.append(f"| {key} | {val} |")
+    (output_dir / "summary.md").write_text("\n".join(md_lines) + "\n")
+
+    if plt is None:  # pragma: no cover - optional dependency
+        return
+
+    keys = list(metrics.keys())
+    values = [metrics[k] for k in keys]
+    plt.figure()
+    plt.bar(keys, values)
+    plt.ylabel("Value")
+    plt.xticks(rotation=45, ha="right")
+    plt.tight_layout()
+    plt.savefig(output_dir / "performance_metrics.png")
+    plt.close()

--- a/tests/diagnostics/test_erosion_models.py
+++ b/tests/diagnostics/test_erosion_models.py
@@ -1,0 +1,33 @@
+import math
+
+import pytest
+
+from dpf2.diagnostics import estimate_lifetime_sputtering
+
+
+def test_estimate_lifetime_sputtering():
+    lifetime = estimate_lifetime_sputtering(
+        1e15,
+        electrode_area_cm2=10.0,
+        electrode_thickness_cm=0.1,
+        material_density_g_cm3=8.0,
+        atomic_mass_g_mol=63.546,
+        rep_rate_hz=1.0,
+    )
+    avog = 6.02214076e23
+    mass_per_shot = 1e15 * 10.0 * 63.546 / avog
+    total_mass = 10.0 * 0.1 * 8.0
+    expected = total_mass / mass_per_shot / 3600.0
+    assert lifetime == pytest.approx(expected)
+
+
+def test_zero_sputtering_rate():
+    life = estimate_lifetime_sputtering(
+        0.0,
+        electrode_area_cm2=1.0,
+        electrode_thickness_cm=1.0,
+        material_density_g_cm3=1.0,
+        atomic_mass_g_mol=1.0,
+        rep_rate_hz=1.0,
+    )
+    assert math.isinf(life)

--- a/tests/diagnostics/test_export_performance_metrics.py
+++ b/tests/diagnostics/test_export_performance_metrics.py
@@ -1,0 +1,36 @@
+import csv
+
+import pytest
+import h5py
+
+from dpf2.diagnostics import compute_performance_metrics, export_performance_metrics
+
+
+def test_export_performance_metrics(tmp_path):
+    pytest.importorskip("matplotlib")
+    metrics = compute_performance_metrics(
+        1e6,
+        rep_rate_hz=1.0,
+        energy_out_j=10.0,
+        energy_in_j=20.0,
+        electrode_mass_g=100.0,
+        erosion_per_shot_g=0.01,
+    )
+    export_performance_metrics(metrics, tmp_path)
+
+    csv_path = tmp_path / "performance_metrics.csv"
+    h5_path = tmp_path / "performance_metrics.h5"
+    md_path = tmp_path / "summary.md"
+    png_path = tmp_path / "performance_metrics.png"
+
+    assert csv_path.exists()
+    assert h5_path.exists()
+    assert md_path.exists()
+    assert png_path.exists()
+
+    with csv_path.open() as fh:
+        rows = list(csv.reader(fh))
+    assert rows[0] == ["metric", "value"]
+
+    with h5py.File(h5_path, "r") as h5:
+        assert "yield_per_shot" in h5

--- a/ui/performance_metrics/README.md
+++ b/ui/performance_metrics/README.md
@@ -1,0 +1,2 @@
+This directory stores generated performance metric summaries for the user
+interface.  Files are created by running `scripts/export_performance_metrics.py`.


### PR DESCRIPTION
## Summary
- add sputtering-based electrode lifetime estimation
- export KPIs and plots for UI use
- provide CLI to write metrics to ui/performance_metrics

## Testing
- `pytest tests/diagnostics/test_performance_metrics.py tests/diagnostics/test_erosion_models.py tests/diagnostics/test_export_performance_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9fb96e630832aa9a46f62707b4929