### PR TITLE
Add calibration path fields to diagnostics config

### DIFF
--- a/src/dpf2/diagnostics/__init__.py
+++ b/src/dpf2/diagnostics/__init__.py
@@ -285,6 +285,23 @@ class Diagnostics(ConfigSectionBase):
     enable_neutron_tof_detectors: bool = False
     sxr_detector_models: List[SXRModel] = Field(default_factory=list)
     neutron_tof_detectors: List[TOFModel] = Field(default_factory=list)
+    # -- Calibration files -------------------------------------------------
+    rogowski_calibration_path: str | None = Field(
+        default=None,
+        description="HDF5 file containing Rogowski coil impulse response",
+    )
+    bdot_calibration_path: str | None = Field(
+        default=None,
+        description="HDF5 file containing B-dot probe impulse response",
+    )
+    sxr_calibration_path: str | None = Field(
+        default=None,
+        description="HDF5 file containing soft X-ray diode response",
+    )
+    neutron_tof_calibration_path: str | None = Field(
+        default=None,
+        description="HDF5 file containing neutron TOF detector response",
+    )
     wall_probe_array_config: Optional[List[DetectorConfig]] = None
     detector_config_hash: Optional[str] = None
     max_detector_count: int = 32

--- a/src/dpf2/dpf_config.py
+++ b/src/dpf2/dpf_config.py
@@ -286,6 +286,22 @@ class Diagnostics(BaseModel):
     enable_DT_yield_modeling: bool = False
     sxr_detector_models: List[Dict[str, Any]] = Field(default_factory=list)
     neutron_tof_detectors: List[Dict[str, Any]] = Field(default_factory=list)
+    rogowski_calibration_path: str | None = Field(
+        default=None,
+        description="Path to Rogowski coil instrument response calibration file",
+    )
+    bdot_calibration_path: str | None = Field(
+        default=None,
+        description="Path to B-dot probe instrument response calibration file",
+    )
+    sxr_calibration_path: str | None = Field(
+        default=None,
+        description="Path to soft X-ray diode instrument response calibration file",
+    )
+    neutron_tof_calibration_path: str | None = Field(
+        default=None,
+        description="Path to neutron time-of-flight instrument response calibration file",
+    )
     wall_probe_array_config: Optional[Dict[str, Any]] = None
     fields_to_output: List[str] = Field(default_factory=list)
     particle_species_to_track: List[str] = Field(default_factory=list)

--- a/tests/dpf_config/test_calibration_paths.py
+++ b/tests/dpf_config/test_calibration_paths.py
@@ -1,0 +1,75 @@
+import json
+from pathlib import Path
+from datetime import datetime
+
+from dpf2.dpf_config import DPFConfig
+
+
+def _serialize(model):
+    if isinstance(model, Path):
+        return str(model)
+    if isinstance(model, datetime):
+        return model.isoformat()
+    if hasattr(model, "model_dump"):
+        try:
+            data = model.model_dump()
+        except Exception:
+            data = model.__dict__
+        if isinstance(data, dict):
+            return {k: _serialize(v) for k, v in data.items()}
+    if isinstance(model, dict):
+        return {k: _serialize(v) for k, v in model.items()}
+    if isinstance(model, list):
+        return [_serialize(v) for v in model]
+    return model
+
+
+def test_calibration_paths_roundtrip(tmp_path):
+    cfg = DPFConfig.with_defaults()
+    cfg.diagnostics.rogowski_calibration_path = "rog.h5"
+    cfg.diagnostics.bdot_calibration_path = "bdot.h5"
+    cfg.diagnostics.sxr_calibration_path = "sxr.h5"
+    cfg.diagnostics.neutron_tof_calibration_path = "tof.h5"
+
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps(_serialize(cfg)))
+
+    loaded = DPFConfig.from_file(path)
+    d = loaded.diagnostics
+    if isinstance(d, dict):
+        assert d["rogowski_calibration_path"] == "rog.h5"
+        assert d["bdot_calibration_path"] == "bdot.h5"
+        assert d["sxr_calibration_path"] == "sxr.h5"
+        assert d["neutron_tof_calibration_path"] == "tof.h5"
+    else:
+        assert d.rogowski_calibration_path == "rog.h5"
+        assert d.bdot_calibration_path == "bdot.h5"
+        assert d.sxr_calibration_path == "sxr.h5"
+        assert d.neutron_tof_calibration_path == "tof.h5"
+
+
+def test_calibration_paths_default_none(tmp_path):
+    cfg = DPFConfig.with_defaults()
+    data = _serialize(cfg)
+    diag = data["diagnostics"]
+    diag.pop("rogowski_calibration_path", None)
+    diag.pop("bdot_calibration_path", None)
+    diag.pop("sxr_calibration_path", None)
+    diag.pop("neutron_tof_calibration_path", None)
+
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps(data))
+
+    loaded = DPFConfig.from_file(path)
+    d = loaded.diagnostics
+    if isinstance(d, dict):
+        assert d.get("rogowski_calibration_path") is None
+        assert d.get("bdot_calibration_path") is None
+        assert d.get("sxr_calibration_path") is None
+        assert d.get("neutron_tof_calibration_path") is None
+    else:
+        assert d.rogowski_calibration_path is None
+        assert d.bdot_calibration_path is None
+        assert d.sxr_calibration_path is None
+        assert d.neutron_tof_calibration_path is None
+


### PR DESCRIPTION
## Summary
- extend diagnostics config with optional calibration files for Rogowski coil, B-dot probe, soft X-ray diode, and neutron TOF detectors
- include serialization fields in extended diagnostics schema
- cover calibration path loading and defaults with tests

## Testing
- `pytest tests/dpf_config/test_calibration_paths.py -q`
- `pytest tests/test_dpf_config.py -q` *(fails: Object of type SimulationControl is not JSON serializable)*

------
https://chatgpt.com/codex/tasks/task_e_68baf5bd5168832abe6b2d90a6333d6a