### PR TITLE
Add OOD-aware surrogate predictions

### DIFF
--- a/ai/surrogates/metadata.json
+++ b/ai/surrogates/metadata.json
@@ -1,12 +1,13 @@
 {
-  "feature_mean": 150.0,
-  "feature_variance": 2066.6666666666665,
+  "feature_mean": [150.0],
+  "feature_cov": [[2066.6666666666665]],
+  "mahalanobis_threshold": 2.0,
   "yield": {
-    "onnx": "yield_surrogate.onnx",
+    "onnx": "yield_model.onnx",
     "quantile": 1919354838.7096791
   },
   "pinch_time": {
-    "onnx": "pinch_time_surrogate.onnx",
+    "onnx": "pinch_time_model.onnx",
     "quantile": 0.21935483870967723
   }
 }

--- a/ai/surrogates/pinch_time_model.json
+++ b/ai/surrogates/pinch_time_model.json
@@ -7,5 +7,9 @@
     90.0,
     200.0
   ],
-  "error": 0.15770609318996462
+  "error": 0.21935483870967723,
+  "onnx": "pinch_time_model.onnx",
+  "mean": 150.0,
+  "covariance": 2066.6666666666665,
+  "ood_threshold": 2.0
 }

--- a/ai/surrogates/train_surrogates.py
+++ b/ai/surrogates/train_surrogates.py
@@ -111,7 +111,10 @@ def _export_onnx(model: "torch.nn.Module", path: Path) -> None:
 def main() -> None:
     x, y, p = _prepare_data()
     feature_mean = float(x.mean())
-    feature_var = float(x.var())
+    feature_cov = float(x.var())
+    distances = ((x - feature_mean) ** 2) / feature_cov
+    mahalanobis_threshold = float(np.quantile(distances, 0.99))
+    domain = [float(x.min()), float(x.max())]
 
     if torch is None:
         raise RuntimeError("PyTorch is required to train surrogates")
@@ -123,14 +126,47 @@ def main() -> None:
     q_p = _conformal_quantile(pinch_model, x, p)
 
     HERE.mkdir(parents=True, exist_ok=True)
-    _export_onnx(yield_model, HERE / "yield_surrogate.onnx")
-    _export_onnx(pinch_model, HERE / "pinch_time_surrogate.onnx")
+    y_onnx = HERE / "yield_model.onnx"
+    p_onnx = HERE / "pinch_time_model.onnx"
+    _export_onnx(yield_model, y_onnx)
+    _export_onnx(pinch_model, p_onnx)
+
+    # Extract linear coefficients for JSON models
+    a_y = float(yield_model.weight.detach().cpu().numpy()[0, 0])
+    b_y = float(yield_model.bias.detach().cpu().numpy()[0])
+    a_p = float(pinch_model.weight.detach().cpu().numpy()[0, 0])
+    b_p = float(pinch_model.bias.detach().cpu().numpy()[0])
+
+    yield_meta = {
+        "coeffs": [a_y, b_y],
+        "training_domain": domain,
+        "error": q_y,
+        "onnx": y_onnx.name,
+        "mean": feature_mean,
+        "covariance": feature_cov,
+        "ood_threshold": mahalanobis_threshold,
+    }
+    pinch_meta = {
+        "coeffs": [a_p, b_p],
+        "training_domain": domain,
+        "error": q_p,
+        "onnx": p_onnx.name,
+        "mean": feature_mean,
+        "covariance": feature_cov,
+        "ood_threshold": mahalanobis_threshold,
+    }
+
+    with (HERE / "yield_model.json").open("w") as fh:
+        json.dump(yield_meta, fh, indent=2)
+    with (HERE / "pinch_time_model.json").open("w") as fh:
+        json.dump(pinch_meta, fh, indent=2)
 
     metadata = {
-        "feature_mean": feature_mean,
-        "feature_variance": feature_var,
-        "yield": {"onnx": "yield_surrogate.onnx", "quantile": q_y},
-        "pinch_time": {"onnx": "pinch_time_surrogate.onnx", "quantile": q_p},
+        "feature_mean": [feature_mean],
+        "feature_cov": [[feature_cov]],
+        "mahalanobis_threshold": mahalanobis_threshold,
+        "yield": {"onnx": y_onnx.name, "quantile": q_y},
+        "pinch_time": {"onnx": p_onnx.name, "quantile": q_p},
     }
     with (HERE / "metadata.json").open("w") as fh:
         json.dump(metadata, fh, indent=2)

