### PR TITLE
Add Spitzer resistivity floor and abort on insufficient anomalies

### DIFF
--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -498,6 +498,22 @@ class HallMHDSolver(PlasmaSolverBase):
             self.last_lh_power = 0.0
             self.last_lh_phase_velocity = 0.0
 
+        if self.m0_instability is not None:
+            model = self.m0_instability
+            if callable(model):
+                res = model(J)
+            elif hasattr(model, "anomalous_resistivity"):
+                res = model.anomalous_resistivity(J)
+            else:  # pragma: no cover - unexpected type
+                res = model(J)  # type: ignore[misc]
+            e_eta, e_E = _process(res)
+            _accumulate(e_eta, e_E, axial=True)
+            s_eta += e_eta
+            if e_E.ndim == E.ndim - 1:
+                s_E[..., 2] += e_E
+            else:
+                s_E += e_E
+
 
         if self.instability_thresholds:
             self._check_instability_onset(J)
@@ -808,7 +824,24 @@ class HallMHDSolver(PlasmaSolverBase):
             else np.full(rho.shape, float(eta_field))
         )
         eta_anom = self.compute_anomalous_resistivity(J)
-        eta_total = eta_local + eta_anom
+        try:  # pragma: no cover - allow stub numpy without vector ops
+            eta_spitzer_scalar = float(
+                spitzer_resistivity(float(np.max(ne)), float(np.max(T)), 1.0)
+            )
+        except Exception:  # fallback constants
+            eta_spitzer_scalar = float(spitzer_resistivity(1.0, 1.0, 1.0))
+        eta_spitzer = np.full_like(eta_local, eta_spitzer_scalar)
+        eta_eff = eta_local + eta_anom
+        eta_total = np.maximum(eta_eff, eta_spitzer)
+        if (
+            (self.anomalous_resistivity is not None
+             or self.lower_hybrid_drift is not None
+             or self.m0_instability is not None)
+            and np.all(eta_eff <= eta_spitzer)
+        ):
+            msg = "No anomalous resistivity above Spitzer floor"
+            logger.error(msg)
+            raise RuntimeError(msg)
         try:
             self.last_eta_total_mean = float(np.mean(eta_total))
         except Exception:

--- a/src/dpf2/simulation/pic_solver.py
+++ b/src/dpf2/simulation/pic_solver.py
@@ -26,6 +26,7 @@ from ..diagnostics import synthetic_signals, IonBeamEDF, compute_beam_target_yie
 from ..diagnostics.quality_dashboard import QualityDashboard
 from ..fusion import bosch_hale_dd
 from ..physics import EnergyTracker
+from dpf2.hall_mhd_solver import spitzer_resistivity
 from .config_schema import PICConfig
 from .models import PhysicsModule
 from .utils import FieldManager, SimulationState
@@ -67,12 +68,17 @@ class AnomalousResistivity:
     def __init__(self, eta: float = 0.0, j_crit: float = 1.0):
         self.eta = eta
         self.j_crit = j_crit
+        self.last_eta: "np.ndarray | None" = None
 
     def apply(self, E: "np.ndarray", J: "np.ndarray") -> "np.ndarray":
         if self.eta == 0.0:
+            self.last_eta = np.zeros(J.shape[1:])
             return E
         magJ = np.linalg.norm(J, axis=0)
         mask = magJ > self.j_crit
+        eta = np.zeros_like(magJ)
+        eta[mask] = self.eta
+        self.last_eta = eta
         if np.any(mask):
             E[:, mask] -= self.eta * J[:, mask]
         return E
@@ -88,6 +94,7 @@ class LHDIResistivity:
     def __init__(self, coeff: float = 1.0):
         self.coeff = coeff
         self.spikes: List[float] = []
+        self.last_eta: "np.ndarray | None" = None
 
     def compute_eta(
         self,
@@ -112,6 +119,7 @@ class LHDIResistivity:
         spacing: Tuple[float, float, float],
     ) -> "np.ndarray":
         eta = self.compute_eta(n, B, spacing)
+        self.last_eta = eta
         E = E - eta[np.newaxis, ...] * J
         magJ = np.linalg.norm(J, axis=0)
         spike = float(np.max(eta * magJ))
@@ -176,6 +184,7 @@ class PICSolver(PhysicsModule):
         self.subgrid_resolution = config.subgrid_resolution
         self.amr = config.amr
         self.density_threshold = config.density_threshold
