### PR TITLE
Add surrogate guardrails and OOD detection

### DIFF
--- a/src/dpf2/ai/surrogate.py
+++ b/src/dpf2/ai/surrogate.py
@@ -81,25 +81,41 @@ class SurrogateModel(ABC):
         self._check_domain(inputs_iter)
         return self._predict(inputs)
 
-    def predict_with_uncertainty(
+    def predict_with_guardrails(
         self, inputs: Any
-    ) -> tuple[float, tuple[float, float]] | list[tuple[float, tuple[float, float]]]:
-        """Return prediction and conformal uncertainty band for ``inputs``."""
+    ) -> tuple[float, tuple[float, float], float] | list[tuple[float, tuple[float, float], float]]:
+        """Return prediction, uncertainty band and OOD distance for ``inputs``."""
 
         if isinstance(inputs, (list, tuple)):
             arr = np.array([[float(v)] for v in inputs])
             preds = self.predict(arr)
-            preds_list = [float(p[0]) if hasattr(p, "__getitem__") else float(p) for p in preds]
+            preds_list = [
+                float(p[0]) if hasattr(p, "__getitem__") else float(p) for p in preds
+            ]
             dists = [self._mahalanobis_distance([float(v)]) for v in inputs]
-            bands = [0.0 if self._quantile is None else self._quantile * (1.0 + d) for d in dists]
-            return [(p, (p - b, p + b)) for p, b in zip(preds_list, bands)]
+            bands = [
+                0.0 if self._quantile is None else self._quantile * (1.0 + d)
+                for d in dists
+            ]
+            return [(p, (p - b, p + b), d) for p, b, d in zip(preds_list, bands, dists)]
         else:
             val = float(inputs)
             arr = np.array([[val]])
             pred = float(self.predict(arr)[0][0])
             dist = self._mahalanobis_distance([val])
             band = 0.0 if self._quantile is None else self._quantile * (1.0 + dist)
-            return pred, (pred - band, pred + band)
+            return pred, (pred - band, pred + band), dist
+
+    def predict_with_uncertainty(
+        self, inputs: Any
+    ) -> tuple[float, tuple[float, float]] | list[tuple[float, tuple[float, float]]]:
+        """Return prediction and conformal uncertainty band for ``inputs``."""
+
+        res = self.predict_with_guardrails(inputs)
+        if isinstance(res, list):
+            return [(p, band) for p, band, _ in res]
+        pred, band, _ = res
+        return pred, band
 
     def _mahalanobis_distance(self, x: Any) -> float:
         if self._feature_mean is None or self._inv_cov is None:

