### PR TITLE
Add physics and verification docs with HPC usage examples

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -86,3 +86,15 @@ dpf2 uq-sweep --config config.json --parameters '{"capacitance":[1e-6,5e-6]}' --
 
 Execute a sweep across the sampled configurations and record peak current
 for each case in ``uq_results.json``.
+
+## HPC Workflow Example
+
+The CLI can be combined with batch systems for parallel runs. For example, a four-rank job under SLURM can be launched with:
+
+```bash
+srun -n 4 dpf2 simulate -c config.json -o output --lab-mode
+```
+
+This executes the solver across multiple tasks while capturing a manifest for reproducibility. Performance characteristics on a reference cluster are shown below.
+
+![Strong scaling](images/strong_scaling.png)

--- a/docs/hpc.md
+++ b/docs/hpc.md
@@ -52,3 +52,23 @@ python -m dpf2.cli --lab-mode simulate \
     --restart run/run_manifest.json
 ```
 
+## Performance Scaling
+
+Strong and weak scaling studies highlight how the solver performs on large clusters.
+
+![Strong scaling](images/strong_scaling.png)
+![Weak scaling](images/weak_scaling.png)
+
+To reproduce these measurements on SLURM:
+
+```bash
+srun -n 8 python scripts/scaling_tests.py --strong --sizes 1 2 4 8
+```
+
+## HPC CLI Example
+
+The command line interface can be launched directly with `srun` to distribute a run:
+
+```bash
+srun -n 4 dpf2 simulate -c config.json -o run --lab-mode
+```

--- a/docs/physics/hall_mhd.md
+++ b/docs/physics/hall_mhd.md
@@ -36,3 +36,7 @@ solver = HallMHDSolver(braginskii=nrl_braginskii)
 solver.step(state, dt)
 print(solver.hall_active, solver.electron_inertia_active)
 ```
+
+## References
+1. E. Priest and T. Forbes, *Magnetic Reconnection*, Cambridge University Press, 2000.
+2. P. A. Davidson, *An Introduction to Magnetohydrodynamics*, Cambridge University Press, 2001.

--- a/docs/physics/kinetic.md
+++ b/docs/physics/kinetic.md
@@ -1,0 +1,7 @@
+# Kinetic Models
+
+Kinetic descriptions resolve the velocity distribution function and capture non-thermal features that fluid models average out. Two common approaches are particle-in-cell (PIC) methods, where computational particles represent parcels of phase space, and Vlasov solvers that evolve the distribution function directly on a grid. Kinetic models recover fluid moments while retaining information on beams and anisotropies at the cost of greater computational expense.
+
+## References
+1. C. K. Birdsall and A. B. Langdon, *Plasma Physics via Computer Simulation*, McGraw-Hill, 1991.
+2. R. C. Davidson, *Methods in Nonlinear Plasma Theory*, Academic Press, 1972.

--- a/docs/physics/mhd.md
+++ b/docs/physics/mhd.md
@@ -1,0 +1,9 @@
+# Magnetohydrodynamics
+
+Magnetohydrodynamics (MHD) treats the plasma as a single conducting fluid coupled to the magnetic field. The model evolves the mass, momentum, magnetic induction and energy equations and is applicable when gyroradii are much smaller than the system size. Resistive and ideal forms are supported depending on whether explicit diffusion terms are included.
+
+Typical assumptions include quasi-neutrality, a Maxwellian particle distribution and negligible displacement current. Under these conditions the fluid velocity advects the magnetic field through the ideal Ohm's law.
+
+## References
+1. P. A. Davidson, *An Introduction to Magnetohydrodynamics*, Cambridge University Press, 2001.
+2. T. J. M. Boyd and J. J. Sanderson, *The Physics of Plasmas*, Cambridge University Press, 2003.

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -1,0 +1,24 @@
+# Verification Tests
+
+This guide summarises common test problems used to verify the numerical implementation.
+
+## Method of Manufactured Solutions (MMS)
+1. Select an analytic solution for the governing equations.
+2. Compute the required source terms and boundary conditions so the analytic fields satisfy the modified system.
+3. Run the simulation with the sources enabled and compare the numerical solution against the analytic expression.
+4. Verify that the error decreases at the expected order with grid refinement.
+
+## Brio--Wu Shock Tube
+1. Initialise left and right states of a 1-D MHD shock tube with discontinuous magnetic field and density.
+2. Evolve to the reference time and compare density and magnetic field profiles with the published solution.
+3. This test exercises the Riemann solver and divergence control algorithm.
+
+## Orszag--Tang Vortex
+1. Start from a doubly periodic domain with sinusoidal velocity and magnetic fields.
+2. Track the development of MHD turbulence and compare energy spectra or time histories of peak current density.
+3. Used to assess robustness of shock capturing and resolution of non-linear interactions.
+
+## References
+1. C. J. Roy, "Review of code and solution verification procedures for computational simulation," J. Comput. Phys., 2010.
+2. M. Brio and C. C. Wu, "An Upwind Differencing Scheme for the Equations of Ideal Magnetohydrodynamics," J. Comput. Phys., 1988.
+3. S. A. Orszag and C. M. Tang, "Small-scale structure of two-dimensional magnetohydrodynamic turbulence," J. Fluid Mech., 1979.


### PR DESCRIPTION
## Summary
- Document MHD, Hall, and kinetic physics models with references
- Add verification guide for MMS, Brio–Wu, and Orszag–Tang tests
- Expand HPC and CLI docs with scaling charts and batch workflow examples

## Testing
- `pytest` *(fails: No module named 'pandas', 'flask', etc., 63 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68baff0afbd8832a813aeb0e47586be5