### PR TITLE
feat: support per-instrument calibration

### DIFF
--- a/src/dpf2/diagnostics/synthetic_signals.py
+++ b/src/dpf2/diagnostics/synthetic_signals.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Callable, Iterable, List, Sequence
 from pathlib import Path
 from bisect import bisect_right
+import json
 import math
 
 import numpy as np
@@ -79,16 +80,21 @@ def coupled_voltage_waveform(
     return _apply(data, response_fn, noise_fn)
 
 
-def _load_calibration_hdf5(
+def _load_calibration_curve(
     path: str | Path, dataset: str
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Load ``(time, response)`` arrays from an HDF5 calibration file."""
+    """Load ``(time, response)`` arrays from a calibration file."""
 
-    with h5py.File(path, "r") as fh:
-        grp = fh[dataset]
-        times = np.array(grp["time"], dtype=float)
-        resp = np.array(grp["response"], dtype=float)
-    return times, resp
+    p = Path(path)
+    if p.suffix.lower() in {".h5", ".hdf5"}:
+        with h5py.File(p, "r") as fh:
+            grp = fh[dataset]
+            times = np.array(grp["time"], dtype=float)
+            resp = np.array(grp["response"], dtype=float)
+        return times, resp
+    data = json.loads(p.read_text())
+    scale = float(data.get("scale", 1.0))
+    return np.array([0.0]), np.array([scale])
 
 
 def _apply_instrument_response(
@@ -100,8 +106,28 @@ def _apply_instrument_response(
     """Convolve ``values`` with an impulse response defined by ``resp_t``/``resp_v``."""
 
     t_grid = np.arange(len(values)) * dt
-    impulse = np.interp(t_grid, resp_t, resp_v, left=0.0, right=0.0)
-    conv = np.convolve(values, impulse, mode="same")
+    try:
+        impulse = np.interp(t_grid, resp_t, resp_v, left=0.0, right=0.0)
+    except TypeError:  # pragma: no cover - for minimal numpy stubs
+        impulse = []
+        for t in t_grid:
+            if t < resp_t[0] or t > resp_t[-1]:
+                impulse.append(0.0)
+            elif len(resp_t) == 1:
+                impulse.append(resp_v[0])
+            else:  # fallback interpolation without bounds
+                impulse.append(np.interp(t, resp_t, resp_v))
+    try:
+        conv = np.convolve(values, impulse, mode="same")
+    except AttributeError:  # pragma: no cover - for minimal numpy stubs
+        n = len(values)
+        m = len(impulse)
+        full = [0.0] * (n + m - 1)
+        for i, a in enumerate(values):
+            for j, b in enumerate(impulse):
+                full[i + j] += a * b
+        start = (m - 1) // 2
+        conv = full[start:start + n]
     return [float(v) for v in conv]
 
 
@@ -130,7 +156,7 @@ def rogowski_signal(
         deriv = [(currents[i + 1] - currents[i]) / dt for i in range(len(currents) - 1)]
         deriv.append(deriv[-1])
     if calibration_file is not None:
-        t, r = _load_calibration_hdf5(calibration_file, "rogowski")
+        t, r = _load_calibration_curve(calibration_file, "rogowski")
         deriv = _apply_instrument_response(deriv, dt, t, r)
     return _apply(deriv, response_fn, noise_fn)
 
@@ -157,7 +183,7 @@ def bdot_signal(
         deriv = [(B[i + 1] - B[i]) / dt for i in range(len(B) - 1)]
         deriv.append(deriv[-1])
     if calibration_file is not None:
-        t, r = _load_calibration_hdf5(calibration_file, "bdot")
+        t, r = _load_calibration_curve(calibration_file, "bdot")
         deriv = _apply_instrument_response(deriv, dt, t, r)
     return _apply(deriv, response_fn, noise_fn)
 
@@ -174,7 +200,7 @@ def sxr_diode_signal(
 
     data = [float(v) for v in signal]
     if calibration_file is not None:
-        t, r = _load_calibration_hdf5(calibration_file, "sxr")
+        t, r = _load_calibration_curve(calibration_file, "sxr")
         data = _apply_instrument_response(data, dt, t, r)
     return _apply(data, response_fn, noise_fn)
 
@@ -213,7 +239,7 @@ def neutron_tof_signal(
 
     if calibration_file is not None:
         dt = time_bins_s[1] - time_bins_s[0] if len(time_bins_s) > 1 else 1.0
-        t_resp, r_resp = _load_calibration_hdf5(calibration_file, "tof")
+        t_resp, r_resp = _load_calibration_curve(calibration_file, "tof")
         hist = _apply_instrument_response(hist, dt, t_resp, r_resp)
     return _apply(hist, response_fn, noise_fn)
 

--- a/src/dpf2/synthetic_diagnostics.py
+++ b/src/dpf2/synthetic_diagnostics.py
@@ -1,0 +1,11 @@
+"""Legacy synthetic diagnostics module.
+
+This module re-exports the public API from
+``dpf2.synthetic_diagnostics.core`` to maintain backwards compatibility
+with older imports that expected ``dpf2.synthetic_diagnostics`` to be a
+standalone module rather than a package.
+"""
+
+from .synthetic_diagnostics.core import *  # noqa: F401,F403
+from .synthetic_diagnostics.core import __all__  # noqa: F401
+

--- a/src/dpf2/synthetic_diagnostics/core.py
+++ b/src/dpf2/synthetic_diagnostics/core.py
@@ -379,6 +379,7 @@ def _faraday_eedf(history: Sequence[CouplingState], bins: int = 50) -> List[floa
 class SyntheticInstrument(BaseModel):
     """Per-instrument overrides for synthetic diagnostics."""
 
+    calibration_file: Optional[Path] = None
     response_file: Optional[Path] = None
     noise_model: Optional[str] = None
     geometry: Optional[str] = None
@@ -622,6 +623,14 @@ def run_diagnostic_calculations(
 
     hist = list(history)
     outputs: Dict[str, List[float]] = {}
+    overrides = cfg.instrument_overrides or {}
+
+    def _cal_path(name: str) -> Path | None:
+        inst = overrides.get(name)
+        if inst and inst.calibration_file is not None:
+            return inst.calibration_file
+        return None
+
     if cfg.synthetic_current_waveform_enabled:
         outputs["current"] = current_waveform(hist)
     if cfg.synthetic_voltage_waveform_enabled:
@@ -631,9 +640,9 @@ def run_diagnostic_calculations(
     if cfg.synthetic_coupled_voltage_waveform_enabled:
         outputs["coupled_voltage"] = coupled_voltage_waveform(hist)
     if cfg.synthetic_rogowski_signal_enabled:
-        outputs["rogowski"] = rogowski_signal(hist, dt)
+        outputs["rogowski"] = rogowski_signal(hist, dt, calibration_file=_cal_path("rogowski"))
     if cfg.synthetic_bdot_signal_enabled:
-        outputs["bdot"] = bdot_signal(hist, bdot_radius, dt)
+        outputs["bdot"] = bdot_signal(hist, bdot_radius, dt, calibration_file=_cal_path("bdot"))
 
     if cfg.synthetic_cr39_image_enabled:
         outputs["cr39_image"] = _cr39_image(hist)

--- a/tests/synthetic_diagnostics/test_calibration.py
+++ b/tests/synthetic_diagnostics/test_calibration.py
@@ -1,0 +1,61 @@
+import json
+import pytest
+
+from dpf2.synthetic_diagnostics import (
+    SyntheticDiagnostics,
+    SyntheticInstrument,
+    run_diagnostic_calculations,
+)
+from dpf2.core.bases import CouplingState
+
+
+def _history():
+    return [
+        CouplingState(current=1.0, voltage=0.0),
+        CouplingState(current=2.0, voltage=0.0),
+    ]
+
+
+def test_rogowski_calibration(tmp_path):
+    hist = _history()
+    cal = tmp_path / "rogowski.json"
+    cal.write_text(json.dumps({"scale": 2.0}))
+    cfg = SyntheticDiagnostics.with_defaults().model_copy(
+        update={
+            "apply_time_response": True,
+            "instrument_response_directory": tmp_path,
+            "synthetic_rogowski_signal_enabled": True,
+            "instrument_overrides": {"rogowski": SyntheticInstrument(calibration_file=cal)},
+        }
+    )
+    out = run_diagnostic_calculations(hist, cfg, dt=1.0)
+    cfg_base = SyntheticDiagnostics.with_defaults().model_copy(
+        update={"synthetic_rogowski_signal_enabled": True}
+    )
+    out_base = run_diagnostic_calculations(hist, cfg_base, dt=1.0)
+    assert out_base["rogowski"] != out["rogowski"]
+    expected = [v * 2.0 for v in out_base["rogowski"]]
+    assert all(abs(a - b) < 1e-8 for a, b in zip(out["rogowski"], expected))
+
+
+def test_bdot_calibration(tmp_path):
+    hist = _history()
+    cal = tmp_path / "bdot.json"
+    cal.write_text(json.dumps({"scale": 0.5}))
+    cfg = SyntheticDiagnostics.with_defaults().model_copy(
+        update={
+            "apply_time_response": True,
+            "instrument_response_directory": tmp_path,
+            "synthetic_bdot_signal_enabled": True,
+            "instrument_overrides": {"bdot": SyntheticInstrument(calibration_file=cal)},
+        }
+    )
+    out = run_diagnostic_calculations(hist, cfg, dt=1.0)
+    cfg_base = SyntheticDiagnostics.with_defaults().model_copy(
+        update={"synthetic_bdot_signal_enabled": True}
+    )
+    out_base = run_diagnostic_calculations(hist, cfg_base, dt=1.0)
+    assert out_base["bdot"] != out["bdot"]
+    expected = [v * 0.5 for v in out_base["bdot"]]
+    assert all(abs(a - b) < 1e-12 for a, b in zip(out["bdot"], expected))
+


### PR DESCRIPTION
## Summary
- allow instruments to specify calibration files
- apply calibration response curves when generating synthetic signals
- exercise calibration behavior with new synthetic diagnostic tests

## Testing
- `pytest tests/synthetic_diagnostics/test_calibration.py -q`
- `pytest tests/test_synthetic_diagnostics.py tests/test_synthetic_diagnostics_imports.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68baf5be8090832ab58e8a2d436845de