### PR TITLE
Implement geometry-aware inductance and snowplow pinch model

### DIFF
--- a/src/dpf2/hall_mhd_solver.py
+++ b/src/dpf2/hall_mhd_solver.py
@@ -44,6 +44,10 @@ from .diagnostics.quality_dashboard import QualityDashboard
 from .diagnostics.modes import azimuthal_mode_spectrum
 from .physics.lower_hybrid_drift import LowerHybridDrift
 from .physics.hall_mhd import LHDIResistivity
+from .physics.inductance import (
+    CoaxialGeometry,
+    dynamic_inductance_with_derivatives,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -351,6 +355,11 @@ class HallMHDSolver(PlasmaSolverBase):
     current: float = 0.0
     inductance: float = 0.0
     back_emf: float = 0.0
+    geometry: CoaxialGeometry = field(
+        default_factory=lambda: CoaxialGeometry(
+            anode_radius=7.5e-3, cathode_radius=4.0e-2, anode_length=0.18
+        )
+    )
     circuit_feedback: CouplingState | None = field(init=False, default=None)
     anomalous_resistivity: Callable[[np.ndarray], np.ndarray | tuple[np.ndarray, np.ndarray]] | None = None
     lower_hybrid_drift: Callable[[np.ndarray], np.ndarray | tuple[np.ndarray, np.ndarray]] | None = None
@@ -385,6 +394,16 @@ class HallMHDSolver(PlasmaSolverBase):
     cart_comm: Any | None = field(init=False, default=None)
     quality: QualityDashboard | None = None
     step_count: int = 0
+    sheath_radius: float = field(init=False, default=0.0)
+    sheath_position: float = field(init=False, default=0.0)
+    sheath_velocity_r: float = field(init=False, default=0.0)
+    sheath_velocity_z: float = field(init=False, default=0.0)
+    _dL_dz: float = field(init=False, default=0.0)
+    _dL_dr: float = field(init=False, default=0.0)
+    _coord_cache: tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray] | None = field(
+        init=False, default=None
+    )
+    _coord_shape: tuple[int, int, int] | None = field(init=False, default=None)
 
     def __post_init__(self) -> None:
         """Initialise MPI cartesian communicator for domain decomposition."""
@@ -961,7 +980,9 @@ class HallMHDSolver(PlasmaSolverBase):
         # Expose plasma inductance and induced EMF for circuit coupling
         L_new = self.compute_plasma_inductance(new_state, current)
         self.inductance = L_new
