### PR TITLE
Add variance-based sensitivity and Bayesian utilities for UQ

### DIFF
--- a/src/dpf2/cli/uq_run.py
+++ b/src/dpf2/cli/uq_run.py
@@ -1,4 +1,4 @@
-"""Command line interface for running UQ calibration routines."""
+"""Command line utilities for running uncertainty quantification analyses."""
 from __future__ import annotations
 
 import argparse
@@ -7,11 +7,12 @@ from typing import Sequence
 
 import numpy as np
 
+from ..uq.analysis import sobol_indices
+from ..uq.calibration import bayes_factor, posterior_summary
 from ..uq import calibrate_waveform
 
 
 def _load_waveform(path: str | Path) -> tuple[np.ndarray, np.ndarray]:
-    """Load two-column ``time,current`` waveform data."""
     arr = np.loadtxt(path, dtype=float)
     if arr.ndim != 2 or arr.shape[1] < 2:
         raise ValueError(f"waveform file {path!s} must have at least two columns")
@@ -19,47 +20,75 @@ def _load_waveform(path: str | Path) -> tuple[np.ndarray, np.ndarray]:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Entry point for the ``uq_run`` CLI."""
-
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("sim", help="CSV file with simulated time,current waveform")
-    parser.add_argument("data", help="CSV file with measured time,current waveform")
-    parser.add_argument(
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    # Calibration sub-command -------------------------------------------------
+    cal = sub.add_parser("calibrate", help="Calibrate waveform scaling factors")
+    cal.add_argument("sim", help="CSV file with simulated time,current waveform")
+    cal.add_argument("data", help="CSV file with measured time,current waveform")
+    cal.add_argument(
         "--method",
         choices=["emcee", "dynesty"],
         default="emcee",
         help="Calibration backend to use",
     )
-    parser.add_argument(
+    cal.add_argument(
         "--output",
         default="uq_results.npz",
         help="Path to store or read calibration samples",
     )
-    parser.add_argument(
-        "--summary",
-        action="store_true",
-        help="Summarise an existing results file instead of running calibration",
-    )
+
+    # Summary sub-command -----------------------------------------------------
+    summ = sub.add_parser("summary", help="Summarise posterior samples from an NPZ file")
+    summ.add_argument("file", help="NPZ file produced by the calibrate command")
+
+    # Bayes factor sub-command -----------------------------------------------
+    bf = sub.add_parser("bayes", help="Compute Bayes factor from two log-evidences")
+    bf.add_argument("logz1", type=float)
+    bf.add_argument("logz2", type=float)
+
+    # Sensitivity sub-command -------------------------------------------------
+    sens = sub.add_parser("sensitivity", help="Compute Sobol indices from arrays")
+    sens.add_argument("samples", help="NPZ file containing 'samples' and 'values'")
+    sens.add_argument("--names", nargs="+", required=True, help="Parameter names")
 
     args = parser.parse_args(argv)
-    out_path = Path(args.output)
 
-    if args.summary:
-        if not out_path.exists():
-            raise SystemExit(f"results file {out_path} does not exist")
-        data = np.load(out_path)
-        for name in data.files:
-            arr = data[name]
-            print(f"{name}: mean={arr.mean():.3f} std={arr.std():.3f}")
+    if args.cmd == "calibrate":
+        out_path = Path(args.output)
+        t_sim, i_sim = _load_waveform(args.sim)
+        t_data, i_data = _load_waveform(args.data)
+        samples = calibrate_waveform(t_sim, i_sim, t_data, i_data, method=args.method)
+        np.savez(out_path, **samples)
+        print(f"Saved results to {out_path}")
         return 0
 
-    t_sim, i_sim = _load_waveform(args.sim)
-    t_data, i_data = _load_waveform(args.data)
-    samples = calibrate_waveform(t_sim, i_sim, t_data, i_data, method=args.method)
-    np.savez(out_path, **samples)
-    print(f"Saved results to {out_path}")
+    if args.cmd == "summary":
+        data = np.load(args.file)
+        samples = {name: data[name] for name in data.files}
+        stats = posterior_summary(samples)
+        for name, s in stats.items():
+            print(f"{name}: mean={s['mean']:.3f} std={s['std']:.3f}")
+        return 0
+
+    if args.cmd == "bayes":
+        bf_val = bayes_factor(args.logz1, args.logz2)
+        print(f"Bayes factor: {bf_val:.3f}")
+        return 0
+
+    if args.cmd == "sensitivity":
+        data = np.load(args.samples)
+        samples = data["samples"]
+        values = data["values"]
+        indices = sobol_indices(samples, values, args.names)
+        for name, val in indices.items():
+            print(f"{name}: {val:.3f}")
+        return 0
+
     return 0
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation
     raise SystemExit(main())
+

--- a/src/dpf2/ui/__init__.py
+++ b/src/dpf2/ui/__init__.py
@@ -1,5 +1,6 @@
 """User interface panels."""
 
 from .verification_panel import VerificationPanelUI
+from .uq_panel import UQPanelUI
 
-__all__ = ["VerificationPanelUI"]
+__all__ = ["VerificationPanelUI", "UQPanelUI"]

--- a/src/dpf2/ui/uq_panel.py
+++ b/src/dpf2/ui/uq_panel.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence, Any
+
+import numpy as np
+
+from ..uq.analysis import sobol_indices
+from ..uq.calibration import bayes_factor, posterior_summary
+
+
+@dataclass
+class UQPanelUI:
+    """Lightweight front-end for basic UQ analyses."""
+
+    def sobol_from_arrays(
+        self, samples: Sequence[Sequence[float]], values: Sequence[float], names: Sequence[str]
+    ) -> dict[str, float]:
+        return sobol_indices(samples, values, names)
+
+    def sobol_from_file(self, path: str | Path, names: Sequence[str]) -> dict[str, float]:
+        data = np.load(path)
+        samples = data["samples"]
+        values = data["values"]
+        return sobol_indices(samples, values, names)
+
+    def summarise(self, path: str | Path) -> dict[str, Any]:
+        data = np.load(path)
+        samples = {name: data[name] for name in data.files}
+        return posterior_summary(samples)
+
+    def compare_models(self, logz_a: float, logz_b: float) -> float:
+        return bayes_factor(logz_a, logz_b)
+
+
+def _main() -> None:  # pragma: no cover - CLI helper
+    import argparse
+    parser = argparse.ArgumentParser(description="Run simple UQ analyses")
+    parser.add_argument("file", help="NPZ file containing posterior samples")
+    args = parser.parse_args()
+    ui = UQPanelUI()
+    stats = ui.summarise(Path(args.file))
+    for name, s in stats.items():
+        print(f"{name}: mean={s['mean']:.3f} std={s['std']:.3f}")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    _main()
+

--- a/src/dpf2/uq/__init__.py
+++ b/src/dpf2/uq/__init__.py
@@ -1,7 +1,15 @@
 """Uncertainty quantification utilities."""
 
 from .samplers import latin_hypercube, sobol_sample
+from .analysis import (
+    sobol_indices,
+    variance_decomposition,
+    propagate_yield_pinch,
+    propagate_jitter_voltage_pressure,
+)
 from .calibration import (
+    bayes_factor,
+    posterior_summary,
     bayesian_calibration,
     nested_calibration,
     emcee_calibrate,
@@ -13,6 +21,8 @@ from .calibration import (
     calibrate_waveform,
 )
 from .inference import (
+    bayes_factor as infer_bayes_factor,
+    posterior_summary as infer_posterior_summary,
     emcee_infer,
     dynesty_infer,
     emcee_infer_waveform,
@@ -22,6 +32,12 @@ from .inference import (
 __all__ = [
     "latin_hypercube",
     "sobol_sample",
+    "sobol_indices",
+    "variance_decomposition",
+    "propagate_yield_pinch",
+    "propagate_jitter_voltage_pressure",
+    "bayes_factor",
+    "posterior_summary",
     "bayesian_calibration",
     "nested_calibration",
     "emcee_calibrate",
@@ -31,6 +47,8 @@ __all__ = [
     "emcee_calibrate_waveform",
     "dynesty_calibrate_waveform",
     "calibrate_waveform",
+    "infer_bayes_factor",
+    "infer_posterior_summary",
     "emcee_infer",
     "dynesty_infer",
     "emcee_infer_waveform",

--- a/src/dpf2/uq/analysis.py
+++ b/src/dpf2/uq/analysis.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Callable, Dict, Sequence
 
 import statistics
+import random
 from pathlib import Path
 
 import numpy as np
@@ -52,6 +53,26 @@ def sobol_indices(
         cov = sum((xi - mean_x) * (yi - mean_y) for xi, yi in zip(x, y)) / len(x)
         indices[name] = (cov ** 2) / (var_x * var_y)
     return indices
+
+
+def variance_decomposition(
+    samples: Sequence[Sequence[float]],
+    values: Sequence[float],
+    names: Sequence[str],
+) -> Dict[str, float]:
+    """Return variance contributions for each parameter.
+
+    The function builds upon :func:`sobol_indices` and multiplies the
+    resulting first-order indices by the total variance of ``values``.  The
+    output dictionary contains a ``"total_variance"`` entry in addition to the
+    per-parameter contributions.
+    """
+
+    indices = sobol_indices(samples, values, names)
+    var_y = statistics.pvariance(list(values)) if values else 0.0
+    contrib = {name: indices[name] * var_y for name in names}
+    contrib["total_variance"] = var_y
+    return contrib
 
 
 def uncertainty_band(values: Sequence[float], alpha: float = 0.95) -> Dict[str, float]:
@@ -147,4 +168,47 @@ def propagate_yield_pinch(
     return stats
 
 
-__all__ = ["sobol_indices", "uncertainty_band", "propagate_yield_pinch"]
+def propagate_jitter_voltage_pressure(
+    model: Callable[[Sequence[float]], tuple[float, float]],
+    voltage: float,
+    pressure: float,
+    voltage_jitter_pct: float,
+    pressure_jitter_pct: float,
+    n_samples: int = 1000,
+    alpha: float = 0.95,
+    seed: int | None = None,
+) -> Dict[str, Dict[str, float]]:
+    """Propagate bank voltage and gas pressure jitter through ``model``.
+
+    ``model`` is expected to accept a two-element array ``[voltage, pressure]``
+    and return ``(neutron_yield, pinch_time)``.  Voltage and pressure are
+    perturbed with independent Gaussian noise according to the supplied
+    relative jitter percentages.
+    """
+
+    rng = random.Random(seed)
+    v_std = abs(voltage) * voltage_jitter_pct
+    p_std = abs(pressure) * pressure_jitter_pct
+    voltages = [rng.gauss(voltage, v_std) for _ in range(n_samples)]
+    pressures = [rng.gauss(pressure, p_std) for _ in range(n_samples)]
+
+    yields: list[float] = []
+    pinches: list[float] = []
+    for v, p in zip(voltages, pressures):
+        yld, pinch = model([v, p])
+        yields.append(float(yld))
+        pinches.append(float(pinch))
+
+    return {
+        "neutron_yield": uncertainty_band(yields, alpha),
+        "pinch_time": uncertainty_band(pinches, alpha),
+    }
+
+
+__all__ = [
+    "sobol_indices",
+    "variance_decomposition",
+    "uncertainty_band",
+    "propagate_yield_pinch",
+    "propagate_jitter_voltage_pressure",
+]

--- a/src/dpf2/uq/calibration.py
+++ b/src/dpf2/uq/calibration.py
@@ -2,14 +2,45 @@
 
 from __future__ import annotations
 
-from typing import Callable, Dict, Tuple
+from typing import Callable, Dict, Tuple, Sequence
 
 import math
 import random
+import statistics
 
 import numpy as np
 
 Bounds = Dict[str, Tuple[float, float]]
+
+
+def bayes_factor(log_evidence_a: float, log_evidence_b: float) -> float:
+    """Return the Bayes factor given two log-evidences."""
+
+    return math.exp(log_evidence_a - log_evidence_b)
+
+
+def posterior_summary(
+    samples: Dict[str, Sequence[float]],
+    alpha: float = 0.95,
+) -> Dict[str, Dict[str, float]]:
+    """Compute mean/std and credible interval for each parameter."""
+
+    out: Dict[str, Dict[str, float]] = {}
+    for name, vals in samples.items():
+        seq = [float(v) for v in vals]
+        if not seq:
+            out[name] = {"mean": 0.0, "std": 0.0, "lower": 0.0, "upper": 0.0}
+            continue
+        lower_q = (1 - alpha) / 2
+        upper_q = 1 - lower_q
+        seq_sorted = sorted(seq)
+        n = len(seq_sorted) - 1
+        lower = seq_sorted[int(lower_q * n)]
+        upper = seq_sorted[int(upper_q * n)]
+        mean = statistics.fmean(seq)
+        std = statistics.pstdev(seq) if len(seq) > 1 else 0.0
+        out[name] = {"mean": mean, "std": std, "lower": float(lower), "upper": float(upper)}
+    return out
 
 
 def bayesian_calibration(
@@ -509,6 +540,8 @@ def calibrate_waveform(
 
 
 __all__ = [
+    "bayes_factor",
+    "posterior_summary",
     "bayesian_calibration",
     "nested_calibration",
     "emcee_calibrate",

--- a/src/dpf2/uq/inference.py
+++ b/src/dpf2/uq/inference.py
@@ -1,11 +1,43 @@
 """Advanced parameter inference routines leveraging external samplers."""
 from __future__ import annotations
 
-from typing import Callable, Dict, Tuple
+from typing import Callable, Dict, Tuple, Sequence
 
+import math
+import statistics
 import numpy as np
 
 Bounds = Dict[str, Tuple[float, float]]
+
+
+def bayes_factor(log_evidence_a: float, log_evidence_b: float) -> float:
+    """Return the Bayes factor between two models."""
+
+    return math.exp(log_evidence_a - log_evidence_b)
+
+
+def posterior_summary(
+    samples: Dict[str, Sequence[float]],
+    alpha: float = 0.95,
+) -> Dict[str, Dict[str, float]]:
+    """Summarise posterior samples with mean, std and interval."""
+
+    out: Dict[str, Dict[str, float]] = {}
+    for name, vals in samples.items():
+        seq = [float(v) for v in vals]
+        if not seq:
+            out[name] = {"mean": 0.0, "std": 0.0, "lower": 0.0, "upper": 0.0}
+            continue
+        lower_q = (1 - alpha) / 2
+        upper_q = 1 - lower_q
+        seq_sorted = sorted(seq)
+        n = len(seq_sorted) - 1
+        lower = seq_sorted[int(lower_q * n)]
+        upper = seq_sorted[int(upper_q * n)]
+        mean = statistics.fmean(seq)
+        std = statistics.pstdev(seq) if len(seq) > 1 else 0.0
+        out[name] = {"mean": mean, "std": std, "lower": float(lower), "upper": float(upper)}
+    return out
 
 
 def emcee_infer(
@@ -215,6 +247,8 @@ def dynesty_infer_waveform(
 
 
 __all__ = [
+    "bayes_factor",
+    "posterior_summary",
     "emcee_infer",
     "dynesty_infer",
     "emcee_infer_waveform",

--- a/tests/uq/test_bayesian.py
+++ b/tests/uq/test_bayesian.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+import math
+
+from dpf2.uq.calibration import bayes_factor, posterior_summary
+
+
+def test_bayes_factor():
+    bf = bayes_factor(-5.0, -6.0)
+    assert bf == pytest.approx(math.exp(1.0))
+
+
+def test_posterior_summary():
+    samples = {"a": np.array([1.0, 2.0, 3.0, 4.0])}
+    stats = posterior_summary(samples)
+    assert pytest.approx(stats["a"]["mean"], rel=1e-6) == 2.5
+    assert stats["a"]["std"] > 0
+    assert stats["a"]["lower"] < stats["a"]["upper"]
+

--- a/tests/uq/test_sensitivity.py
+++ b/tests/uq/test_sensitivity.py
@@ -1,0 +1,31 @@
+import pytest
+
+from dpf2.uq.analysis import sobol_indices, propagate_jitter_voltage_pressure
+
+
+def test_sobol_indices_linear():
+    x = [i / 9 for i in range(10)]
+    y = [2 * xi + 1 for xi in x]
+    samples = [[xi] for xi in x]
+    res = sobol_indices(samples, y, ["x"])
+    assert res["x"] == pytest.approx(1.0)
+
+
+def test_propagate_jitter_voltage_pressure():
+    def model(params):
+        v, p = params
+        return v + p, v - p
+
+    stats = propagate_jitter_voltage_pressure(
+        model,
+        voltage=100.0,
+        pressure=10.0,
+        voltage_jitter_pct=0.1,
+        pressure_jitter_pct=0.2,
+        n_samples=100,
+        alpha=0.9,
+        seed=0,
+    )
+    assert stats["neutron_yield"]["std"] > 0.0
+    assert stats["pinch_time"]["std"] > 0.0
+


### PR DESCRIPTION
## Summary
- implement variance decomposition and voltage/pressure jitter propagation in `analysis`
- add Bayes factor calculation and posterior summaries in calibration/inference helpers
- extend CLI and new GUI panel for running UQ analyses
- include tests for sensitivity routines and Bayesian utilities

## Testing
- `pytest tests/uq/test_sensitivity.py tests/uq/test_bayesian.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb2056312c832a9769a0b148940d80