### PR TITLE
Add neutron benchmark utilities and tests

### DIFF
--- a/diagnostics/neutron/__init__.py
+++ b/diagnostics/neutron/__init__.py
@@ -1,0 +1,17 @@
+"""Neutron diagnostic benchmark utilities."""
+
+from .benchmarks import (
+    load_reference,
+    load_pf1000_reference,
+    load_mjolnir_reference,
+    within_pass_band,
+    evaluate_pass_fail,
+)
+
+__all__ = [
+    "load_reference",
+    "load_pf1000_reference",
+    "load_mjolnir_reference",
+    "within_pass_band",
+    "evaluate_pass_fail",
+]

--- a/diagnostics/neutron/benchmarks.py
+++ b/diagnostics/neutron/benchmarks.py
@@ -1,0 +1,74 @@
+"""Utilities for neutron benchmark reference data and evaluation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+_REFERENCE_DIRS = {
+    "pf-1000": "PF-1000",
+    "pf1000": "PF-1000",
+    "mjolnir": "MJOLNIR",
+}
+
+
+def _data_path(name: str) -> Path:
+    """Return the path to the reference data file for ``name``."""
+    root = Path(__file__).resolve().parents[2]
+    directory = _REFERENCE_DIRS.get(name.lower())
+    if directory is None:
+        raise ValueError(f"Unknown benchmark '{name}'")
+    return root / "benchmarks" / directory / "reference.csv"
+
+
+def load_reference(name: str) -> pd.DataFrame:
+    """Load reference current trace for a benchmark device."""
+    path = _data_path(name)
+    return pd.read_csv(path)
+
+
+def load_pf1000_reference() -> pd.DataFrame:
+    """Load PF-1000 reference data."""
+    return load_reference("pf-1000")
+
+
+def load_mjolnir_reference() -> pd.DataFrame:
+    """Load MJOLNIR reference data."""
+    return load_reference("mjolnir")
+
+
+def within_pass_band(
+    data: Iterable[float],
+    reference: Iterable[float],
+    band: float | Iterable[float],
+) -> np.ndarray:
+    """Return boolean array indicating whether points lie within band.
+
+    Parameters
+    ----------
+    data, reference:
+        Measured and reference values.
+    band:
+        Relative pass band expressed as a fraction. If a scalar is provided
+        the same band is applied to all points. When a reference value is
+        zero the band is interpreted as an absolute tolerance.
+    """
+    data_arr = np.asarray(data, dtype=float)
+    ref_arr = np.asarray(reference, dtype=float)
+    band_arr = np.asarray(band, dtype=float)
+    if band_arr.size == 1:
+        band_arr = np.full_like(ref_arr, band_arr)
+    tol = band_arr * np.where(ref_arr != 0, np.abs(ref_arr), 1.0)
+    return np.abs(data_arr - ref_arr) <= tol
+
+
+def evaluate_pass_fail(
+    data: Iterable[float],
+    reference: Iterable[float],
+    band: float | Iterable[float],
+) -> bool:
+    """Return ``True`` if all points fall within the pass band."""
+    return bool(np.all(within_pass_band(data, reference, band)))

--- a/examples/diagnostics/run_neutron_benchmarks.py
+++ b/examples/diagnostics/run_neutron_benchmarks.py
@@ -1,0 +1,28 @@
+"""Example workflows for neutron benchmark comparisons."""
+
+from diagnostics.neutron.benchmarks import (
+    load_pf1000_reference,
+    load_mjolnir_reference,
+    evaluate_pass_fail,
+)
+
+
+def run_pf1000_benchmark(pass_band: float = 0.1) -> bool:
+    """Return ``True`` if sample data matches PF-1000 reference."""
+    reference = load_pf1000_reference()
+    # Offset current trace within pass band
+    simulated = reference["current"] + 0.05
+    return evaluate_pass_fail(simulated, reference["current"], pass_band)
+
+
+def run_mjolnir_benchmark(pass_band: float = 0.1) -> bool:
+    """Return ``True`` if sample data matches MJOLNIR reference."""
+    reference = load_mjolnir_reference()
+    # Offset current trace beyond pass band to demonstrate failure
+    simulated = reference["current"] + 0.5
+    return evaluate_pass_fail(simulated, reference["current"], pass_band)
+
+
+if __name__ == "__main__":
+    print("PF-1000 benchmark passed:", run_pf1000_benchmark())
+    print("MJOLNIR benchmark passed:", run_mjolnir_benchmark())

--- a/tests/diagnostics/test_neutron_benchmarks.py
+++ b/tests/diagnostics/test_neutron_benchmarks.py
@@ -1,0 +1,29 @@
+import importlib
+
+from diagnostics.neutron.benchmarks import (
+    load_pf1000_reference,
+    load_mjolnir_reference,
+    within_pass_band,
+    evaluate_pass_fail,
+)
+
+
+def test_reference_loading():
+    pf = load_pf1000_reference()
+    mj = load_mjolnir_reference()
+    assert list(pf.columns) == ["time", "current"]
+    assert list(mj.columns) == ["time", "current"]
+
+
+def test_pass_band_evaluation():
+    reference = [0.0, 10.0]
+    good = [0.0, 10.5]
+    bad = [0.0, 12.0]
+    assert within_pass_band(good, reference, 0.1).all()
+    assert not evaluate_pass_fail(bad, reference, 0.1)
+
+
+def test_example_workflow_runs():
+    module = importlib.import_module("examples.diagnostics.run_neutron_benchmarks")
+    assert module.run_pf1000_benchmark()
+    assert not module.run_mjolnir_benchmark()


### PR DESCRIPTION
## Summary
- add benchmark helpers for loading PF-1000 and MJOLNIR reference data
- support pass-band evaluation for neutron benchmark comparisons
- include example scripts and unit tests demonstrating benchmark workflows

## Testing
- `pytest tests/diagnostics/test_neutron_benchmarks.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bafbb7e750832a92c8e9a0cbf9aa5e