### PR TITLE
Enhance distributed circuit modeling with jitter and crowbar support

### DIFF
--- a/src/dpf2/circuit/distributed.py
+++ b/src/dpf2/circuit/distributed.py
@@ -37,6 +37,7 @@ __all__ = [
     "TriggeredSwitch",
     "CrowbarStage",
     "BlumleinSection",
+    "MultiSectionLine",
     "PlasmaInductance",
     "assemble_matrices",
 ]
@@ -245,6 +246,25 @@ class BlumleinSection:
 
 
 @dataclass
+class MultiSectionLine:
+    """Container representing a chain of transmission line segments.
+
+    Realistic drivers are often approximated by several lumped sections.  The
+    solver itself operates purely on individual ``TransmissionLineSegment``
+    objects; this helper merely groups a number of segments so they can be
+    passed around as a single object before being expanded by
+    :func:`assemble_matrices`.
+    """
+
+    sections: Sequence[TransmissionLineSegment]
+
+    def components(self) -> list[TransmissionLineSegment]:
+        """Return the contained segments as a list."""
+
+        return list(self.sections)
+
+
+@dataclass
 class PlasmaInductance:
     """Dynamic inductive branch sourced from an external plasma solver."""
 
@@ -273,7 +293,7 @@ class PlasmaInductance:
 
 
 def assemble_matrices(
-    segments: Sequence[TransmissionLineSegment],
+    segments: Sequence[Any],
     switches: Sequence[TriggeredSwitch] | None = None,
     t: float = 0.0,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -295,7 +315,21 @@ def assemble_matrices(
     tests.
     """
 
-    switches = list(switches or [])
+    # Expand composite helpers into raw segments and switches
+    seg_list: list[TransmissionLineSegment] = []
+    sw_list: list[TriggeredSwitch] = list(switches or [])
+    for item in segments:
+        if isinstance(item, BlumleinSection):
+            seg, trig = item.components()
+            seg_list.append(seg)
+            sw_list.append(trig)
+        elif isinstance(item, MultiSectionLine):
+            seg_list.extend(item.components())
+        else:
+            seg_list.append(item)  # type: ignore[arg-type]
+
+    segments = seg_list
+    switches = sw_list
 
     # Determine mapping from node identifiers to matrix indices
     nodes = set()

--- a/src/dpf2/circuit_config.py
+++ b/src/dpf2/circuit_config.py
@@ -345,7 +345,11 @@ class CircuitConfig(ConfigSectionBase):
         :class:`dpf2.circuit.distributed.TransmissionLineSegment`.
         """
 
-        from .circuit.distributed import TransmissionLineSegment, TriggeredSwitch
+        from .circuit.distributed import (
+            TransmissionLineSegment,
+            TriggeredSwitch,
+            CrowbarStage,
+        )
 
         def _convert_profile(
             prof: Optional[TimeVoltageProfile], scale_val: float
@@ -380,12 +384,29 @@ class CircuitConfig(ConfigSectionBase):
                     )
                 )
 
+        # Optional lumped driver sections approximating a multi‑section line
+        if self.rlc_sections:
+            node = 0
+            for sec in self.rlc_sections:
+                segments.append(
+                    TransmissionLineSegment(
+                        from_node=node,
+                        to_node=node + 1,
+                        length=1.0,
+                        L_per_m=sec.L,
+                        R_per_m=sec.R,
+                        C_per_m=sec.C,
+                    )
+                )
+                node += 1
+
         switches: List[TriggeredSwitch] = []
         if self.switches:
             for sw in self.switches:
                 trig = None
                 if sw.trigger_times:
                     trig = [tt * 1e-9 for tt in sw.trigger_times]
+                jitter = sw.jitter_std if sw.jitter_std else self.trigger_jitter_stddev
                 switches.append(
                     TriggeredSwitch(
                         from_node=sw.from_node,
@@ -397,10 +418,30 @@ class CircuitConfig(ConfigSectionBase):
                         R_parasitic=sw.R_parasitic * 1e-3,
                         C_parasitic=sw.C_parasitic * 1e-6,
                         trigger_times=trig,
-                        jitter_std=sw.jitter_std * 1e-9,
+                        jitter_std=jitter * 1e-9,
                         arc_resistance=sw.arc_resistance * 1e6,
                     )
                 )
+
+        # Optional crowbar stages tying the source to the return path
+        if self.crowbar_stages:
+            if segments:
+                src_node = segments[0].from_node
+                last_node = segments[-1].to_node
+            else:
+                src_node, last_node = 0, 1
+            for cb in self.crowbar_stages:
+                jitter = cb.jitter if cb.jitter else self.trigger_jitter_stddev
+                sw = CrowbarStage(
+                    src_node,
+                    last_node,
+                    cb.resistance,
+                    cb.trigger * 1e-9,
+                    jitter_std=jitter * 1e-9,
+                )
+                if cb.arc_resistance:
+                    sw.arc_resistance = cb.arc_resistance * 1e6
+                switches.append(sw)
 
         return segments, switches
 

--- a/src/dpf2/circuit_solver.py
+++ b/src/dpf2/circuit_solver.py
@@ -343,68 +343,15 @@ def run_circuit_simulation(
 
     # ------------------------------------------------------------------
     # Distributed multi‑section circuit handling
-    if getattr(cfg, "segments", None) or getattr(cfg, "rlc_sections", None) or getattr(cfg, "crowbar_stages", None):
-        segments: list[TransmissionLineSegment] = []
-        switches: list[CrowbarStage | TriggeredSwitch] = []
-
-        # Existing transmission line segments defined via configuration
-        if getattr(cfg, "segments", None) or getattr(cfg, "switches", None):
-            segs, sws = cfg.build_distributed_model()
-            segments.extend(segs)
-            switches.extend(sws)
-        if switches and getattr(cfg, "trigger_jitter_stddev", 0.0):
-            jitter = cfg.trigger_jitter_stddev * 1e-9
-            for sw in switches:
-                # Respect per-switch jitter specified at construction time
-                if getattr(sw, "jitter_std", 0.0) > 0.0:
-                    continue
-                if getattr(sw, "trigger_times", None):
-                    sw.trigger_times = [tt + _gauss(0.0, jitter) for tt in sw.trigger_times]
-                    sw.trigger_times.sort()
-                    sw._next_trigger = 0
-
-        # Optional multi‑section lumped elements
-        secs = getattr(cfg, "rlc_sections", None)
-        if secs:
-            node = 0
-            for sec in secs:
-                L = sec.get("L", 0.0)
-                R = sec.get("R", 0.0)
-                C = sec.get("C", 0.0)
-                segments.append(
-                    TransmissionLineSegment(
-                        from_node=node,
-                        to_node=node + 1,
-                        length=1.0,
-                        L_per_m=L,
-                        R_per_m=R,
-                        C_per_m=C,
-                    )
-                )
-                node += 1
-
-        # Optional crowbar stages connecting source to return
-        cbs = getattr(cfg, "crowbar_stages", None)
-        if cbs:
-            if segments:
-                src_node = segments[0].from_node
-                last_node = segments[-1].to_node
-            else:
-                src_node, last_node = 0, 1
-            for stage in cbs:
-                res = stage.get("resistance", 0.0)
-                trig = stage.get("trigger", 0.0) * 1e-9
-                jitter = stage.get(
-                    "jitter", getattr(cfg, "trigger_jitter_stddev", 0.0)
-                ) * 1e-9
-                arc = stage.get("arc_resistance", 0.0) * 1e6
-                cb = CrowbarStage(
-                    src_node, last_node, res, trig, jitter_std=jitter
-                )
-                if arc:
-                    cb.arc_resistance = arc
-                switches.append(cb)
-
+    if (
+        getattr(cfg, "segments", None)
+        or getattr(cfg, "rlc_sections", None)
+        or getattr(cfg, "crowbar_stages", None)
+        or getattr(cfg, "switches", None)
+    ):
+        # ``build_distributed_model`` now handles optional multi‑section
+        # elements, crowbar branches and per‑switch jitter.
+        segments, switches = cfg.build_distributed_model()
         dt = t_end * 1e-6 / (num_points - 1)
         sol = solve_distributed_circuit(
             segments,

--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -968,8 +968,21 @@ class HallMHDSolver(PlasmaSolverBase):
         )
 
         if self.circuit is not None:
+            # Recompute the plasma inductance using the prospective current so
+            # the circuit solver receives a self‑consistent ``Lp`` for this
+            # timestep.
+            def _refresh(I: float, V: float) -> CouplingState:
+                try:
+                    Lp = float(self.compute_plasma_inductance(new_state, I))
+                except Exception:
+                    Lp = self.inductance
+                return CouplingState(Lp=Lp, emf=self.back_emf, current=I, voltage=V)
+
             updated = self.circuit.step(
-                self.circuit_feedback, self.last_voltage_spike, dt
+                self.circuit_feedback,
+                self.last_voltage_spike,
+                dt,
+                update_coupling=_refresh,
             )
             self.current = updated.current
             self.back_emf = updated.voltage


### PR DESCRIPTION
## Summary
- Support multi-section transmission lines via `MultiSectionLine` and expand `assemble_matrices` to flatten composite sections and Blumlein blocks
- Centralize distributed network construction with crowbar stages and switch jitter in `CircuitConfig.build_distributed_model`
- Streamline circuit solver to use the new builder and add plasma inductance feedback each timestep

## Testing
- `python -m py_compile src/dpf2/circuit/distributed.py src/dpf2/circuit_solver.py src/dpf2/hall_mhd_solver.py src/dpf2/circuit_config.py`
- `pytest` *(fails: Missing dependencies for many test modules)*


------
https://chatgpt.com/codex/tasks/task_e_68baff0389d8832ab8fa63893f308924