### PR TITLE
feat: add calibration options for synthetic diagnostics

### DIFF
--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -1133,6 +1133,16 @@ def make_surrogate(data: str, outdir: str) -> None:
 @click.option("--voltage", is_flag=True, help="Output voltage waveform")
 @click.option("--rogowski", is_flag=True, help="Output Rogowski signal")
 @click.option("--bdot", is_flag=True, help="Output B-dot signal")
+@click.option(
+    "--rogowski-cal",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Optional Rogowski calibration file",
+)
+@click.option(
+    "--bdot-cal",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Optional B-dot calibration file",
+)
 @click.option("--dt", type=float, default=1e-9, help="Time step for derivatives [s]")
 @click.option(
     "--radius", type=float, default=0.01, help="Probe radius for B-dot signal [m]"
@@ -1144,6 +1154,8 @@ def diagnostics(
     voltage: bool,
     rogowski: bool,
     bdot: bool,
+    rogowski_cal: str | None,
+    bdot_cal: str | None,
     dt: float,
     radius: float,
 ) -> None:
@@ -1162,18 +1174,26 @@ def diagnostics(
             if cfg.synthetic_voltage_waveform_enabled:
                 outputs["voltage"] = voltage_waveform(states)
             if cfg.synthetic_rogowski_signal_enabled:
-                outputs["rogowski"] = rogowski_signal(states, dt)
+                outputs["rogowski"] = rogowski_signal(
+                    states, dt, calibration_file=rogowski_cal
+                )
             if cfg.synthetic_bdot_signal_enabled:
-                outputs["bdot"] = bdot_signal(states, radius, dt)
+                outputs["bdot"] = bdot_signal(
+                    states, radius, dt, calibration_file=bdot_cal
+                )
 
         if current:
             outputs["current"] = current_waveform(states)
         if voltage:
             outputs["voltage"] = voltage_waveform(states)
         if rogowski:
-            outputs["rogowski"] = rogowski_signal(states, dt)
+            outputs["rogowski"] = rogowski_signal(
+                states, dt, calibration_file=rogowski_cal
+            )
         if bdot:
-            outputs["bdot"] = bdot_signal(states, radius, dt)
+            outputs["bdot"] = bdot_signal(
+                states, radius, dt, calibration_file=bdot_cal
+            )
 
         click.echo(json.dumps(outputs))
     except Exception as e:

--- a/src/dpf2/synthetic_diagnostics.py
+++ b/src/dpf2/synthetic_diagnostics.py
@@ -1,0 +1,3 @@
+from .synthetic_diagnostics.core import SyntheticDiagnostics
+
+__all__ = ["SyntheticDiagnostics"]

--- a/tests/test_cli_diagnostics.py
+++ b/tests/test_cli_diagnostics.py
@@ -1,17 +1,32 @@
 import json
+try:  # pragma: no cover - prefer real h5py
+    import h5py  # type: ignore
+except Exception:  # pragma: no cover
+    import h5py_stub as h5py  # type: ignore
 from click.testing import CliRunner
 
 from dpf2.cli.main import diagnostics
 
 
-def test_cli_outputs_current_and_voltage(tmp_path):
+def _write_calibration(path, group):
+    with h5py.File(path, "w") as fh:
+        grp = fh.require_group(group)
+        grp.create_dataset("time", data=[0.0, 1.0])
+        grp.create_dataset("response", data=[1.0, 0.0])
+
+
+def _write_history(path):
     history = [
         {"Lp": 0.0, "emf": 0.0, "current": 0.0, "voltage": 1.0},
         {"Lp": 0.0, "emf": 0.0, "current": 1.0, "voltage": 0.5},
         {"Lp": 0.0, "emf": 0.0, "current": 2.0, "voltage": 0.0},
     ]
+    path.write_text(json.dumps(history))
+
+
+def test_cli_outputs_current_and_voltage(tmp_path):
     hist_path = tmp_path / "history.json"
-    hist_path.write_text(json.dumps(history))
+    _write_history(hist_path)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -22,4 +37,50 @@ def test_cli_outputs_current_and_voltage(tmp_path):
     data = json.loads(result.output)
     assert data["current"] == [0.0, 1.0, 2.0]
     assert data["voltage"] == [1.0, 0.5, 0.0]
+
+
+def test_cli_accepts_calibration_files(tmp_path):
+    hist_path = tmp_path / "history.json"
+    _write_history(hist_path)
+    rog_cal = tmp_path / "rog.h5"
+    bdot_cal = tmp_path / "bdot.h5"
+    _write_calibration(rog_cal, "rogowski")
+    _write_calibration(bdot_cal, "bdot")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        diagnostics,
+        [
+            "--history",
+            str(hist_path),
+            "--rogowski-cal",
+            str(rog_cal),
+            "--bdot-cal",
+            str(bdot_cal),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data == {}
+
+
+def test_cli_calibration_file_missing(tmp_path):
+    hist_path = tmp_path / "history.json"
+    _write_history(hist_path)
+
+    runner = CliRunner()
+    missing = tmp_path / "missing.h5"
+    result = runner.invoke(
+        diagnostics,
+        ["--history", str(hist_path), "--rogowski", "--rogowski-cal", str(missing)],
+    )
+    assert result.exit_code != 0
+    assert "does not exist" in result.output
+
+
+def test_cli_help_shows_calibration_options():
+    runner = CliRunner()
+    result = runner.invoke(diagnostics, ["--help"])
+    assert "--rogowski-cal" in result.output
+    assert "--bdot-cal" in result.output
 

--- a/web/frontend/src/help.json
+++ b/web/frontend/src/help.json
@@ -6,5 +6,9 @@
     "geometryFile": "Optional CAD file for custom geometry",
     "import": "Load a configuration set from JSON"
 
+  },
+  "diagnostics": {
+    "rogowskiCal": "Optional HDF5 calibration file for Rogowski coil; ideal response used if omitted",
+    "bdotCal": "Optional HDF5 calibration file for B-dot probe; ideal response used if omitted"
   }
 }


### PR DESCRIPTION
## Summary
- add `--rogowski-cal` and `--bdot-cal` options to `dpf2 diagnostics` for instrument calibration files
- expose calibration help text in `web/frontend/src/help.json`
- test CLI parsing and validation for new calibration options

## Testing
- `pytest tests/test_cli_diagnostics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baf5befe60832a859e4a1f3fab6e5b