### PR TITLE
Add lab-mode manifest and jitter UI enhancements

### DIFF
--- a/docs/workflows/reproducibility.md
+++ b/docs/workflows/reproducibility.md
@@ -6,12 +6,19 @@ outputs. The manifest captures:
 
 - git commit hash of the code
 - full configuration used for the run
+- SHA256 hash of the configuration inputs
 - random number generator seeds for Python and NumPy
+- optional diagnostic summaries for each execution
 - basic environment information such as Python version, platform and exported
   environment variables
 
 These details allow results to be precisely reproduced even when runs are moved
 between systems.
+
+The recorded metadata follows the FAIR and FAIR4RS principles, ensuring that
+results are Findable, Accessible, Interoperable and Reusable by embedding
+machine-readable hashes, seeds and diagnostics directly within each
+``run_manifest.json``.
 
 When launching jobs through :class:`dpf2.hpc.JobManager`, provide the manifest
 path via the ``manifest`` argument. The manager will stage the manifest file

--- a/src/dpf2/web/lab_mode_api.py
+++ b/src/dpf2/web/lab_mode_api.py
@@ -1,6 +1,7 @@
 """Utilities for managing lab-mode manifests via a simple API."""
 from __future__ import annotations
 
+import hashlib
 import json
 import random
 import zipfile
@@ -10,7 +11,15 @@ from typing import Mapping, Sequence
 from ..cli.lab import _code_hash
 
 
-def generate_manifest(config: Mapping[str, object], *, seed: int | None = None) -> dict[str, object]:
+def _config_hash(config: Mapping[str, object]) -> str:
+    """Return a stable hash of ``config`` for provenance purposes."""
+    serialized = json.dumps(config, sort_keys=True)
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+def generate_manifest(
+    config: Mapping[str, object], *, seed: int | None = None, diagnostics: Mapping[str, object] | None = None
+) -> dict[str, object]:
     """Generate a single manifest describing a run.
 
     Parameters
@@ -19,26 +28,34 @@ def generate_manifest(config: Mapping[str, object], *, seed: int | None = None) 
         Configuration mapping used for the run.
     seed:
         Optional random seed. When omitted a random seed is sampled.
+    diagnostics:
+        Optional diagnostic metadata to embed in the manifest.
     """
     if seed is None:
         seed = random.randint(0, 2**32 - 1)