--- a/ai/surrogates/yield_model.json
+++ b/ai/surrogates/yield_model.json
@@ -7,6 +7,9 @@
     90.0,
     200.0
   ],
-  "error": 1379928315.4121861,
-  "onnx": "yield_model.onnx"
+  "error": 1919354838.7096791,
+  "onnx": "yield_model.onnx",
+  "mean": 150.0,
+  "covariance": 2066.6666666666665,
+  "ood_threshold": 2.0
 }

--- a/src/dpf2/ai/surrogate.py
+++ b/src/dpf2/ai/surrogate.py
@@ -30,6 +30,7 @@ class SurrogateModel(ABC):
         self._feature_mean: list[float] | None = None
         self._inv_cov: list[list[float]] | None = None
         self._mahalanobis_threshold: float | None = None
+        self._quantile: float | None = None
         if metadata_path.exists():
             with metadata_path.open() as fh:
                 metadata = json.load(fh)
@@ -37,6 +38,13 @@ class SurrogateModel(ABC):
             cov_inv = metadata.get("feature_cov_inv")
             cov = metadata.get("feature_cov")
             threshold = metadata.get("mahalanobis_threshold")
+            # Extract per-model quantile if present
+            for info in metadata.values():
+                if isinstance(info, dict) and info.get("onnx") == self.model_path.name:
+                    q = info.get("quantile")
+                    if q is not None:
+                        self._quantile = float(q)
+                        break
             if mean is not None and threshold is not None:
                 self._feature_mean = list(mean)
                 inv = None
@@ -47,7 +55,16 @@ class SurrogateModel(ABC):
                         import numpy as _np  # type: ignore
                         inv = _np.linalg.inv(_np.asarray(cov)).tolist()
                     except Exception:
-                        inv = None
+                        if (
+                            isinstance(cov, list)
+                            and len(cov) == 1
+                            and isinstance(cov[0], list)
+                            and len(cov[0]) == 1
+                            and cov[0][0] != 0
+                        ):
+                            inv = [[1.0 / float(cov[0][0])]]
+                        else:
+                            inv = None
                 if inv is not None:
                     self._inv_cov = inv
                     self._mahalanobis_threshold = float(threshold)
@@ -63,6 +80,26 @@ class SurrogateModel(ABC):
         inputs_iter = [inputs] if getattr(inputs, "ndim", 1) == 1 else inputs
         self._check_domain(inputs_iter)
         return self._predict(inputs)
+
+    def predict_with_uncertainty(
+        self, inputs: Any
+    ) -> tuple[float, tuple[float, float]] | list[tuple[float, tuple[float, float]]]:
+        """Return prediction and conformal uncertainty band for ``inputs``."""
+
+        if isinstance(inputs, (list, tuple)):
+            arr = np.array([[float(v)] for v in inputs])
+            preds = self.predict(arr)
+            preds_list = [float(p[0]) if hasattr(p, "__getitem__") else float(p) for p in preds]
+            dists = [self._mahalanobis_distance([float(v)]) for v in inputs]
+            bands = [0.0 if self._quantile is None else self._quantile * (1.0 + d) for d in dists]
+            return [(p, (p - b, p + b)) for p, b in zip(preds_list, bands)]
+        else:
+            val = float(inputs)
+            arr = np.array([[val]])
+            pred = float(self.predict(arr)[0][0])
+            dist = self._mahalanobis_distance([val])
+            band = 0.0 if self._quantile is None else self._quantile * (1.0 + dist)
+            return pred, (pred - band, pred + band)
 
     def _mahalanobis_distance(self, x: Any) -> float:
         if self._feature_mean is None or self._inv_cov is None:

