### PR TITLE
Add radiation warning path in SimulationEngine

### DIFF
--- a/docs/tutorials/advanced_physics.md
+++ b/docs/tutorials/advanced_physics.md
@@ -19,6 +19,12 @@ physics:
   radiation: true
 ```
 
+> **Note:** The lightweight :class:`dpf2.simulation_engine.SimulationEngine` used in
+> rapid prototyping does not yet implement radiation losses. Requesting a
+> radiation model with that engine logs a warning and keeps the tracked
+> radiative energy at zero. Use the full simulation backends for coupled
+> radiation transport.
+
 ## 2. Run with detailed diagnostics
 
 The additional physics can slow the solver, so enable only the

--- a/src/dpf2/simulation_engine.py
+++ b/src/dpf2/simulation_engine.py
@@ -32,6 +32,7 @@ except Exception:  # pragma: no cover
 
 from .dpf_config import DPFConfig
 from .circuit_config import CircuitConfig
+from .core_schema import RadiationModel as RadiationModelEnum, RadiationTransportModel as RadiationTransportModelEnum
 
 from .circuit_solver import RLCCircuit, CircuitSolver, run_circuit_simulation
 from .core.bases import PlasmaSolverBase, CouplingState, DiagnosticsBase
@@ -193,12 +194,64 @@ class SimulationEngine:
         self.cell_size: float | None = None
         self.particles_per_cell: float | None = None
 
+        # Radiation coupling ------------------------------------------------
+        self._radiation_modes: dict[str, str] = {}
+        self._radiation_warning_emitted = False
+        pm = getattr(self.config, "physics_models", None)
+        if pm is not None:
+            self._register_radiation_mode("model", getattr(pm, "radiation_model", None))
+            self._register_radiation_mode(
+                "transport", getattr(pm, "radiation_transport_model", None)
+            )
+
     # ------------------------------------------------------------------
     def _to_numpy(self, arr: np.ndarray | "cp.ndarray") -> np.ndarray:
         """Convert ``arr`` to a NumPy array regardless of backend."""
         if self.use_gpu and cp is not None:
             return cp.asnumpy(arr)  # type: ignore[no-untyped-call]
         return np.asarray(arr)
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalise_enum(value: object) -> str:
+        """Return a stable string representation for enum-like values."""
+
+        if value is None:
+            return "None"
+        if hasattr(value, "value"):
+            return str(getattr(value, "value"))
+        return str(value)
+
+    def _register_radiation_mode(self, key: str, value: object) -> None:
+        """Record requested radiation modes that the engine cannot service."""
+
+        if value is None:
+            return
+        normalised = self._normalise_enum(value)
+        if normalised.lower() == "none":
+            return
+        # Map enums back to canonical names when possible
+        if isinstance(value, RadiationModelEnum):
+            normalised = value.value
+        elif isinstance(value, RadiationTransportModelEnum):
+            normalised = value.value
+        self._radiation_modes[key] = normalised
+
+    def _handle_radiation_coupling(self, tracker: EnergyTracker) -> None:
+        """Emit diagnostics when unsupported radiation coupling is requested."""
+
+        if not self._radiation_modes:
+            return
+        if not self._radiation_warning_emitted:
+            details = ", ".join(f"{k}={v}" for k, v in self._radiation_modes.items())
+            logger.warning(
+                "Radiation coupling requested (%s) but SimulationEngine does not "
+                "implement radiation losses; radiative energy will remain zero.",
+                details,
+            )
+            self._radiation_warning_emitted = True
+        if tracker.radiative:
+            tracker.radiative[-1] = 0.0
 
     # ------------------------------------------------------------------
     def _setup_circuit(self) -> CircuitSolver:
@@ -352,6 +405,7 @@ class SimulationEngine:
             capacitor=_capacitor_energy(circuit.voltages[-1], circuit.circuit.C),
             inductive=0.5 * circuit.circuit.L * circuit.currents[-1] ** 2,
         )
+        self._handle_radiation_coupling(tracker)
 
         current = circuit.currents[-1]
         voltage = circuit.voltages[-1]
@@ -428,10 +482,8 @@ class SimulationEngine:
             coupling.voltage = updated.voltage
             current, voltage = updated.current, updated.voltage
 
-            # Radiation transport coupling (placeholder)
-            rad_in = tracker.thermal[-1] if tracker.thermal else 0.0
-            tracker.thermal[-1] = float(rad_in)
-            tracker.radiative[-1] = 0.0
+            # Radiation transport coupling (not yet implemented for the minimal engine)
+            self._handle_radiation_coupling(tracker)
 
             if diag_list:
                 for diag in diag_list:

--- a/tests/test_simulation_engine.py
+++ b/tests/test_simulation_engine.py
@@ -1,3 +1,5 @@
+import logging
+
 import numpy as np
 import pydantic
 
@@ -6,8 +8,10 @@ if not hasattr(pydantic.BaseModel, "parse_obj"):  # pragma: no cover - compatibi
 if not hasattr(pydantic.BaseModel, "model_validate"):  # pragma: no cover - compatibility
     pydantic.BaseModel.model_validate = classmethod(lambda cls, d, **_: cls.parse_obj(d))
 
+from dpf2.core_schema import RadiationModel
 from dpf2.dpf_config import DPFConfig
 from dpf2.simulation_engine import SimulationEngine, EnsembleResults
+from dpf2.physics.energy import EnergyTracker
 from dpf2.experimental_variability import ExperimentalVariabilityModel, MonteCarloVariability
 
 
@@ -92,3 +96,19 @@ def test_engine_progress_callback():
     engine.run(progress_cb=cb)
     assert len(calls) > 0
     assert all(calls[i] <= calls[i + 1] for i in range(len(calls) - 1))
+
+
+def test_engine_warns_when_radiation_requested(caplog):
+    cfg = DPFConfig.with_defaults()
+    cfg.physics_models.radiation_model = RadiationModel.BREMSSTRAHLUNG
+    cfg.physics_models.sxr_bandpass_nm = (0.5, 1.0)
+    engine = SimulationEngine(cfg)
+    tracker = EnergyTracker()
+    tracker.add()
+    with caplog.at_level(logging.WARNING):
+        engine._handle_radiation_coupling(tracker)
+        engine._handle_radiation_coupling(tracker)
+    warnings = [rec.message for rec in caplog.records if rec.levelno >= logging.WARNING]
+    matches = [msg for msg in warnings if "Radiation coupling requested" in msg]
+    assert len(matches) == 1
+    assert tracker.radiative[-1] == 0.0


### PR DESCRIPTION
## Summary
- replace the placeholder radiation coupling in `SimulationEngine` with a warning-backed helper that records requested modes and zeroes radiative energy
- surface the unsupported radiation warning in documentation for the advanced physics tutorial
- add a regression test ensuring the warning is emitted once when radiation models are requested

## Testing
- `pytest tests/test_simulation_engine.py::test_engine_warns_when_radiation_requested -vv`


------
https://chatgpt.com/codex/tasks/task_e_68cadf2f157c832aa15f8c1ef906efc5