### PR TITLE
Implement Hall transport gating and coefficients

### DIFF
--- a/src/dpf2/physics/__init__.py
+++ b/src/dpf2/physics/__init__.py
@@ -27,9 +27,10 @@ from .material_interactions import (
 # missing.
 
 try:  # pragma: no cover - exercised when dependency is available
-    from .hall_mhd import HallMHD  # type: ignore
+    from .hall_mhd import HallMHD, hall_parameters, braginskii_coefficients  # type: ignore
 except Exception:  # pragma: no cover - fallback for minimal environments
     HallMHD = None  # type: ignore
+    hall_parameters = braginskii_coefficients = None  # type: ignore
 
 try:  # pragma: no cover - exercised when dependency is available
     from .simple_plasma import ZeroDPlasma  # type: ignore
@@ -70,7 +71,7 @@ __all__ = [
 if ZeroDPlasma is not None:
     __all__.append("ZeroDPlasma")
 if HallMHD is not None:
-    __all__.append("HallMHD")
+    __all__.extend(["HallMHD", "hall_parameters", "braginskii_coefficients"])
 if neutral_density_source is not None:
     __all__.extend(["neutral_density_source", "wall_ablation_source"])
 __all__.append("PicDriver")

--- a/src/dpf2/physics/hall_mhd.py
+++ b/src/dpf2/physics/hall_mhd.py
@@ -1,3 +1,22 @@
+"""Simplified Hall-MHD model and transport helpers.
+
+This module implements a light‑weight Hall‑MHD toy model used throughout the
+unit tests.  The class :class:`HallMHD` augments the resistive MHD equations
+with optional Hall and electron inertia terms.  These corrections are only
+activated when the plasma parameters indicate that they are important:
+
+* Hall physics requires both strong electron magnetisation
+  ``ω_ce τ_e > omega_ce_tau_e_min`` and a sufficiently large ion inertial
+  length ``d_i/L > di_over_L_min``.
+* Electron inertia uses the same ``d_i/L`` criterion and is only applied when
+  the ``electron_inertia`` coefficient is non–zero.
+
+For convenience a number of helper functions are provided.  In particular
+``hall_parameters`` returns the magnetisation and ion inertial length used for
+activation gating and ``braginskii_coefficients`` evaluates a very small subset
+of the Braginskii transport coefficients using the NRL Formulary scalings.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -33,6 +52,12 @@ class HallMHD(ResistiveMHD):
       energy the plasma self‑inductance is estimated and fed back to external
       circuit models.
 
+    Hall and electron inertia effects are only included when
+    :meth:`update_transport` deems them important.  The Hall term requires
+    ``ω_ce τ_e`` to exceed ``omega_ce_tau_e_min`` *and* ``d_i/L`` to exceed
+    ``di_over_L_min``.  Electron inertia uses the same ``d_i/L`` check and is
+    controlled by the ``electron_inertia`` coefficient.
+
     Only the terms required for regression tests are implemented; the class is
     not intended to be a production ready Hall‑MHD solver.
     """
@@ -45,6 +70,7 @@ class HallMHD(ResistiveMHD):
     nernst: float = 0.0
     righi_leduc: float = 0.0
     hall_active: bool = field(default=False, init=False)
+    electron_inertia_active: bool = field(default=False, init=False)
     current: float = 0.0
     back_emf: float = 0.0
     beam_velocity: float = 0.0
@@ -60,10 +86,12 @@ class HallMHD(ResistiveMHD):
         """Update transport coefficients and activation state.
 
         The Braginskii coefficients are calculated using very small subsets of
-        the NRL Formulary expressions.  Activation is gated on the electron
-        magnetisation ``ω_ce τ_e`` and the ratio of the ion inertial length to
-        the system size ``d_i/L``.  When the Hall model is inactive the
-        coefficients are set to zero to recover classical resistive MHD.
+        the NRL Formulary expressions.  Hall physics is activated when the
+        electron magnetisation ``ω_ce τ_e`` exceeds ``omega_ce_tau_e_min`` and
+        the ratio of the ion inertial length to the system size ``d_i/L``
+        exceeds ``di_over_L_min``.  The electron inertia term uses the same
+        ``d_i/L`` criterion.  When the Hall model is inactive the coefficients
+        are set to zero to recover classical resistive MHD.
         """
 
         omega_tau, di_over_L = hall_parameters(ne, Te, B, L)
@@ -73,6 +101,9 @@ class HallMHD(ResistiveMHD):
             self.hall_enabled
             and omega_tau > self.omega_ce_tau_e_min
             and di_over_L > self.di_over_L_min
+        )
+        self.electron_inertia_active = (
+            self.electron_inertia != 0.0 and di_over_L > self.di_over_L_min
         )
 
         if not self.hall_active:
@@ -221,10 +252,10 @@ class HallMHD(ResistiveMHD):
 
         F = super().flux_function(U, direction)
 
-        if not self.hall_active:
+        if not (self.hall_active or self.electron_inertia_active):
             return F
 
-        if J is not None and self.hall_coeff != 0.0:
+        if self.hall_active and J is not None and self.hall_coeff != 0.0:
             rho = U[0]
             B = U[5:8]
             hall_e = self.hall_coeff * np.cross(J, B) / rho
@@ -238,7 +269,7 @@ class HallMHD(ResistiveMHD):
                 F[5] -= hall_e[1]
                 F[6] -= hall_e[0]
 
-        if J is not None and self.electron_inertia != 0.0:
+        if self.electron_inertia_active and J is not None and self.electron_inertia != 0.0:
             inertia_e = self.electron_inertia * J
             if direction == "x":
                 F[6] += inertia_e[2]

--- a/tests/physics/test_hall_mhd.py
+++ b/tests/physics/test_hall_mhd.py
@@ -5,7 +5,7 @@ from dpf2.physics import HallMHD
 from dpf2.core.circuit import RLCCircuitSolver
 from dpf2.mesh import Mesh3D
 from dpf2.hall_mhd_solver import HallMHDSolver, MHDState
-from dpf2.physics.hall_mhd import nrl_braginskii
+from dpf2.physics.hall_mhd import nrl_braginskii, braginskii_coefficients
 from dpf2.diagnostics.quality_dashboard import QualityDashboard
 
 
@@ -108,6 +108,24 @@ def test_activation_gates_and_closure():
     nu, kappa = nrl_braginskii(np.array([1.0]), np.array([1.0]), np.array([1.0]))
     assert nu.shape == (1,)
     assert kappa.shape == (1,)
+
+
+def test_transport_activation_and_coefficients():
+    model = HallMHD(hall_coeff=0.1, electron_inertia=0.2)
+    ne, Te, B, L = 1.0e20, 100.0, 50.0, 0.1
+    model.update_transport(ne, Te, B, L)
+    assert model.hall_active
+    assert model.electron_inertia_active
+    expected = braginskii_coefficients(ne, Te, B)
+    assert model.eta == pytest.approx(expected["eta_parallel"])
+    assert model.kappa_parallel == pytest.approx(expected["kappa_parallel"])
+    assert model.kappa_perp == pytest.approx(expected["kappa_perp"])
+
+    # parameters far below thresholds disable transport
+    model.update_transport(ne, Te, 0.01, 10.0)
+    assert not model.hall_active
+    assert not model.electron_inertia_active
+    assert model.eta == model.kappa_parallel == model.kappa_perp == 0.0
 
 
 def test_quality_diagnostics(tmp_path):


### PR DESCRIPTION
## Summary
- calculate Braginskii transport coefficients using NRL formulary
- gate Hall and electron inertia terms based on magnetisation and ion inertial length
- expose helper functions `hall_parameters` and `braginskii_coefficients`
- cover HallMHD gating and coefficients in tests

## Testing
- `pytest tests/physics/test_hall_mhd.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb2045bce0832ab11d3e70f4acad9f