--- a/src/dpf2/ai/training.py
+++ b/src/dpf2/ai/training.py
@@ -50,8 +50,13 @@ def train_torch_model(
     optimizer = torch.optim.Adam(model.parameters(), lr=lr)
     loss_fn = torch.nn.MSELoss()
 
-    for _ in range(epochs):
+    features: list[np.ndarray] = []
+    targets: list[np.ndarray] = []
+    for epoch in range(epochs):
         for xb, yb in dataloader:
+            if epoch == 0:
+                features.append(xb.detach().cpu().numpy())
+                targets.append(yb.detach().cpu().numpy())
             optimizer.zero_grad()
             pred = model(xb)
             loss = loss_fn(pred, yb)
@@ -68,6 +73,21 @@ def train_torch_model(
             count += len(xb)
     mse = total_loss / max(count, 1)
 
+    # Domain statistics --------------------------------------------------
+    x_all = np.concatenate(features, axis=0) if features else np.empty((0, 1))
+    y_all = np.concatenate(targets, axis=0) if targets else np.empty((0, 1))
+    feature_mean = x_all.mean(axis=0) if x_all.size else np.zeros(1)
+    feature_cov = np.cov(x_all, rowvar=False) if x_all.size else np.zeros((1, 1))
+    cov_inv = np.linalg.pinv(feature_cov) if x_all.size else np.zeros((1, 1))
+    diff = x_all - feature_mean
+    distances = np.einsum("ij,jk,ik->i", diff, cov_inv, diff) if x_all.size else np.zeros(1)
+    mahal_threshold = float(np.quantile(distances, 0.99)) if distances.size else 0.0
+
+    with torch.no_grad():
+        preds = model(torch.as_tensor(x_all, dtype=torch.float32)) if x_all.size else torch.zeros_like(torch.as_tensor(y_all))
+    resid = np.abs(y_all - preds.cpu().numpy()) if x_all.size else np.zeros(1)
+    quantile = float(np.quantile(resid, 0.95)) if resid.size else 0.0
+
     if metadata is not None:
         metadata.ml_metadata = MLMetadata(
             model=type(model).__name__,
@@ -77,7 +97,15 @@ def train_torch_model(
         )
         metadata.ml_result = MLResult(model_error=mse)
 
-    return model, {"mse": mse}
+    metrics = {
+        "mse": mse,
+        "feature_mean": feature_mean.tolist(),
+        "feature_cov": feature_cov.tolist() if feature_cov.ndim == 2 else [float(feature_cov)],
+        "mahalanobis_threshold": mahal_threshold,
+        "quantile": quantile,
+    }
+
+    return model, metrics
 
 
 __all__ = ["load_numpy_dataset", "train_torch_model"]

--- a/src/dpf2/gui/qt_sweep.py
+++ b/src/dpf2/gui/qt_sweep.py
@@ -97,6 +97,8 @@ def plot_yield_vs_param(
 
     vals = sorted(metrics.keys())
     y_vals = [metrics[v].get("yield", 0.0) for v in vals]
+    y_lo = [metrics[v].get("yield_lo", metrics[v].get("yield", 0.0)) for v in vals]
+    y_hi = [metrics[v].get("yield_hi", metrics[v].get("yield", 0.0)) for v in vals]
     s_vals = [metrics[v].get("S", 0.0) for v in vals]
     colors = ["red" if abs(s - gv_S) > 0.5 else "blue" for s in s_vals]
 
@@ -107,7 +109,8 @@ def plot_yield_vs_param(
     best_S = s_vals[best_idx] if vals else 0.0
 
     plt.figure()
-    plt.scatter(vals, y_vals, c=colors)
+    for x, y, lo, hi, c in zip(vals, y_vals, y_lo, y_hi, colors):
+        plt.errorbar([x], [y], yerr=[[y - lo], [hi - y]], fmt="o", color=c)
     plt.scatter(
         [best_val],
         [best_yield],

--- a/src/dpf2/optimization/param_sweep.py
+++ b/src/dpf2/optimization/param_sweep.py
@@ -14,7 +14,7 @@ warning is emitted so that callers can decide how to handle missing results.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Iterable, Tuple
+from typing import Any, Dict, Iterable, Tuple
 import warnings
 
 from ..core.config import DPFConfig
@@ -28,8 +28,8 @@ class OutOfDomainError(Exception):
 # A prediction consists of a value and its (lo, hi) conformal band
 Prediction = Tuple[float, Tuple[float, float]]
 
-# Each sweep result stores the yield and pinch time predictions
-SweepResult = Dict[str, Prediction]
+# Each sweep result stores predictions and optional guardrail metrics
+SweepResult = Dict[str, Any]
 
 
 def run_parametric_sweep(
@@ -68,7 +68,8 @@ def run_parametric_sweep(
     Dict[float, SweepResult]
         Mapping of parameter values to prediction dictionaries.  Each
         dictionary contains entries ``{"yield": (y, (lo, hi)), "pinch_time":
-        (p, (lo, hi))}``.
+        (p, (lo, hi)), "yield_ood": d_y, "pinch_time_ood": d_p}`` where the
+        ``*_ood`` keys hold Mahalanobis distances from the training domain.
     """
 
     model_dir = Path(__file__).resolve().parents[2] / "ai" / "surrogates"
@@ -105,8 +106,8 @@ def run_parametric_sweep(
     results: Dict[float, SweepResult] = {}
     for val in values:
         try:
-            y_pred, y_band = y_model.predict_with_uncertainty(val)
-            p_pred, p_band = p_model.predict_with_uncertainty(val)
+            y_pred, y_band, y_dist = y_model.predict_with_guardrails(val)
+            p_pred, p_band, p_dist = p_model.predict_with_guardrails(val)
         except OutOfDomainError as exc:
             warnings.warn(str(exc), OptimizationWarning, stacklevel=2)
             continue
@@ -114,6 +115,8 @@ def run_parametric_sweep(
         results[float(val)] = {
             "yield": (float(y_pred), (float(y_band[0]), float(y_band[1]))),
             "pinch_time": (float(p_pred), (float(p_band[0]), float(p_band[1]))),
+            "yield_ood": float(y_dist),
+            "pinch_time_ood": float(p_dist),
         }
 
     return results
@@ -137,6 +140,8 @@ def compute_sweep_metrics(
     for val, preds in results.items():
         y_pred, y_band = preds.get("yield", (0.0, (0.0, 0.0)))
         p_pred, p_band = preds.get("pinch_time", (0.0, (0.0, 0.0)))
+        y_ood = preds.get("yield_ood", 0.0)
+        p_ood = preds.get("pinch_time_ood", 0.0)
         metric: Dict[str, float] = {
             "yield": float(y_pred),
             "pinch_time": float(p_pred),
@@ -144,6 +149,8 @@ def compute_sweep_metrics(
             "yield_hi": float(y_band[1]),
             "pinch_time_lo": float(p_band[0]),
             "pinch_time_hi": float(p_band[1]),
+            "yield_ood": float(y_ood),
+            "pinch_time_ood": float(p_ood),
             "efficiency": 0.0,
         }
 
@@ -169,13 +176,19 @@ def plot_metric_overlay(
     yields = [metrics[v]["yield"] for v in vals]
     pinch = [metrics[v].get("pinch_time", 0.0) for v in vals]
     effs = [metrics[v].get("efficiency", 0.0) for v in vals]
+    y_lo = [metrics[v].get("yield_lo", metrics[v]["yield"]) for v in vals]
+    y_hi = [metrics[v].get("yield_hi", metrics[v]["yield"]) for v in vals]
+    p_lo = [metrics[v].get("pinch_time_lo", metrics[v].get("pinch_time", 0.0)) for v in vals]
+    p_hi = [metrics[v].get("pinch_time_hi", metrics[v].get("pinch_time", 0.0)) for v in vals]
 
     fig, axes = plt.subplots(3, 1, sharex=True, figsize=(6, 9))
 
     axes[0].plot(vals, yields, marker="o")
+    axes[0].fill_between(vals, y_lo, y_hi, color="C0", alpha=0.2)
     axes[0].set_ylabel("Yield")
 
     axes[1].plot(vals, pinch, marker="^")
+    axes[1].fill_between(vals, p_lo, p_hi, color="C1", alpha=0.2)
     axes[1].set_ylabel("Pinch Time")
 
     axes[2].plot(vals, effs, marker="s")
@@ -198,11 +211,22 @@ def plot_yield_vs_S(metrics: Dict[float, Dict[str, float]], path: str | Path) ->
 
     import matplotlib.pyplot as plt
 
-    pairs = sorted((m.get("S", 0.0), m.get("yield", 0.0)) for m in metrics.values())
+    pairs = sorted(
+        (
+            m.get("S", 0.0),
+            m.get("yield", 0.0),
+            m.get("yield_lo", m.get("yield", 0.0)),
+            m.get("yield_hi", m.get("yield", 0.0)),
+        )
+        for m in metrics.values()
+    )
     s_vals = [p[0] for p in pairs]
     y_vals = [p[1] for p in pairs]
+    y_lo = [p[2] for p in pairs]
+    y_hi = [p[3] for p in pairs]
     plt.figure()
     plt.plot(s_vals, y_vals, marker="o")
+    plt.fill_between(s_vals, y_lo, y_hi, color="C0", alpha=0.2)
     plt.xlabel("S")
     plt.ylabel("Yield")
     path = Path(path)

--- a/tests/ai/test_surrogate_guardrails.py
+++ b/tests/ai/test_surrogate_guardrails.py
@@ -1,0 +1,47 @@
+import json
+from pathlib import Path
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from dpf2.ai import SurrogateModel, OutOfDomainError
+
+
+class _SimpleSurrogate(SurrogateModel):
+    def __init__(self, model_path: Path, scale: float = 1.0) -> None:
+        super().__init__(model_path)
+        self.scale = scale
+
+    def _predict(self, inputs: Any) -> Any:  # type: ignore[override]
+        return inputs * self.scale
+
+
+def _make_model(tmp_path: Path, threshold: float = 5.0) -> _SimpleSurrogate:
+    model_path = tmp_path / "model.pkl"
+    meta = {
+        "feature_mean": [0.0],
+        "feature_cov": [[1.0]],
+        "mahalanobis_threshold": threshold,
+        "toy": {"onnx": model_path.name, "quantile": 0.5},
+    }
+    (tmp_path / "metadata.json").write_text(json.dumps(meta))
+    return _SimpleSurrogate(model_path)
+
+
+def test_predict_with_guardrails_interval(tmp_path: Path) -> None:
+    model = _make_model(tmp_path)
+    pred, (lo, hi), dist = model.predict_with_guardrails(1.0)
+    assert pred == pytest.approx(1.0)
+    assert dist == pytest.approx(1.0)
+    assert lo == pytest.approx(0.0)
+    assert hi == pytest.approx(2.0)
+
+
+def test_predict_with_guardrails_ood(tmp_path: Path) -> None:
+    model = _make_model(tmp_path, threshold=0.5)
+    with pytest.raises(OutOfDomainError):
+        model.predict_with_guardrails(1.0)


### PR DESCRIPTION
## Summary
- extend surrogate predictions with conformal intervals and Mahalanobis-distance OOD scores
- capture training-domain statistics and residual quantiles during surrogate training
- surface guardrail bands and distances through parameter sweeps and engineer GUI
- test coverage for prediction bands and out-of-domain rejection

## Testing
- `pytest tests/test_ai_surrogate.py tests/ai/test_surrogate_guardrails.py tests/test_param_sweep.py tests/test_project_manager.py` (skipped: test_project_manager.py::test_export_and_overlay, tests/test_param_sweep.py)
- `pytest tests/ai/test_surrogate_guardrails.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb20580220832aa4be170db7b40643