### PR TITLE
Add sheath vector overlays and snapshot sharing

### DIFF
--- a/examples/labs/instability_lab.md
+++ b/examples/labs/instability_lab.md
@@ -6,7 +6,7 @@ This exercise guides you through interpreting the Instability Visualizer.
    vectors.
 2. Note how phase annotations divide the timeline into breakdown, rundown,
    pinch, and afterglow segments.
-3. Capture a snapshot via **Save & Share** and reload it from the shared link or
-   by uploading the snapshot JSON file.
+3. Capture a snapshot via **Save & Share** and reload it from the shared URL
+   (``?snap=<id>``) or by uploading the snapshot JSON file.
 4. Discuss how the vector field evolves between phases and how it relates to the
    amplitude trace.

--- a/examples/labs/sheath_beam_lab.md
+++ b/examples/labs/sheath_beam_lab.md
@@ -4,7 +4,8 @@ Explore the interactive sheath and J×B overlay from the web sandbox.
 
 1. Launch the web frontend and open the **Sheath & J×B** panel.
 2. Vary the voltage and pressure sliders to see the sheath radius and drift
-   arrows respond. Green arrows show the phase‐dependent vector field.
+   arrows respond. Blue arrows indicate sheath velocities while green arrows
+   show the J×B force vectors.
 3. Use **Save & Share** to export the current state. Share the returned URL with
    a partner and reload it to resume the scene.
-4. Record observations on how phase transitions modify the vector field.
+4. Record observations on how phase transitions modify the vector fields.

--- a/src/dpf2/gui/interactive.py
+++ b/src/dpf2/gui/interactive.py
@@ -24,7 +24,7 @@ from .project_manager import ProjectManager
 from ..core.config import DPFConfig
 from ..device_profiles import DeviceProfiles
 from ..optimization import OptimizationWarning
-from ..visualization.sheath import jxb_field
+from ..visualization.sheath import jxb_field, sheath_velocity_field
 
 try:  # pragma: no cover - optional dependency
     import dash
@@ -478,14 +478,28 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
         Input("pressure", "value"),
     )
     def _update_sheath_overlay(voltage, pressure):
-        field = jxb_field(voltage, pressure, 0.0)
+        force = jxb_field(voltage, pressure, 0.0)
+        vel = sheath_velocity_field(voltage, pressure, 0.0)
         fig = ff.create_quiver(
-            field.x.ravel(),
-            field.y.ravel(),
-            field.u.ravel(),
-            field.v.ravel(),
+            vel.x.ravel(),
+            vel.y.ravel(),
+            vel.u.ravel(),
+            vel.v.ravel(),
             scale=0.2,
+            name="velocity",
         )
+        fig.data[0].line.color = "blue"
+        force_fig = ff.create_quiver(
+            force.x.ravel(),
+            force.y.ravel(),
+            force.u.ravel(),
+            force.v.ravel(),
+            scale=0.2,
+            name="J×B force",
+        )
+        for tr in force_fig.data:
+            tr.line.color = "green"
+            fig.add_trace(tr)
         v_norm = voltage / 30_000.0
         radius = 0.2 + v_norm * 0.6
         theta = np.linspace(0, 2 * np.pi, 100)
