### PR TITLE
Add angular neutron distribution utilities

### DIFF
--- a/src/dpf2/diagnostics/neutron/__init__.py
+++ b/src/dpf2/diagnostics/neutron/__init__.py
@@ -7,7 +7,7 @@ from typing import Sequence, List, Dict, Any, Mapping
 import json
 
 # Re-export core synthesis utilities from :mod:`neutron_spectra`
-from .neutron_spectra import (
+from ..neutron_spectra import (
     Detector,
     DetectorLayout,
     synthetic_tof_spectrum,
@@ -18,6 +18,12 @@ from .neutron_spectra import (
     load_detector_layout,
     time_resolved_spectra,
     directional_time_resolved_spectra,
+)
+
+from .angular_distribution import (
+    per_angle_yield,
+    forward_radial_backward_totals,
+    directional_yield,
 )
 
 
@@ -137,6 +143,9 @@ __all__ = [
     "load_detector_layout",
     "time_resolved_spectra",
     "directional_time_resolved_spectra",
+    "per_angle_yield",
+    "forward_radial_backward_totals",
+    "directional_yield",
     "load_response",
     "apply_response",
     "anisotropy_report",

--- a/src/dpf2/diagnostics/neutron/angular_distribution.py
+++ b/src/dpf2/diagnostics/neutron/angular_distribution.py
@@ -1,0 +1,72 @@
+"""Angular distribution utilities for neutron diagnostics."""
+
+from __future__ import annotations
+
+from typing import Mapping, Sequence, Dict
+
+
+def per_angle_yield(
+    spectra: Mapping[float, Sequence[float]],
+    responses: Mapping[float, Sequence[float]] | None = None,
+) -> Dict[float, float]:
+    """Integrate spectra at each angle to obtain per-angle yields.
+
+    Parameters
+    ----------
+    spectra:
+        Mapping of detector angle in degrees to a sequence of counts.
+    responses:
+        Optional mapping of detector angle to an instrument response curve.
+        When provided, counts are weighted by the response curve before
+        integration.
+
+    Returns
+    -------
+    dict
+        Mapping of angle to the integrated (optionally weighted) yield.
+    """
+
+    yields: Dict[float, float] = {}
+    for angle, counts in spectra.items():
+        vals = [float(c) for c in counts]
+        if responses and angle in responses:
+            resp = [float(r) for r in responses[angle]]
+            if len(resp) != len(vals):
+                raise ValueError("response curve length must match counts")
+            yld = sum(v * r for v, r in zip(vals, resp))
+        else:
+            yld = sum(vals)
+        yields[float(angle)] = float(yld)
+    return yields
+
+
+def forward_radial_backward_totals(yields: Mapping[float, float]) -> Dict[str, float]:
+    """Aggregate per-angle yields into forward, radial, and backward totals."""
+
+    totals = {"forward": 0.0, "radial": 0.0, "backward": 0.0}
+    for angle, value in yields.items():
+        ang = float(angle) % 360.0
+        val = float(value)
+        if ang <= 45.0 or ang >= 315.0:
+            totals["forward"] += val
+        elif 135.0 <= ang <= 225.0:
+            totals["backward"] += val
+        else:
+            totals["radial"] += val
+    return totals
+
+
+def directional_yield(
+    spectra: Mapping[float, Sequence[float]],
+    responses: Mapping[float, Sequence[float]] | None = None,
+) -> Dict[str, float]:
+    """Convenience wrapper returning directional totals directly."""
+
+    return forward_radial_backward_totals(per_angle_yield(spectra, responses))
+
+
+__all__ = [
+    "per_angle_yield",
+    "forward_radial_backward_totals",
+    "directional_yield",
+]

--- a/tests/diagnostics/test_neutron_angular_distribution.py
+++ b/tests/diagnostics/test_neutron_angular_distribution.py
@@ -1,0 +1,28 @@
+from dpf2.diagnostics.neutron.angular_distribution import (
+    per_angle_yield,
+    forward_radial_backward_totals,
+    directional_yield,
+)
+
+
+def test_per_angle_yield_and_totals():
+    spectra = {0.0: [1.0, 2.0], 90.0: [3.0, 4.0], 180.0: [5.0, 6.0]}
+    yields = per_angle_yield(spectra)
+    assert yields[0.0] == 3.0
+    assert yields[90.0] == 7.0
+    assert yields[180.0] == 11.0
+    totals = forward_radial_backward_totals(yields)
+    assert totals["forward"] == 3.0
+    assert totals["radial"] == 7.0
+    assert totals["backward"] == 11.0
+
+
+def test_instrument_response_weighting():
+    spectra = {0.0: [1.0, 2.0]}
+    responses = {0.0: [0.5, 1.5]}
+    yields = per_angle_yield(spectra, responses)
+    assert yields[0.0] == 1.0 * 0.5 + 2.0 * 1.5
+    totals = directional_yield(spectra, responses)
+    assert totals["forward"] == yields[0.0]
+    assert totals["radial"] == 0.0
+    assert totals["backward"] == 0.0


### PR DESCRIPTION
## Summary
- Add angular distribution utilities for neutron diagnostics with optional instrument response weighting
- Provide aggregation helpers to compute forward, radial, and backward yields
- Expose new utilities via the neutron diagnostics package and add unit tests

## Testing
- `pytest tests/diagnostics/test_neutron_helpers.py tests/diagnostics/test_neutron_angular_distribution.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bafbb5ad00832abc2dec9cabe94d95