### PR TITLE
Add calibration-aware diagnostics and directional neutron metrics

### DIFF
--- a/src/dpf2/cli/main.py
+++ b/src/dpf2/cli/main.py
@@ -28,6 +28,7 @@ from dpf2.diagnostics.synthetic_signals import (
     coupled_voltage_waveform,
     rogowski_signal,
     bdot_signal,
+    angular_neutron_spectrum,
 )
 from dpf2.synthetic_diagnostics import SyntheticDiagnostics
 from dpf2.exceptions import ConfigurationError, SimulationRuntimeError
@@ -1143,6 +1144,21 @@ def make_surrogate(data: str, outdir: str) -> None:
     type=click.Path(exists=True, dir_okay=False),
     help="Optional B-dot calibration file",
 )
+@click.option(
+    "--sxr-cal",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Optional SXR calibration file",
+)
+@click.option(
+    "--tof-cal",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Optional neutron TOF calibration file",
+)
+@click.option(
+    "--anisotropy-plot",
+    is_flag=True,
+    help="Output simple angular neutron spectrum",
+)
 @click.option("--dt", type=float, default=1e-9, help="Time step for derivatives [s]")
 @click.option(
     "--radius", type=float, default=0.01, help="Probe radius for B-dot signal [m]"
@@ -1156,6 +1172,9 @@ def diagnostics(
     bdot: bool,
     rogowski_cal: str | None,
     bdot_cal: str | None,
+    sxr_cal: str | None,
+    tof_cal: str | None,
+    anisotropy_plot: bool,
     dt: float,
     radius: float,
 ) -> None:
@@ -1194,6 +1213,10 @@ def diagnostics(
             outputs["bdot"] = bdot_signal(
                 states, radius, dt, calibration_file=bdot_cal
             )
+
+        if anisotropy_plot:
+            angles = [0.0, 90.0, 180.0]
+            outputs["anisotropy"] = angular_neutron_spectrum(angles, 1.0, 0.0)
 
         click.echo(json.dumps(outputs))
     except Exception as e:

--- a/src/dpf2/diagnostics/synthetic_signals.py
+++ b/src/dpf2/diagnostics/synthetic_signals.py
@@ -17,6 +17,11 @@ import math
 import numpy as np
 import h5py
 
+try:
+    from ..dpf_config import DPFConfig  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    DPFConfig = None  # type: ignore
+
 from ..core.bases import CouplingState
 
 
@@ -131,10 +136,33 @@ def _apply_instrument_response(
     return [float(v) for v in conv]
 
 
+def _cfg_calibration(cfg: "DPFConfig | None", attr: str) -> Path | None:
+    """Return calibration path for ``attr`` from :class:`DPFConfig`.
+
+    Parameters
+    ----------
+    cfg:
+        Optional configuration object providing a ``diagnostics`` section.
+    attr:
+        Attribute name on ``cfg.diagnostics`` holding the calibration path.
+    """
+
+    if cfg is None or DPFConfig is None:
+        return None
+    diag = getattr(cfg, "diagnostics", None)
+    if diag is None:
+        return None
+    path = getattr(diag, attr, None)
+    if path is None:
+        return None
+    return Path(path)
+
+
 def rogowski_signal(
     history: Iterable[CouplingState],
     dt: float,
     *,
+    cfg: "DPFConfig | None" = None,
     calibration_file: str | Path | None = None,
     response_fn: Callable[[float], float] | None = None,
     noise_fn: Callable[[float], float] | None = None,
@@ -155,6 +183,8 @@ def rogowski_signal(
     else:
         deriv = [(currents[i + 1] - currents[i]) / dt for i in range(len(currents) - 1)]
         deriv.append(deriv[-1])
+    if calibration_file is None:
+        calibration_file = _cfg_calibration(cfg, "rogowski_calibration_path")
     if calibration_file is not None:
         t, r = _load_calibration_curve(calibration_file, "rogowski")
         deriv = _apply_instrument_response(deriv, dt, t, r)
@@ -166,6 +196,7 @@ def bdot_signal(
     radius: float,
     dt: float,
     *,
+    cfg: "DPFConfig | None" = None,
     calibration_file: str | Path | None = None,
     response_fn: Callable[[float], float] | None = None,
     noise_fn: Callable[[float], float] | None = None,
@@ -182,6 +213,8 @@ def bdot_signal(
     else:
         deriv = [(B[i + 1] - B[i]) / dt for i in range(len(B) - 1)]
         deriv.append(deriv[-1])
+    if calibration_file is None:
+        calibration_file = _cfg_calibration(cfg, "bdot_calibration_path")
     if calibration_file is not None:
         t, r = _load_calibration_curve(calibration_file, "bdot")
         deriv = _apply_instrument_response(deriv, dt, t, r)
@@ -192,6 +225,7 @@ def sxr_diode_signal(
     signal: Sequence[float],
     dt: float,
     *,
+    cfg: "DPFConfig | None" = None,
     calibration_file: str | Path | None = None,
     response_fn: Callable[[float], float] | None = None,
     noise_fn: Callable[[float], float] | None = None,
@@ -199,6 +233,8 @@ def sxr_diode_signal(
     """Apply soft X-ray diode filter response to a signal history."""
 
     data = [float(v) for v in signal]
+    if calibration_file is None:
+        calibration_file = _cfg_calibration(cfg, "sxr_calibration_path")
     if calibration_file is not None:
         t, r = _load_calibration_curve(calibration_file, "sxr")
         data = _apply_instrument_response(data, dt, t, r)
@@ -211,6 +247,7 @@ def neutron_tof_signal(
     flight_path_m: float,
     time_bins_s: Sequence[float],
     *,
+    cfg: "DPFConfig | None" = None,
     calibration_file: str | Path | None = None,
     response_fn: Callable[[float], float] | None = None,
     noise_fn: Callable[[float], float] | None = None,
@@ -237,11 +274,30 @@ def neutron_tof_signal(
         if 0 <= idx < len(hist):
             hist[idx] += float(count)
 
+    if calibration_file is None:
+        calibration_file = _cfg_calibration(cfg, "neutron_tof_calibration_path")
     if calibration_file is not None:
         dt = time_bins_s[1] - time_bins_s[0] if len(time_bins_s) > 1 else 1.0
         t_resp, r_resp = _load_calibration_curve(calibration_file, "tof")
         hist = _apply_instrument_response(hist, dt, t_resp, r_resp)
     return _apply(hist, response_fn, noise_fn)
+
+
+def angular_neutron_spectrum(
+    angles_deg: Sequence[float],
+    base_yield: float,
+    anisotropy: float = 0.0,
+) -> List[float]:
+    """Return a cosine-based angular neutron spectrum.
+
+    This helper mirrors :func:`dpf2.diagnostics.neutron_spectra.angular_spectrum`
+    but is provided here for lightweight synthetic diagnostics.
+    """
+
+    return [
+        float(base_yield * (1.0 + anisotropy * math.cos(math.radians(a))))
+        for a in angles_deg
+    ]
 
 
 __all__ = [
@@ -253,5 +309,6 @@ __all__ = [
     "bdot_signal",
     "sxr_diode_signal",
     "neutron_tof_signal",
+    "angular_neutron_spectrum",
 ]
 

--- a/src/dpf2/neutron_yield_model.py
+++ b/src/dpf2/neutron_yield_model.py
@@ -417,11 +417,64 @@ def partition_yield(
     }
 
 
+def directional_counts(
+    forward_rate: Sequence[float],
+    radial_rate: Sequence[float],
+    backward_rate: Sequence[float],
+    dt: float,
+    forward_sigma: Sequence[float] | None = None,
+    radial_sigma: Sequence[float] | None = None,
+    backward_sigma: Sequence[float] | None = None,
+) -> Dict[str, Tuple[float, float]]:
+    """Integrate directional rates and return counts with uncertainties.
+
+    Parameters
+    ----------
+    forward_rate, radial_rate, backward_rate:
+        Time histories of neutron production rates for the forward, radial and
+        backward directions respectively.
+    dt:
+        Time step width in seconds.
+    forward_sigma, radial_sigma, backward_sigma:
+        Optional per-sample uncertainties for each rate history.  When
+        provided, uncertainties are propagated in quadrature and combined with
+        Poisson counting statistics (``sqrt(N)``).
+    """
+
+    if dt <= 0:
+        raise ValueError("dt must be positive")
+    n = len(forward_rate)
+    if not (len(radial_rate) == len(backward_rate) == n):
+        raise ValueError("rate histories must have the same length")
+
+    def _integrate(rate: Sequence[float], sigma: Sequence[float] | None) -> Tuple[float, float]:
+        count = sum(float(v) for v in rate) * dt
+        var = count if count > 0 else 0.0
+        if sigma is not None:
+            if len(sigma) != len(rate):
+                raise ValueError("sigma length must match rate length")
+            var += sum((float(s) * dt) ** 2 for s in sigma)
+        return count, math.sqrt(var) if var > 0 else 0.0
+
+    fwd = _integrate(forward_rate, forward_sigma)
+    rad = _integrate(radial_rate, radial_sigma)
+    back = _integrate(backward_rate, backward_sigma)
+    total = fwd[0] + rad[0] + back[0]
+    total_var = fwd[1] ** 2 + rad[1] ** 2 + back[1] ** 2
+    return {
+        "forward": fwd,
+        "radial": rad,
+        "backward": back,
+        "total": (total, math.sqrt(total_var) if total_var > 0 else 0.0),
+    }
+
+
 __all__ = [
     "NeutronYieldModel",
     "TabulatedIonEDF",
     "compute_directional_spectrum",
     "partition_yield",
+    "directional_counts",
     "load_endf_b_viii",
     "compute_angular_spectra",
 ]

--- a/tests/diagnostics/test_neutron_yield.py
+++ b/tests/diagnostics/test_neutron_yield.py
@@ -1,6 +1,8 @@
 import math
 
-from dpf2.neutron_yield_model import partition_yield
+import math
+
+from dpf2.neutron_yield_model import partition_yield, directional_counts
 from dpf2.fusion import dd_yield_components
 
 
@@ -44,3 +46,30 @@ def test_dd_yield_components_zero_beam():
     )
     assert res["beam_target"][0] == 0.0
     assert math.isclose(res["total"][0], res["thermonuclear"][0])
+
+
+def test_directional_counts_components():
+    fwd = [1.0, 1.0]
+    rad = [2.0, 2.0]
+    back = [3.0, 3.0]
+    res = directional_counts(fwd, rad, back, dt=1.0)
+    assert math.isclose(res["forward"][0], 2.0)
+    assert math.isclose(res["radial"][0], 4.0)
+    assert math.isclose(res["backward"][0], 6.0)
+    assert math.isclose(res["total"][0], 12.0)
+    assert math.isclose(res["forward"][1], math.sqrt(2.0))
+
+
+def test_directional_counts_uncertainty():
+    fwd = [1.0, 1.0]
+    rad = [2.0, 2.0]
+    back = [3.0, 3.0]
+    fwd_s = [0.1, 0.1]
+    rad_s = [0.2, 0.2]
+    back_s = [0.3, 0.3]
+    res = directional_counts(fwd, rad, back, dt=1.0, forward_sigma=fwd_s, radial_sigma=rad_s, backward_sigma=back_s)
+    def _expected(count, sigs):
+        return math.sqrt(count + sum(s ** 2 for s in sigs))
+    assert math.isclose(res["forward"][1], _expected(2.0, fwd_s))
+    assert math.isclose(res["radial"][1], _expected(4.0, rad_s))
+    assert math.isclose(res["backward"][1], _expected(6.0, back_s))

--- a/tests/diagnostics/test_synthetic_signals_config.py
+++ b/tests/diagnostics/test_synthetic_signals_config.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+from dpf2.diagnostics.synthetic_signals import rogowski_signal, angular_neutron_spectrum
+from dpf2.core.bases import CouplingState
+from dpf2.dpf_config import DPFConfig
+
+
+def _history():
+    return [
+        CouplingState(current=1.0, voltage=0.0),
+        CouplingState(current=2.0, voltage=0.0),
+    ]
+
+
+def test_rogowski_calibration_from_config(tmp_path):
+    cal = tmp_path / "rog.json"
+    cal.write_text(json.dumps({"scale": 2.0}))
+    cfg = DPFConfig.with_defaults()
+    cfg.diagnostics.rogowski_calibration_path = str(cal)
+    hist = _history()
+    out = rogowski_signal(hist, 1.0, cfg=cfg)
+    base = rogowski_signal(hist, 1.0)
+    assert out != base
+    assert all(abs(o - b * 2.0) < 1e-8 for o, b in zip(out, base))
+
+
+def test_angular_neutron_spectrum():
+    spec = angular_neutron_spectrum([0.0, 90.0, 180.0], 1.0, anisotropy=0.5)
+    assert spec[0] > spec[1]
+    assert spec[2] < spec[1]

--- a/tests/test_cli_diagnostics.py
+++ b/tests/test_cli_diagnostics.py
@@ -3,6 +3,7 @@ try:  # pragma: no cover - prefer real h5py
     import h5py  # type: ignore
 except Exception:  # pragma: no cover
     import h5py_stub as h5py  # type: ignore
+import json
 from click.testing import CliRunner
 
 from dpf2.cli.main import diagnostics
@@ -44,8 +45,12 @@ def test_cli_accepts_calibration_files(tmp_path):
     _write_history(hist_path)
     rog_cal = tmp_path / "rog.h5"
     bdot_cal = tmp_path / "bdot.h5"
+    sxr_cal = tmp_path / "sxr.h5"
+    tof_cal = tmp_path / "tof.h5"
     _write_calibration(rog_cal, "rogowski")
     _write_calibration(bdot_cal, "bdot")
+    _write_calibration(sxr_cal, "sxr")
+    _write_calibration(tof_cal, "tof")
 
     runner = CliRunner()
     result = runner.invoke(
@@ -57,6 +62,10 @@ def test_cli_accepts_calibration_files(tmp_path):
             str(rog_cal),
             "--bdot-cal",
             str(bdot_cal),
+            "--sxr-cal",
+            str(sxr_cal),
+            "--tof-cal",
+            str(tof_cal),
         ],
     )
     assert result.exit_code == 0, result.output
@@ -83,4 +92,20 @@ def test_cli_help_shows_calibration_options():
     result = runner.invoke(diagnostics, ["--help"])
     assert "--rogowski-cal" in result.output
     assert "--bdot-cal" in result.output
+    assert "--sxr-cal" in result.output
+    assert "--tof-cal" in result.output
+    assert "--anisotropy-plot" in result.output
+
+
+def test_cli_anisotropy_plot(tmp_path):
+    hist_path = tmp_path / "history.json"
+    _write_history(hist_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        diagnostics,
+        ["--history", str(hist_path), "--anisotropy-plot"],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert "anisotropy" in data
 

--- a/web/frontend/src/help.json
+++ b/web/frontend/src/help.json
@@ -9,6 +9,9 @@
   },
   "diagnostics": {
     "rogowskiCal": "Optional HDF5 calibration file for Rogowski coil; ideal response used if omitted",
-    "bdotCal": "Optional HDF5 calibration file for B-dot probe; ideal response used if omitted"
+    "bdotCal": "Optional HDF5 calibration file for B-dot probe; ideal response used if omitted",
+    "sxrCal": "Optional HDF5 calibration file for soft X-ray diode",
+    "tofCal": "Optional HDF5 calibration file for neutron TOF detector",
+    "anisotropyPlot": "Display simple forward/radial/backward anisotropy"
   }
 }


### PR DESCRIPTION
## Summary
- Allow synthetic signal generators to pull calibration files from `DPFConfig` and compute basic angular neutron spectra
- Provide directional neutron counts with uncertainty via new `directional_counts` helper
- Expose CLI options for additional calibration files and anisotropy plotting, updating GUI help accordingly

## Testing
- `pytest tests/diagnostics/test_synthetic_signals_config.py tests/diagnostics/test_neutron_yield.py tests/test_cli_diagnostics.py -q`
- `pytest -q` *(fails: ImportError: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68baff06ff8c832ab2aec05ff09d71f3