-        emf = 0.0
+        emf = -current * (
+            self._dL_dz * self.sheath_velocity_z + self._dL_dr * self.sheath_velocity_r
+        )
         self.back_emf = emf
         self.circuit_feedback = CouplingState(
             Lp=L_new, emf=emf, current=current, voltage=voltage
@@ -976,7 +997,11 @@ class HallMHDSolver(PlasmaSolverBase):
                     Lp = float(self.compute_plasma_inductance(new_state, I))
                 except Exception:
                     Lp = self.inductance
-                return CouplingState(Lp=Lp, emf=self.back_emf, current=I, voltage=V)
+                emf_candidate = -I * (
+                    self._dL_dz * self.sheath_velocity_z
+                    + self._dL_dr * self.sheath_velocity_r
+                )
+                return CouplingState(Lp=Lp, emf=emf_candidate, current=I, voltage=V)
 
             updated = self.circuit.step(
                 self.circuit_feedback,
@@ -1088,24 +1113,80 @@ class HallMHDSolver(PlasmaSolverBase):
             return self.inductance
 
     def compute_plasma_inductance(self, state: MHDState, current: float, cell_volume: float = 1.0) -> float:
-        """Estimate plasma inductance from magnetic energy.
+        """Return geometry-aware plasma inductance and update sheath metrics."""
 
-        Parameters
-        ----------
-        state : MHDState
-            Current plasma state.
-        current : float
-            Circuit current in amperes.
-        cell_volume : float, optional
-            Volume of a single cell, by default 1.0.
+        if state is None:
+            return self.inductance
 
-        Returns
-        -------
-        float
-            Estimated inductance in henries.
-        """
-        B2 = np.sum(state.B ** 2)
-        magnetic_energy = B2 * cell_volume / (2 * mu_0)
-        if current == 0.0:
-            return 0.0
-        return 2 * magnetic_energy / (current ** 2)
+        r_mean, z_mean, vr_mean, vz_mean = self._estimate_sheath_state(state)
+        L, dL_dz, dL_dr = dynamic_inductance_with_derivatives(
+            z_mean, r_mean, self.geometry
+        )
+        self.sheath_radius = r_mean
+        self.sheath_position = z_mean
+        self.sheath_velocity_r = vr_mean
+        self.sheath_velocity_z = vz_mean
+        self._dL_dz = dL_dz
+        self._dL_dr = dL_dr
+        return L
+
+    # ------------------------------------------------------------------
+    def _ensure_coordinate_cache(
+        self, shape: Tuple[int, int, int]
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        if self._coord_shape == tuple(shape) and self._coord_cache is not None:
+            return self._coord_cache
+
+        nx, ny, nz = shape
+        r_max = self.geometry.cathode_radius
+        z_max = self.geometry.anode_length
+
+        def _centered(axis_points: int, lo: float, hi: float) -> np.ndarray:
+            if axis_points <= 1:
+                return np.array([(lo + hi) / 2.0])
+            arr = np.linspace(lo, hi, axis_points, endpoint=False)
+            delta = (hi - lo) / axis_points
+            return arr + 0.5 * delta
+
+        x = _centered(nx, -r_max, r_max)
+        y = _centered(ny, -r_max, r_max)
+        z = _centered(nz, 0.0, z_max)
+
+        X, Y, Z = np.meshgrid(x, y, z, indexing="ij")
+        R = np.sqrt(X**2 + Y**2)
+        self._coord_cache = (R, Z, X, Y)
+        self._coord_shape = tuple(shape)
+        return self._coord_cache
+
+    # ------------------------------------------------------------------
+    def _estimate_sheath_state(self, state: MHDState) -> tuple[float, float, float, float]:
+        R, Z, X, Y = self._ensure_coordinate_cache(state.rho.shape)
+        rho = np.asarray(state.rho)
+        weights = np.clip(rho, a_min=0.0, a_max=None)
+        total = float(np.sum(weights))
+        if not np.isfinite(total) or total <= 0.0:
+            r_mean = 0.5 * (self.geometry.anode_radius + self.geometry.cathode_radius)
+            z_mean = 0.0
+            vr_mean = 0.0
+            vz_mean = 0.0
+            return r_mean, z_mean, vr_mean, vz_mean
+
+        r_mean = float(np.sqrt(np.sum(weights * R**2) / total))
+        z_mean = float(np.sum(weights * Z) / total)
+
+        momentum = np.asarray(state.mom)
+        denom = np.maximum(rho, 1e-30)
+        vx = momentum[..., 0] / denom
+        vy = momentum[..., 1] / denom
+        vz = momentum[..., 2] / denom
+
+        radial_speed = np.zeros_like(R)
+        mask = R > 1e-9
+        radial_speed[mask] = (vx[mask] * X[mask] + vy[mask] * Y[mask]) / R[mask]
+        vr_mean = float(np.sum(weights * radial_speed) / total)
+        vz_mean = float(np.sum(weights * vz) / total)
+
+        r_min = 0.2 * self.geometry.anode_radius
+        r_mean = float(np.clip(r_mean, r_min, self.geometry.cathode_radius))
+        z_mean = float(np.clip(z_mean, 0.0, self.geometry.anode_length))
+        return r_mean, z_mean, vr_mean, vz_mean

--- a/src/dpf2/physics/inductance.py
+++ b/src/dpf2/physics/inductance.py
@@ -1,0 +1,103 @@
+"""Geometry-aware plasma inductance utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import numpy as np
+
+try:  # pragma: no cover - SciPy optional during tests
+    from scipy.constants import mu_0
+except Exception:  # pragma: no cover
+    mu_0 = 4e-7 * np.pi
+
+__all__ = [
+    "CoaxialGeometry",
+    "axial_inductance",
+    "radial_inductance",
+    "dynamic_inductance",
+    "dynamic_inductance_with_derivatives",
+]
+
+
+@dataclass(frozen=True)
+class CoaxialGeometry:
+    """Electrode geometry description used by the inductance model."""
+
+    anode_radius: float
+    cathode_radius: float
+    anode_length: float
+    insulator_length: float = 0.0
+    pinch_length: float | None = None
+    end_correction: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.anode_radius <= 0.0:
+            raise ValueError("anode_radius must be positive")
+        if self.cathode_radius <= self.anode_radius:
+            raise ValueError("cathode_radius must exceed anode_radius")
+        if self.anode_length <= 0.0:
+            raise ValueError("anode_length must be positive")
+
+    @property
+    def pinch_span(self) -> float:
+        if self.pinch_length is not None:
+            return self.pinch_length
+        return 0.2 * self.anode_length
+
+    @property
+    def axial_gradient(self) -> float:
+        return mu_0 / (2.0 * np.pi) * np.log(self.cathode_radius / self.anode_radius)
+
+    @property
+    def radial_gradient_scale(self) -> float:
+        return mu_0 * self.pinch_span / (2.0 * np.pi)
+
+    @property
+    def insulator_inductance(self) -> float:
+        if self.insulator_length <= 0.0:
+            return 0.0
+        return self.axial_gradient * self.insulator_length
+
+
+def _clip(value: float | np.ndarray, lo: float, hi: float) -> float | np.ndarray:
+    return np.clip(value, lo, hi)
+
+
+def axial_inductance(z: float | np.ndarray, geom: CoaxialGeometry) -> float | np.ndarray:
+    z_eff = _clip(z, 0.0, geom.anode_length)
+    return geom.axial_gradient * z_eff
+
+
+def radial_inductance(r: float | np.ndarray, geom: CoaxialGeometry) -> float | np.ndarray:
+    r_min = 0.1 * geom.anode_radius
+    r_eff = _clip(r, r_min, geom.cathode_radius)
+    return geom.radial_gradient_scale * np.log(geom.cathode_radius / r_eff)
+
+
+def dynamic_inductance(
+    z: float | np.ndarray,
+    r: float | np.ndarray,
+    geom: CoaxialGeometry,
+) -> float | np.ndarray:
+    return (
+        geom.end_correction
+        + geom.insulator_inductance
+        + axial_inductance(z, geom)
+        + radial_inductance(r, geom)
+    )
+
+
+def dynamic_inductance_with_derivatives(
+    z: float,
+    r: float,
+    geom: CoaxialGeometry,
+) -> Tuple[float, float, float]:
+    r_min = 0.1 * geom.anode_radius
+    r_eff = float(_clip(r, r_min, geom.cathode_radius))
+    L = dynamic_inductance(z, r_eff, geom)
+    dL_dz = geom.axial_gradient if 0.0 < z < geom.anode_length else 0.0
+    dL_dr = -geom.radial_gradient_scale / r_eff
+    return L, dL_dz, dL_dr
+

--- a/src/dpf2/pinch_models.py
+++ b/src/dpf2/pinch_models.py
@@ -22,12 +22,25 @@ from .eos import RealGasEOS
 from .fusion import bosch_hale_dd
 from .hall_mhd_solver import HallMHDSolver, MHDState
 from .physics import PicDriver
+from .physics.inductance import (
+    CoaxialGeometry,
+    dynamic_inductance,
+    dynamic_inductance_with_derivatives,
+)
 from .diagnostics import (
     plasma_beta,
     alfven_mach_number,
     magnetic_reynolds_number,
     lundquist_number,
 )
+
+try:  # pragma: no cover - optional constants
+    from scipy.constants import mu_0, k as k_B, e as q_e, m_p
+except Exception:  # pragma: no cover
+    mu_0 = 4e-7 * np.pi
+    k_B = 1.380649e-23
+    q_e = 1.602176634e-19
+    m_p = 1.67262192369e-27
 
 __all__ = [
     "PinchModelBase",
@@ -36,6 +49,7 @@ __all__ = [
     "SemiAnalyticPinchModel",
     "MHDPinchModel",
     "HybridPinchModel",
+    "SnowplowPinchModel",
 ]
 
 
@@ -54,6 +68,7 @@ class PinchResult:
     lundquist: np.ndarray | None = None
     voltage: np.ndarray | None = None
     current: np.ndarray | None = None
+    rayleigh_taylor_growth: np.ndarray | None = None
 
 
 class PinchModelBase:
@@ -162,6 +177,153 @@ class SemiAnalyticPinchModel(PinchModelBase):
             alfven_mach=alfven,
             magnetic_reynolds=rm,
             lundquist=s,
+        )
+
+
+class SnowplowPinchModel(PinchModelBase):
+    """Two-stage slug model with Rayleigh-Taylor diagnostics."""
+
+    def __init__(
+        self,
+        geometry: CoaxialGeometry | None = None,
+        fill_pressure: float = 1.5e3,
+        fill_temperature: float = 300.0,
+        species_mass: float = 2.0 * m_p,
+        mode_number: int = 12,
+        resistivity: float = 5e-6,
+    ) -> None:
+        self.geometry = geometry or CoaxialGeometry(
+            anode_radius=8.0e-3, cathode_radius=4.0e-2, anode_length=0.18
+        )
+        self.fill_pressure = fill_pressure
+        self.fill_temperature = fill_temperature
+        self.species_mass = species_mass
+        self.mode_number = mode_number
+        self.resistivity = resistivity
+        self._annulus_area = np.pi * (
+            self.geometry.cathode_radius**2 - self.geometry.anode_radius**2
+        )
+        self._rho0 = (
+            fill_pressure * species_mass / (k_B * max(fill_temperature, 1.0))
+        )
+        self._mass_floor = 1e-9
+
+    def run(self, time: Iterable[float], current: Iterable[float]) -> PinchResult:
+        t = np.asarray(time)
+        I = np.asarray(current)
+        if t.ndim != 1 or I.ndim != 1 or len(t) != len(I):
+            raise ValueError("time and current must be one-dimensional arrays of equal length")
+
+        geom = self.geometry
+        radius = np.zeros_like(t)
+        axial = np.zeros_like(t)
+        temperature = np.zeros_like(t)
+        pressure = np.zeros_like(t)
+        beta_hist = np.zeros_like(t)
+        alfven_hist = np.zeros_like(t)
+        rm_hist = np.zeros_like(t)
+        s_hist = np.zeros_like(t)
+        energy_hist = np.zeros_like(t)
+        rt_hist = np.zeros_like(t)
+        voltage_hist = np.zeros_like(t)
+
+        r = geom.cathode_radius
+        z = 0.0
+        vr = 0.0
+        vz = 0.0
+        mass = self._mass_floor
+        stage = "axial"
+        neutron_yield = 0.0
+        rt_integral = 0.0
+
+        for k, tk in enumerate(t):
+            I_k = float(I[k])
+            r_eff = max(r, 0.5 * geom.anode_radius)
+            volume = max(np.pi * r_eff**2 * geom.pinch_span, 1e-12)
+            density = mass / volume
+            n_i = max(density / self.species_mass, 1e6)
+            B = mu_0 * I_k / (2.0 * np.pi * max(r_eff, 1e-4))
+            magnetic_pressure = B**2 / (2.0 * mu_0)
+            dynamic_pressure = 0.5 * density * (vr**2 + vz**2)
+            pressure_k = magnetic_pressure + dynamic_pressure + self.fill_pressure
+            T_K = max(pressure_k / (n_i * k_B), 1.0)
+            T_keV = T_K * k_B / (1e3 * q_e)
+            reactivity = bosch_hale_dd(max(T_keV, 1e-3))
+            rate = 0.25 * n_i**2 * reactivity
+            if k + 1 < len(t):
+                dt = t[k + 1] - tk
+            else:
+                dt = (t[k] - t[k - 1]) if k > 0 else 0.0
+            neutron_yield += rate * volume * max(dt, 0.0)
+
+            Lp, dL_dz, dL_dr = dynamic_inductance_with_derivatives(z, r_eff, geom)
+            dL_dt = dL_dz * vz + dL_dr * vr
+            voltage_hist[k] = -I_k * dL_dt
+            energy_hist[k] = 0.5 * Lp * I_k**2
+
+            radius[k] = r
+            axial[k] = z
+            temperature[k] = T_K
+            pressure[k] = pressure_k
+            beta_hist[k] = plasma_beta(n_i, T_K, B)
+            v_char = float(np.sqrt(vr**2 + vz**2))
+            alfven_hist[k] = alfven_mach_number(v_char, B, n_i)
+            sigma = 1.0 / max(self.resistivity, 1e-8)
+            rm_hist[k] = magnetic_reynolds_number(max(abs(v_char), 1e-9), r_eff, sigma)
+            s_hist[k] = lundquist_number(B, n_i, r_eff, sigma)
+            rt_hist[k] = rt_integral
+
+            if k == len(t) - 1:
+                continue
+
+            dt = t[k + 1] - tk
+            if dt <= 0.0:
+                continue
+
+            if stage == "axial" and z < geom.anode_length:
+                dm_dt = self._rho0 * self._annulus_area * max(vz, 0.0)
+                F_mag = 0.5 * I_k**2 * geom.axial_gradient
+                F_back = self.fill_pressure * self._annulus_area
+                accel = (F_mag - F_back - vz * dm_dt) / max(mass, self._mass_floor)
+                vz_new = vz + accel * dt
+                z += 0.5 * (vz + vz_new) * dt
+                mass += dm_dt * dt
+                vz = vz_new
+                if z >= geom.anode_length:
+                    z = geom.anode_length
+                    stage = "radial"
+                    vz = 0.0
+            else:
+                surface = 2.0 * np.pi * r_eff * geom.pinch_span
+                F_mag = 0.5 * I_k**2 * (-geom.radial_gradient_scale / r_eff)
+                F_back = self.fill_pressure * surface
+                accel = (F_mag - F_back) / max(mass, self._mass_floor)
+                vr_new = vr + accel * dt
+                r += 0.5 * (vr + vr_new) * dt
+                r = max(r, 0.4 * geom.anode_radius)
+                if r <= 0.4 * geom.anode_radius:
+                    vr_new = 0.0
+                vr = vr_new
+                if accel < 0.0:
+                    k_mode = self.mode_number / max(r, geom.anode_radius * 0.4)
+                    gamma = np.sqrt(abs(accel) * k_mode)
+                    rt_integral += gamma * dt
+
+        return PinchResult(
+            t,
+            radius,
+            temperature,
+            pressure,
+            float(neutron_yield),
+            axial_position=axial,
+            energy=energy_hist,
+            beta=beta_hist,
+            alfven_mach=alfven_hist,
+            magnetic_reynolds=rm_hist,
+            lundquist=s_hist,
+            voltage=voltage_hist,
+            current=I,
+            rayleigh_taylor_growth=rt_hist,
         )
 
 

--- a/tests/test_inductance.py
+++ b/tests/test_inductance.py
@@ -1,0 +1,75 @@
+"""Unit tests for the geometry-aware inductance helpers."""
+
+from __future__ import annotations
+
+import math
+
+try:  # pragma: no cover - SciPy optional during tests
+    from scipy.constants import mu_0
+except Exception:  # pragma: no cover
+    mu_0 = 4e-7 * math.pi
+
+from dpf2.physics.inductance import (
+    CoaxialGeometry,
+    axial_inductance,
+    dynamic_inductance,
+    dynamic_inductance_with_derivatives,
+    radial_inductance,
+)
+
+
+def test_axial_inductance_matches_coaxial_expression() -> None:
+    geom = CoaxialGeometry(anode_radius=0.01, cathode_radius=0.05, anode_length=0.2)
+    z = 0.12
+    expected = mu_0 / (2.0 * math.pi) * z * math.log(geom.cathode_radius / geom.anode_radius)
+    assert math.isclose(axial_inductance(z, geom), expected, rel_tol=1e-12)
+
+
+def test_radial_inductance_matches_log_scaling() -> None:
+    geom = CoaxialGeometry(
+        anode_radius=0.01,
+        cathode_radius=0.05,
+        anode_length=0.2,
+        pinch_length=0.03,
+    )
+    r = 0.02
+    expected = (
+        mu_0
+        * geom.pinch_span
+        / (2.0 * math.pi)
+        * math.log(geom.cathode_radius / r)
+    )
+    assert math.isclose(radial_inductance(r, geom), expected, rel_tol=1e-12)
+
+
+def test_dynamic_inductance_combines_terms() -> None:
+    geom = CoaxialGeometry(
+        anode_radius=0.01,
+        cathode_radius=0.05,
+        anode_length=0.2,
+        insulator_length=0.01,
+        pinch_length=0.03,
+        end_correction=5e-9,
+    )
+    z = 0.15
+    r = 0.018
+    total = dynamic_inductance(z, r, geom)
+    expected = (
+        geom.end_correction
+        + geom.insulator_inductance
+        + axial_inductance(z, geom)
+        + radial_inductance(r, geom)
+    )
+    assert math.isclose(total, expected, rel_tol=1e-12)
+
+
+def test_dynamic_inductance_derivatives() -> None:
+    geom = CoaxialGeometry(anode_radius=0.01, cathode_radius=0.05, anode_length=0.2)
+    z = 0.1
+    r = 0.03
+    L, dL_dz, dL_dr = dynamic_inductance_with_derivatives(z, r, geom)
+    assert math.isclose(L, dynamic_inductance(z, r, geom), rel_tol=1e-12)
+    expected_dz = mu_0 / (2.0 * math.pi) * math.log(geom.cathode_radius / geom.anode_radius)
+    assert math.isclose(dL_dz, expected_dz, rel_tol=1e-12)
+    expected_dr = -geom.radial_gradient_scale / r
+    assert math.isclose(dL_dr, expected_dr, rel_tol=1e-12)

--- a/tests/test_snowplow_pinch.py
+++ b/tests/test_snowplow_pinch.py
@@ -1,0 +1,35 @@
+"""Regression tests for the snowplow pinch model."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from dpf2.physics.inductance import dynamic_inductance
+from dpf2.pinch_models import SnowplowPinchModel
+
+
+def _synthetic_waveform(num: int = 400) -> tuple[np.ndarray, np.ndarray]:
+    t = np.linspace(0.0, 2.0e-6, num)
+    I = 1.8e6 * np.sin(np.pi * t / t[-1]) ** 2
+    return t, I
+
+
+def test_snowplow_transitions_and_radius_collapse() -> None:
+    model = SnowplowPinchModel()
+    t, I = _synthetic_waveform()
+    result = model.run(t, I)
+
+    assert result.radius[0] == model.geometry.cathode_radius
+    assert result.axial_position[-1] >= model.geometry.anode_length * 0.95
+    assert result.radius[-1] < model.geometry.cathode_radius * 0.7
+    assert np.all(np.diff(result.rayleigh_taylor_growth) >= -1e-6)
+    assert result.neutron_yield > 0.0
+
+
+def test_snowplow_inductance_consistency() -> None:
+    model = SnowplowPinchModel()
+    t, I = _synthetic_waveform()
+    result = model.run(t, I)
+    Lp = dynamic_inductance(result.axial_position, result.radius, model.geometry)
+    energy_expected = 0.5 * Lp * I**2
+    assert np.allclose(result.energy, energy_expected, rtol=1e-6, atol=1e-9)


### PR DESCRIPTION
## Summary
- add an analytic coaxial inductance model with geometry-aware derivatives
- hook the Hall-MHD circuit feedback to the new inductance and back-EMF estimates
- introduce a two-stage snowplow pinch model with Rayleigh-Taylor tracking
- add regression tests for the inductance helper functions and snowplow solver

## Testing
- pytest tests/test_inductance.py tests/test_snowplow_pinch.py -q

------
https://chatgpt.com/codex/tasks/task_e_68c94f3c51e4832aadf9d07efc11bc8e