### PR TITLE
Add LHDI resistivity utility

### DIFF
--- a/src/dpf2/physics/__init__.py
+++ b/src/dpf2/physics/__init__.py
@@ -7,6 +7,7 @@ from .radiation import RadiationTransport
 from .pic_driver import PicDriver, PhysicalPICDriver, WarpXPICDriver
 from .lower_hybrid_drift import LowerHybridDrift
 from .m0_instability import MZeroInstability
+from .lhdi_resistivity import compute_effective_eta
 
 from .material_interactions import (
     Species,
@@ -53,6 +54,7 @@ __all__ = [
     "LowerHybridDrift",
     "MZeroInstability",
     "GVFront",
+    "compute_effective_eta",
 
     "Species",
     "sigmund_yield",

--- a/src/dpf2/physics/lhdi_resistivity.py
+++ b/src/dpf2/physics/lhdi_resistivity.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Lower-hybrid drift wave derived effective resistivity utilities.
+
+This module exposes :func:`compute_effective_eta` which estimates an
+anomalous resistivity and corresponding axial electric-field surge from
+simple lower-hybrid drift wave diagnostics.  The implementation is
+minimal and primarily intended to provide a lightweight stand-in for
+more sophisticated models.
+"""
+
+from typing import Any, Tuple
+import numpy as np
+
+
+def _to_array(val: Any) -> np.ndarray:
+    """Return ``val`` as a floating point array.
+
+    Tolerates the lightweight ``numpy`` substitute used in the tests, which
+    lacks support for the ``dtype`` argument.
+    """
+
+    try:  # pragma: no cover - real ``numpy`` path
+        return np.asarray(val, dtype=float)
+    except TypeError:  # pragma: no cover - ``numpy_stub`` path
+        return np.asarray(val)
+
+
+def compute_effective_eta(wave_power: Any, phase_velocity: Any) -> Tuple[np.ndarray, np.ndarray]:
+    """Return an effective resistivity and axial electric-field surge.
+
+    Parameters
+    ----------
+    wave_power:
+        Turbulent wave power driving anomalous transport [W m^-3].
+    phase_velocity:
+        Estimated wave phase velocity [m s^-1].
+
+    Returns
+    -------
+    eta:
+        Effective anomalous resistivity [Ohm m].
+    e_field:
+        Axial electric-field surge associated with the wave [V m^-1].
+
+    Notes
+    -----
+    The resistivity is approximated by ``wave_power / phase_velocity**2`` and
+    the axial electric field is ``eta * phase_velocity``.  Inputs are converted
+    to :class:`numpy.ndarray` and broadcast following NumPy semantics.  A small
+    numerical floor prevents division by zero when ``phase_velocity`` contains
+    zeros.
+    """
+
+    power = _to_array(wave_power)
+    velocity = _to_array(phase_velocity)
+
+    eta = power / (velocity ** 2 + 1.0e-30)
+    e_field = eta * velocity
+    return eta, e_field
+
+
+__all__ = ["compute_effective_eta"]

--- a/tests/physics/test_lhdi_resistivity.py
+++ b/tests/physics/test_lhdi_resistivity.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pytest
+
+from dpf2.physics import compute_effective_eta
+
+
+def test_compute_effective_eta_basic():
+    eta, e = compute_effective_eta(4.0, 2.0)
+    assert float(eta) == pytest.approx(1.0)
+    assert float(e) == pytest.approx(2.0)
+
+
+def test_compute_effective_eta_array_broadcast():
+    power = np.array([2.0, 8.0])
+    phase = np.array([1.0, 2.0])
+    eta, e = compute_effective_eta(power, phase)
+    assert np.allclose(eta, [2.0, 2.0])
+    assert np.allclose(e, [2.0, 4.0])


### PR DESCRIPTION
## Summary
- add `compute_effective_eta` to estimate anomalous resistivity and axial electric field from lower-hybrid drift wave metrics
- expose utility through `dpf2.physics`
- cover function with unit tests

## Testing
- `pytest tests/physics/test_lhdi_resistivity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bafba4ea18832a863ef4472bc86838