--- a/src/dpf2/optimization/param_sweep.py
+++ b/src/dpf2/optimization/param_sweep.py
@@ -71,29 +71,33 @@ def run_parametric_sweep(
         (p, (lo, hi))}``.
     """
 
-    from ..ai.simple_surrogates import (
-        LinearSurrogate,
-        load_pinch_time_surrogate,
-        load_yield_surrogate,
-    )
-    try:  # pragma: no cover - prefer surrogate-defined error if available
-        from ..ai.simple_surrogates import OutOfDomainError as _OOD
-    except Exception:  # pragma: no cover
-        _OOD = OutOfDomainError
-    else:
-        global OutOfDomainError
+    model_dir = Path(__file__).resolve().parents[2] / "ai" / "surrogates"
+    try:  # pragma: no cover - optional dependency
+        from ..ai.surrogate import ONNXSurrogateModel, OutOfDomainError as _OOD
+
+        y_path = Path(yield_model) if yield_model else model_dir / "yield_model.onnx"
+        p_path = Path(pinch_model) if pinch_model else model_dir / "pinch_time_model.onnx"
+        y_model = ONNXSurrogateModel.load(y_path)
+        p_model = ONNXSurrogateModel.load(p_path)
         OutOfDomainError = _OOD
+    except Exception:  # pragma: no cover - fallback to simple models
+        from ..ai.simple_surrogates import (
+            LinearSurrogate,
+            load_pinch_time_surrogate,
+            load_yield_surrogate,
+            OutOfDomainError as _OOD,
+        )
 
-    # Load surrogate models -------------------------------------------------
-    if yield_model:
-        y_model = LinearSurrogate.load(Path(yield_model))
-    else:
-        y_model = load_yield_surrogate()
+        if yield_model:
+            y_model = LinearSurrogate.load(Path(yield_model))
+        else:
+            y_model = load_yield_surrogate()
 
-    if pinch_model:
-        p_model = LinearSurrogate.load(Path(pinch_model))
-    else:
-        p_model = load_pinch_time_surrogate()
+        if pinch_model:
+            p_model = LinearSurrogate.load(Path(pinch_model))
+        else:
+            p_model = load_pinch_time_surrogate()
+        OutOfDomainError = _OOD
 
     # Ensure the output directory exists for compatibility with older APIs
     Path(output_dir).mkdir(parents=True, exist_ok=True)

--- a/tests/test_ai_surrogate.py
+++ b/tests/test_ai_surrogate.py
@@ -59,6 +59,22 @@ def test_out_of_domain(tmp_path):
         model.predict(outside)
 
 
+def test_predict_with_uncertainty(tmp_path):
+    model_path = tmp_path / "model.pkl"
+    meta = {
+        "feature_mean": [0.0],
+        "feature_cov": [[1.0]],
+        "mahalanobis_threshold": 5.0,
+        "toy": {"onnx": model_path.name, "quantile": 0.5},
+    }
+    (tmp_path / "metadata.json").write_text(json.dumps(meta))
+    model = SimpleSurrogate(model_path, scale=1.0)
+    pred, (lo, hi) = model.predict_with_uncertainty(1.0)
+    assert pred == pytest.approx(1.0)
+    assert lo == pytest.approx(0.0)
+    assert hi == pytest.approx(2.0)
+
+
 def test_torch_surrogate_import_error(tmp_path):
     path = tmp_path / "model.pt"
     path.write_text("dummy")


### PR DESCRIPTION
## Summary
- enrich surrogate training with feature statistics and ONNX exports
- add Mahalanobis OOD checks and conformal uncertainty bands to surrogate API
- support ONNX surrogates in parameter sweeps with fallback to simple models

## Testing
- `pytest tests/test_ai_surrogate.py::test_predict_with_uncertainty -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68baff0a9214832ab1a47ecef486ae3d