+        self.electron_temperature = getattr(config, 'electron_temperature', 1e6)
         self.levels = [{'grid_shape': tuple(config.grid_shape), 'grid_spacing': tuple(config.grid_spacing), 'offset': (0, 0, 0)}]
         self.heating_grid = 0.0
         self.species = {}
@@ -441,17 +450,11 @@ class PICSolver(PhysicsModule):
             B = self.field_manager.get_B()
             rho = self.field_manager.get_rho()
             J = self.field_manager.get_J()
+            n = np.abs(rho)
+            eta_spitzer = spitzer_resistivity(n, np.full_like(n, self.electron_temperature), 1.0)
+            eta_anom = np.zeros_like(n)
             if self.warpx:
                 E, B = self.warpx.step(rho, J, E, B, self.dt)
-                if self.anomalous_resistivity_model:
-                    E = self.anomalous_resistivity_model.apply(E, J)
-                if self.lhdi_model:
-                    n = np.abs(rho)
-                    E = self.lhdi_model.apply(E, J, n, B, (self.dx, self.dy, self.dz))
-                    if self.lhdi_model.spikes:
-                        self.voltage_spikes.extend(self.lhdi_model.spikes[-1:])
-                if self.m0_instability_model:
-                    E[2] = self.m0_instability_model.apply(E[2], self.dt)
             else:
                 # FDTD update
                 curlE = np.array([(np.roll(E[2], -1, 1) - E[2]) / self.dy - (np.roll(E[1], -1, 2) - E[1]) / self.dz,
@@ -462,22 +465,37 @@ class PICSolver(PhysicsModule):
                                   (np.roll(B[0], -1, 2) - B[0]) / self.dz - (np.roll(B[2], -1, 0) - B[2]) / self.dx,
                                   (np.roll(B[1], -1, 0) - B[1]) / self.dx - (np.roll(E[0], -1, 1) - E[0]) / self.dy])
                 E += self.dt * (PICSolver.c**2 * curlB - J / PICSolver.epsilon0)
-                if self.anomalous_resistivity_model:
-                    E = self.anomalous_resistivity_model.apply(E, J)
-                if self.lhdi_model:
-                    n = np.abs(rho)
-                    E = self.lhdi_model.apply(E, J, n, B, (self.dx, self.dy, self.dz))
-                    if self.lhdi_model.spikes:
-                        self.voltage_spikes.extend(self.lhdi_model.spikes[-1:])
-                if self.m0_instability_model:
-                    E[2] = self.m0_instability_model.apply(E[2], self.dt)
                 self._apply_pml()  # Apply PML damping
+            if self.anomalous_resistivity_model:
+                E = self.anomalous_resistivity_model.apply(E, J)
+                if self.anomalous_resistivity_model.last_eta is not None:
+                    eta_anom += self.anomalous_resistivity_model.last_eta
+            if self.lhdi_model:
+                E = self.lhdi_model.apply(E, J, n, B, (self.dx, self.dy, self.dz))
+                if self.lhdi_model.last_eta is not None:
+                    eta_anom += self.lhdi_model.last_eta
+                if self.lhdi_model.spikes:
+                    self.voltage_spikes.extend(self.lhdi_model.spikes[-1:])
+            if self.m0_instability_model:
+                E[2] = self.m0_instability_model.apply(E[2], self.dt)
+            eta_needed = np.maximum(eta_spitzer - eta_anom, 0.0)
+            if np.any(eta_needed > 0):
+                E -= eta_needed[np.newaxis, ...] * J
+            if (
+                self.anomalous_resistivity_model is not None
+                or self.lhdi_model is not None
+                or self.m0_instability_model is not None
+            ) and np.all(eta_anom <= eta_spitzer):
+                msg = "No anomalous resistivity above Spitzer floor"
+                logger.error(msg)
+                raise RuntimeError(msg)
             self.field_manager.update_E(E)
             self.field_manager.update_B(B)
             self.filter_current()
             self._clean_divergence()
         except Exception as e:
             logger.error(f"Error solving fields: {e}")
+            raise
 
     #-------------------------------------------------------------------------------------
     # Diagnostics: VDF, moments, spatial diagnostics