@@ -495,6 +509,7 @@ def launch(host: str = "127.0.0.1", port: int = 8050, *, simplified: bool = Fals
         fig.update_layout(
             xaxis=dict(scaleanchor="y", range=[-1, 1]),
             yaxis=dict(range=[-1, 1]),
+            showlegend=True,
         )
         return fig
 

--- a/src/dpf2/visualization/sheath.py
+++ b/src/dpf2/visualization/sheath.py
@@ -72,6 +72,16 @@ def _sheath_field(voltage: float, pressure: float, t: float) -> SheathField:
     return SheathField(x, y, u, v)
 
 
+def sheath_velocity_field(voltage: float, pressure: float, t: float) -> SheathField:
+    """Return the synthetic sheath velocity field.
+
+    This is a thin public wrapper around :func:`_sheath_field` so that other
+    modules (e.g. the web sandbox) can overlay the nominal sheath velocities
+    without relying on the private helper."""
+
+    return _sheath_field(voltage, pressure, t)
+
+
 def jxb_field(voltage: float, pressure: float, t: float) -> SheathField:
     """Compute the J×B drift field for the toy sheath.
 
@@ -211,5 +221,10 @@ def animate_discharge_phases(
     )
 
 
-__all__ = ["animate_sheath", "animate_discharge_phases", "jxb_field"]
+__all__ = [
+    "animate_sheath",
+    "animate_discharge_phases",
+    "jxb_field",
+    "sheath_velocity_field",
+]
 

--- a/tests/test_snapshot_api.py
+++ b/tests/test_snapshot_api.py
@@ -1,0 +1,24 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from web.backend.main import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _auth_headers(client):
+    res = client.post('/token', data={'username': 'user', 'password': 'secret'})
+    return {'Authorization': f"Bearer {res.json()['access_token']}"}
+
+
+def test_snapshot_roundtrip(client):
+    headers = _auth_headers(client)
+    state = {'config': {'foo': 1}, 'voltage': 5.0}
+    resp = client.post('/snapshot/save', json={'state': state}, headers=headers)
+    assert resp.status_code == 200
+    snap_id = resp.json()['id']
+    resp2 = client.get(f'/snapshot/{snap_id}')
+    assert resp2.json() == state

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -37,3 +37,13 @@ def test_jxb_field_cross_product():
     assert np.allclose(jxb.u, -0.2 * b.v)
     assert np.allclose(jxb.v, 0.2 * b.u)
 
+
+def test_sheath_velocity_field_matches_internal():
+    import numpy as np
+    from dpf2.visualization.sheath import _sheath_field, sheath_velocity_field
+
+    b = _sheath_field(1.0, 0.2, 0.0)
+    vel = sheath_velocity_field(1.0, 0.2, 0.0)
+    assert np.allclose(vel.u, b.u)
+    assert np.allclose(vel.v, b.v)
+

--- a/web/frontend/src/App.jsx
+++ b/web/frontend/src/App.jsx
@@ -29,6 +29,21 @@ export default function App() {
 
   // load snapshot on startup
   useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const snapId = params.get('snap');
+    if (snapId) {
+      axios.get(`/snapshot/${snapId}`).then(({ data }) => {
+        if (data.config) setConfig(JSON.stringify(data.config));
+        if (data.voltage !== undefined) setVoltage(data.voltage);
+        if (data.pressure !== undefined) setPressure(data.pressure);
+        if (data.jitter) {
+          setUseJitter(true);
+          setPressureJitter(data.jitter.pressure_jitter_pct || 0);
+          setSwitchJitter(data.jitter.trigger_jitter_ns || 0);
+        }
+      });
+      return;
+    }
     const saved = localStorage.getItem('dpfSnapshot');
     if (saved) {
       try {
@@ -114,6 +129,29 @@ export default function App() {
     a.download = 'snapshot.json';
     a.click();
     URL.revokeObjectURL(url);
+  };
+
+  const shareSnapshot = async () => {
+    const snapshot = {
+      config: JSON.parse(config),
+      voltage,
+      pressure,
+      jitter: useJitter
+        ? { pressure_jitter_pct: pressureJitter, trigger_jitter_ns: switchJitter }
+        : undefined,
+    };
+    const { data } = await axios.post(
+      '/snapshot/save',
+      { state: snapshot },
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+    const link = `${window.location.origin}?snap=${data.id}`;
+    try {
+      await navigator.clipboard.writeText(link);
+      alert('Snapshot link copied to clipboard');
+    } catch {
+      alert(link);
+    }
   };
 
   const importSnapshot = (e) => {
@@ -228,7 +266,7 @@ export default function App() {
             setPressure={setPressure}
             onChange={updateSimulation}
           />
-          <button type="button" onClick={exportSnapshot}>
+          <button type="button" onClick={shareSnapshot}>
             Share Scene
           </button>
           <InstabilityVisualizer />


### PR DESCRIPTION
## Summary
- Overlay sheath velocity and J×B force vectors in the interactive GUI
- Expose public `sheath_velocity_field` helper for reusable velocity fields
- Enable Save & Share snapshots with frontend loading and backend round-trip tests

## Testing
- `pytest tests/test_visualization.py -q` *(skipped: matplotlib)*
- `pytest tests/test_snapshot_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68baff096670832a80eb8a62d22f3071