### PR TITLE
Add neutron yield helpers with detector response and ToF hooks

### DIFF
--- a/diagnostics/neutron/__init__.py
+++ b/diagnostics/neutron/__init__.py
@@ -1,0 +1,9 @@
+"""Neutron diagnostic yield utilities."""
+
+from .thermonuclear import compute_yield as thermonuclear_yield
+from .beam_target import compute_yield as beam_target_yield
+
+__all__ = [
+    "thermonuclear_yield",
+    "beam_target_yield",
+]

--- a/diagnostics/neutron/beam_target.py
+++ b/diagnostics/neutron/beam_target.py
@@ -1,0 +1,54 @@
+"""Beam-target neutron yield calculations."""
+
+from __future__ import annotations
+
+from typing import Callable, Sequence, List, Tuple
+
+from dpf2.diagnostics.neutron_yield import compute_beam_target_yield as _compute_bt
+
+
+def compute_yield(
+    ion_edf: any,
+    cross_section: Callable[[float], float],
+    angles: Sequence[float],
+    distance: float,
+    time_bins: Sequence[float],
+    response_fn: Callable[[float], float] | None = None,
+    tof_hook: Callable[[Sequence[float], float], Sequence[float]] | None = None,
+) -> Tuple[List[float], List[List[float]]]:
+    """Return per-angle beam–target yield and time-of-flight histograms.
+
+    Parameters
+    ----------
+    ion_edf:
+        Provider implementing ``energy_distribution(angle_deg)`` which returns
+        ``(energies, differential_flux)`` sequences.
+    cross_section:
+        Callable yielding reaction cross section for a given energy value.
+    angles:
+        Detector angles in degrees.
+    distance:
+        Source to detector distance in meters used for time-of-flight
+        calculation.
+    time_bins:
+        Monotonic sequence of time bin edges in seconds for the histogram.
+    response_fn:
+        Optional callable applied to the integrated yield and histogram.
+    tof_hook:
+        Optional callable invoked for each histogram after response processing.
+        The hook receives ``(hist, angle_deg)`` and must return an iterable of
+        bin contents.  This provides a convenient extension point for later
+        instrumentation.
+    """
+
+    yields, tofs = _compute_bt(
+        ion_edf,
+        cross_section,
+        angles,
+        distance,
+        time_bins,
+        response_fn=response_fn,
+    )
+    if tof_hook is not None:
+        tofs = [list(tof_hook(hist, ang)) for hist, ang in zip(tofs, angles)]
+    return yields, [ [float(v) for v in hist] for hist in tofs ]

--- a/diagnostics/neutron/thermonuclear.py
+++ b/diagnostics/neutron/thermonuclear.py
@@ -1,0 +1,56 @@
+"""Thermonuclear neutron yield calculations."""
+
+from __future__ import annotations
+
+from typing import Callable, Sequence, List, Tuple
+
+from dpf2.diagnostics.neutron_yield import compute_thermonuclear_yield
+
+
+def compute_yield(
+    reactivity: Sequence[float],
+    ion_density: Sequence[float],
+    dt: float,
+    angles: Sequence[float] | None = None,
+    response_fn: Callable[[float], float] | None = None,
+    tof_hook: Callable[[float, Sequence[float]], Sequence[float]] | None = None,
+    time_bins: Sequence[float] | None = None,
+) -> Tuple[List[float], List[List[float]]]:
+    """Return per-angle thermonuclear yield and optional TOF histograms.
+
+    Parameters
+    ----------
+    reactivity, ion_density, dt:
+        Inputs forwarded to :func:`dpf2.diagnostics.neutron_yield.compute_thermonuclear_yield`.
+    angles:
+        Sequence of detector angles in degrees.  The thermonuclear yield is
+        distributed isotropically across the provided angles.
+    response_fn:
+        Optional callable applied to the per-angle yield values.
+    tof_hook:
+        Optional callable used to generate a time-of-flight histogram for each
+        angle.  The hook is invoked with the response-corrected per-angle yield
+        and the ``time_bins`` sequence and must return an iterable of bin
+        contents.
+    time_bins:
+        Monotonic sequence of time bin edges in seconds.  Required when
+        ``tof_hook`` is provided.  If supplied without ``tof_hook`` empty
+        histograms are returned, providing a convenient hook for later
+        instrumentation.
+    """
+
+    total = compute_thermonuclear_yield(reactivity, ion_density, dt)
+    n = len(angles) if angles else 0
+    per_angle = [total / n for _ in range(n)] if n else []
+    if response_fn:
+        per_angle = [response_fn(v) for v in per_angle]
+    tofs: List[List[float]] = []
+    if time_bins is not None:
+        for val in per_angle:
+            hist = (
+                list(tof_hook(val, time_bins))
+                if tof_hook is not None
+                else [0.0 for _ in range(len(time_bins) - 1)]
+            )
+            tofs.append([float(v) for v in hist])
+    return per_angle, tofs