--- a/tests/physics/test_spitzer_floor.py
+++ b/tests/physics/test_spitzer_floor.py
@@ -1,0 +1,102 @@
+from types import ModuleType, SimpleNamespace
+import sys
+import numpy as np
+import pytest
+
+if 'numba' not in sys.modules:  # provide minimal numba stub
+    numba_stub = ModuleType('numba')
+    numba_stub.njit = lambda *a, **k: (lambda f: f)
+    numba_stub.prange = range
+    sys.modules['numba'] = numba_stub
+
+warpx_stub = ModuleType('dpf2.simulation.warpx_wrapper')
+class _WarpXWrapper:
+    def __init__(self, *a, **k):
+        pass
+warpx_stub.WarpXWrapper = _WarpXWrapper
+sys.modules['dpf2.simulation.warpx_wrapper'] = warpx_stub
+
+coll_stub = ModuleType('dpf2.simulation.collision_model')
+class _CollisionProcess:
+    def __init__(self, *a, **k):
+        pass
+    def apply(self, solver, dt):
+        pass
+coll_stub.CollisionProcess = _CollisionProcess
+coll_stub.BetheBlochStopping = _CollisionProcess
+coll_stub.ElectronIonCollision = _CollisionProcess
+coll_stub.ElectronNeutralCollision = _CollisionProcess
+coll_stub.IonizationProcess = _CollisionProcess
+coll_stub.RecombinationProcess = _CollisionProcess
+sys.modules['dpf2.simulation.collision_model'] = coll_stub
+
+from dpf2.hall_mhd_solver import HallMHDSolver, MHDState
+from dpf2.simulation.pic_solver import PICSolver
+
+
+# --- Helper constructors for PIC solver ---
+
+def make_config():
+    return SimpleNamespace(
+        grid_shape=(2, 2, 2),
+        grid_spacing=(1.0, 1.0, 1.0),
+        max_dt=None,
+        electromag='yee',
+        boundary_conditions={'x': 'reflecting', 'y': 'reflecting', 'z': 'reflecting'},
+        dt=0.1,
+        use_warpx=False,
+        unity_params={},
+        vdf_bins=8,
+        max_vel=1.0,
+        subgrid_resolution=1,
+        amr=False,
+        density_threshold=1.0,
+        electron_temperature=1.0,  # ensure sizable Spitzer floor
+        enable_quantum=False,
+        enable_radiation=False,
+        enable_mesh_adaptivity=False,
+    )
+
+
+def make_field_manager():
+    shape = (2, 2, 2)
+    fm = SimpleNamespace()
+    fm.E = np.zeros((3,) + shape)
+    fm.B = np.zeros((3,) + shape)
+    fm.J = np.zeros((3,) + shape)
+    fm.rho = np.ones(shape)
+    fm.get_E = lambda: fm.E
+    fm.get_B = lambda: fm.B
+    fm.get_J = lambda: fm.J
+    fm.get_rho = lambda: fm.rho
+    fm.update_E = lambda E: setattr(fm, 'E', E)
+    fm.update_B = lambda B: setattr(fm, 'B', B)
+    fm.update_J = lambda J: setattr(fm, 'J', J)
+    return fm
+
+
+# --- Tests ---
+
+def test_hall_mhd_aborts_when_below_floor():
+    shape = (2, 2, 2)
+    rho = np.ones(shape)
+    mom = np.zeros(shape + (3,))
+    B = np.zeros(shape + (3,))
+    energy = np.ones(shape)
+    state = MHDState(rho=rho, mom=mom, energy=energy, B=B)
+
+    def zero_resistivity(J):
+        return np.zeros(J.shape[:-1])
+
+    solver = HallMHDSolver(anomalous_resistivity=zero_resistivity)
+    with pytest.raises(RuntimeError, match="Spitzer floor"):
+        solver.step(state, 0.1)
+
+
+def test_pic_aborts_when_below_floor():
+    cfg = make_config()
+    fm = make_field_manager()
+    solver = PICSolver(cfg, fm)
+    solver.set_lhdi_model(0.0)
+    with pytest.raises(RuntimeError, match="Spitzer floor"):
+        solver.solve_fields()


### PR DESCRIPTION
## Summary
- enforce a Spitzer-based minimum resistivity in Hall-MHD and PIC solvers
- abort runs when anomalous mechanisms fail to exceed the classical floor
- cover failure mode with regression tests

## Testing
- `pytest tests/test_hall_mhd_solver.py tests/physics/test_anomalous_resistivity.py tests/physics/test_spitzer_floor.py`


------
https://chatgpt.com/codex/tasks/task_e_68bafba6d378832a8b6afc5799b70405