-    return {
+    manifest = {
         "code_hash": _code_hash(),
+        "config_hash": _config_hash(config),
         "inputs": dict(config),
         "random_seeds": {"python": int(seed)},
     }
+    if diagnostics is not None:
+        manifest["diagnostics"] = dict(diagnostics)
+    return manifest
 
 
 def generate_manifest_bundle(
     configs: Sequence[Mapping[str, object]],
     *,
     seeds: Sequence[int] | None = None,
+    diagnostics: Sequence[Mapping[str, object]] | None = None,
 ) -> list[dict[str, object]]:
     """Generate manifests for a batch of configurations."""
     bundle: list[dict[str, object]] = []
     for idx, cfg in enumerate(configs):
         seed = seeds[idx] if seeds and idx < len(seeds) else None
-        bundle.append(generate_manifest(cfg, seed=seed))
+        diag = diagnostics[idx] if diagnostics and idx < len(diagnostics) else None
+        bundle.append(generate_manifest(cfg, seed=seed, diagnostics=diag))
     return bundle
 
 
@@ -47,6 +64,7 @@ def export_manifest_bundle(
     output: str | Path,
     *,
     seeds: Sequence[int] | None = None,
+    diagnostics: Sequence[Mapping[str, object]] | None = None,
 ) -> Path:
     """Write a zip bundle containing inputs and manifests for each run.
 
@@ -63,8 +81,10 @@ def export_manifest_bundle(
         Path to the zip file that should be written.
     seeds:
         Optional sequence of RNG seeds corresponding to ``configs``.
+    diagnostics:
+        Optional sequence of diagnostic metadata matching ``configs``.
     """
-    manifests = generate_manifest_bundle(configs, seeds=seeds)
+    manifests = generate_manifest_bundle(configs, seeds=seeds, diagnostics=diagnostics)
     out_path = Path(output)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     index: list[dict[str, str]] = []

--- a/tests/web/test_lab_mode_api.py
+++ b/tests/web/test_lab_mode_api.py
@@ -11,24 +11,32 @@ from dpf2.web.lab_mode_api import (
 def test_generate_manifest_bundle():
     configs = [{"a": 1}, {"a": 2}]
     seeds = [42, 43]
-    bundle = generate_manifest_bundle(configs, seeds=seeds)
+    diags = [{"note": "ok"}, {"note": "also ok"}]
+    bundle = generate_manifest_bundle(configs, seeds=seeds, diagnostics=diags)
     assert bundle[0]["inputs"] == {"a": 1}
     assert bundle[1]["random_seeds"]["python"] == 43
     assert bundle[0]["code_hash"]
+    assert len(bundle[0]["config_hash"]) == 64
+    assert bundle[0]["diagnostics"]["note"] == "ok"
 
 
 def test_generate_manifest():
-    manifest = generate_manifest({"b": 3}, seed=99)
+    manifest = generate_manifest({"b": 3}, seed=99, diagnostics={"val": 1})
     assert manifest["inputs"]["b"] == 3
     assert manifest["random_seeds"]["python"] == 99
+    assert manifest["diagnostics"]["val"] == 1
 
 
 def test_export_manifest_bundle(tmp_path):
     configs = [{"x": 10}]
-    zip_path = export_manifest_bundle(configs, tmp_path / "bundle.zip", seeds=[123])
+    zip_path = export_manifest_bundle(
+        configs, tmp_path / "bundle.zip", seeds=[123], diagnostics=[{"d": 5}]
+    )
     assert zip_path.exists()
     with zipfile.ZipFile(zip_path, "r") as z:
         assert "inputs_0.json" in z.namelist()
         manifest = json.loads(z.read("run_manifest_0.json"))
         assert manifest["inputs"]["x"] == 10
         assert manifest["random_seeds"]["python"] == 123
+        assert manifest["diagnostics"]["d"] == 5
+        assert len(manifest["config_hash"]) == 64

--- a/web/backend/main.py
+++ b/web/backend/main.py
@@ -5,6 +5,8 @@ import logging
 from datetime import datetime
 from pathlib import Path
 import asyncio
+import random
+import tempfile
 from typing import Any, Dict, List
 
 from fastapi import (
@@ -17,12 +19,14 @@ from fastapi import (
     WebSocketDisconnect,
     status,
 )
+from fastapi.responses import FileResponse
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from pydantic import BaseModel
 
 from dpf2.dpf_config import DPFConfig
 from dpf2.optimization.param_sweep import compute_sweep_metrics
 from dpf2.diagnostics import RegimePanel
+from dpf2.web.lab_mode_api import export_manifest_bundle
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 AUDIT_LOG = BASE_DIR / "audit.log"
@@ -90,6 +94,10 @@ class SweepRequest(BaseModel):
 
 class SnapshotRequest(BaseModel):
     state: Dict[str, Any]
+
+
+class LabBundleRequest(BaseModel):
+    runs: List[Dict[str, Any]]
 
 
 async def broadcast_progress(run_id: str, progress: float) -> None:
@@ -235,6 +243,16 @@ async def upload_snapshot(file: UploadFile = File(...)):
     """Load a snapshot from a user-uploaded JSON file."""
     data = json.loads(await file.read())
     return data
+
+
+@app.post("/lab-mode/manifests")
+def create_lab_manifest_bundle(req: LabBundleRequest, user=Depends(get_current_user)):
+    """Generate a manifest bundle for a batch of lab-mode configurations."""
+    seeds = [random.randint(0, 2**32 - 1) for _ in req.runs]
+    with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as tmp:
+        export_manifest_bundle(req.runs, tmp.name, seeds=seeds)
+        logger.info("action=lab_bundle user=%s runs=%d", user["username"], len(req.runs))
+        return FileResponse(tmp.name, media_type="application/zip", filename="manifest_bundle.zip")
 
 
 @app.websocket("/ws/progress/{run_id}")

--- a/web/frontend/src/LabMode.jsx
+++ b/web/frontend/src/LabMode.jsx
@@ -3,18 +3,28 @@ import axios from 'axios';
 
 export default function LabMode({ token }) {
   const [configs, setConfigs] = useState(['{}']);
+  const [shotCounts, setShotCounts] = useState([1]);
   const [useJitter, setUseJitter] = useState(false);
   const [switchJitter, setSwitchJitter] = useState(0.0);
   const [pressureJitter, setPressureJitter] = useState(0.0);
+  const [gasPuffTiming, setGasPuffTiming] = useState(0.0);
 
-  const addRun = () => setConfigs((c) => [...c, '{}']);
+  const addRun = () => {
+    setConfigs((c) => [...c, '{}']);
+    setShotCounts((s) => [...s, 1]);
+  };
 
   const updateConfig = (idx, value) => {
     setConfigs((c) => c.map((cfg, i) => (i === idx ? value : cfg)));
   };
 
+  const updateShotCount = (idx, value) => {
+    setShotCounts((s) => s.map((count, i) => (i === idx ? value : count)));
+  };
+
   const exportBundle = async () => {
-    const runs = configs.map((text) => {
+    const runs = [];
+    configs.forEach((text, idx) => {
       const cfg = JSON.parse(text || '{}');
       if (useJitter) {
         cfg.experimental_variability = {
@@ -22,7 +32,10 @@ export default function LabMode({ token }) {
           trigger_jitter_ns: switchJitter,
         };
       }
-      return cfg;
+      cfg.gas_puff_timing_ns = gasPuffTiming;
+      for (let i = 0; i < shotCounts[idx]; i += 1) {
+        runs.push({ ...cfg });
+      }
     });
     const { data } = await axios.post(
       '/lab-mode/manifests',
@@ -70,6 +83,14 @@ export default function LabMode({ token }) {
                 onChange={(e) => setPressureJitter(parseFloat(e.target.value))}
               />
             </label>
+            <label>
+              Gas Puff Timing (ns)
+              <input
+                type="number"
+                value={gasPuffTiming}
+                onChange={(e) => setGasPuffTiming(parseFloat(e.target.value))}
+              />
+            </label>
           </div>
         )}
       </div>
@@ -82,6 +103,17 @@ export default function LabMode({ token }) {
             value={cfg}
             onChange={(e) => updateConfig(idx, e.target.value)}
           />
+          <div>
+            <label>
+              Shots
+              <input
+                type="number"
+                min={1}
+                value={shotCounts[idx]}
+                onChange={(e) => updateShotCount(idx, parseInt(e.target.value, 10))}
+              />
+            </label>
+          </div>
         </div>
       ))}
       <button type="button" onClick={addRun}>
@@ -90,6 +122,17 @@ export default function LabMode({ token }) {
       <button type="button" onClick={exportBundle} disabled={!token}>
         Export Manifest Bundle
       </button>
+      <div>
+        <h4>Variability Summary</h4>
+        <p>Total Shots: {shotCounts.reduce((a, b) => a + b, 0)}</p>
+        {useJitter && (
+          <ul>
+            <li>Switch Jitter: {switchJitter} ns</li>
+            <li>Pressure Jitter: {pressureJitter} %</li>
+            <li>Gas Puff Timing: {gasPuffTiming} ns</li>
+          </ul>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Extend lab-mode manifest generation with config hashes, RNG seeds and optional diagnostics for FAIR reproducibility
- Expose lab-mode manifest bundle endpoint and GUI controls for gas puff timing, jitter and shot sequences
- Document reproducibility metadata and FAIR/FAIR4RS compliance

## Testing
- `pytest tests/web/test_lab_mode_api.py tests/test_manifest_metadata.py tests/test_lab_mode_ensemble.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9fb97af24832a8034851fa5847aee