--- a/tests/diagnostics/neutron/test_beam_target.py
+++ b/tests/diagnostics/neutron/test_beam_target.py
@@ -1,0 +1,40 @@
+from diagnostics.neutron import beam_target
+
+
+class DummyEDF:
+    def energy_distribution(self, angle_deg: float):
+        return [0.0, 1.0], [0.0, 1.0]
+
+
+def test_yield_and_response():
+    edf = DummyEDF()
+    angles = [0.0]
+    distance = 1.0
+    time_bins = [0.0, 1.0, 2.0]
+
+    y, hist = beam_target.compute_yield(edf, lambda e: 1.0, angles, distance, time_bins)
+    assert len(y) == 1 and abs(y[0] - 0.5) < 1e-12
+    assert hist == [[0.5, 0.0]]
+
+    resp = lambda x: x * 2.0
+    y2, hist2 = beam_target.compute_yield(
+        edf, lambda e: 1.0, angles, distance, time_bins, response_fn=resp
+    )
+    assert y2 == [1.0]
+    assert hist2 == [[1.0, 0.0]]
+
+
+def test_tof_hook():
+    edf = DummyEDF()
+    angles = [0.0]
+    distance = 1.0
+    time_bins = [0.0, 1.0, 2.0]
+
+    def hook(hist, ang):
+        return [v * 3.0 for v in hist]
+
+    _, hist = beam_target.compute_yield(
+        edf, lambda e: 1.0, angles, distance, time_bins, tof_hook=hook
+    )
+    assert hist == [[1.5, 0.0]]
+

--- a/tests/diagnostics/neutron/test_thermonuclear.py
+++ b/tests/diagnostics/neutron/test_thermonuclear.py
@@ -1,0 +1,38 @@
+from diagnostics.neutron import thermonuclear
+
+
+def test_isotropic_yield_and_response():
+    reactivity = [1.0, 1.0]
+    ion_density = [2.0, 2.0]
+    dt = 0.5
+    angles = [0.0, 90.0]
+    yields, tofs = thermonuclear.compute_yield(reactivity, ion_density, dt, angles)
+    assert yields == [2.0, 2.0]
+    assert tofs == []
+
+    resp = lambda x: x * 2.0
+    yields2, _ = thermonuclear.compute_yield(
+        reactivity, ion_density, dt, angles, response_fn=resp
+    )
+    assert yields2 == [4.0, 4.0]
+
+
+def test_tof_hook_generation():
+    reactivity = [1.0, 1.0]
+    ion_density = [2.0, 2.0]
+    dt = 0.5
+    angles = [0.0]
+
+    def hook(val, bins):
+        return [val for _ in range(len(bins) - 1)]
+
+    yields, tofs = thermonuclear.compute_yield(
+        reactivity,
+        ion_density,
+        dt,
+        angles,
+        time_bins=[0.0, 1.0],
+        tof_hook=hook,
+    )
+    assert yields == [4.0]
+    assert tofs == [[4.0]]


### PR DESCRIPTION
## Summary
- add lightweight thermonuclear yield helper with optional response and time-of-flight histogram hooks
- add beam–target yield wrapper supporting per-angle histograms and response functions
- test neutron yield utilities, detector response processing, and ToF hook behavior

## Testing
- `pytest tests/diagnostics/neutron -q`


------
https://chatgpt.com/codex/tasks/task_e_68bafbb3a7f4832a9863b57c3b3a274c